### PR TITLE
Migrate api code to rest

### DIFF
--- a/app/scripts/modules/amazon/src/image/image.reader.ts
+++ b/app/scripts/modules/amazon/src/image/image.reader.ts
@@ -1,6 +1,6 @@
 import { $q } from 'ngimport';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 export interface IAmazonImage {
   accounts: string[];
@@ -26,14 +26,16 @@ export class AwsImageReader {
       return $q.when([{ message: 'Please enter at least 3 characters...', disabled: true }]) as any;
     }
 
-    return API.path('images', 'find')
+    return REST()
+      .path('images', 'find')
       .query(params)
       .get()
       .catch(() => [] as IAmazonImage[]);
   }
 
   public getImage(amiName: string, region: string, credentials: string): PromiseLike<IAmazonImage> {
-    return API.path('images', credentials, region, amiName)
+    return REST()
+      .path('images', credentials, region, amiName)
       .query({ provider: 'aws' })
       .get()
       .then((results: any[]) => (results && results.length ? results[0] : null))

--- a/app/scripts/modules/amazon/src/image/image.reader.ts
+++ b/app/scripts/modules/amazon/src/image/image.reader.ts
@@ -26,18 +26,18 @@ export class AwsImageReader {
       return $q.when([{ message: 'Please enter at least 3 characters...', disabled: true }]) as any;
     }
 
-    return API.one('images', 'find')
-      .withParams(params)
+    return API.path('images', 'find')
+      .query(params)
       .get()
       .catch(() => [] as IAmazonImage[]);
   }
 
   public getImage(amiName: string, region: string, credentials: string): PromiseLike<IAmazonImage> {
-    return API.one('images')
-      .one(credentials)
-      .one(region)
-      .one(amiName)
-      .withParams({ provider: 'aws' })
+    return API.path('images')
+      .path(credentials)
+      .path(region)
+      .path(amiName)
+      .query({ provider: 'aws' })
       .get()
       .then((results: any[]) => (results && results.length ? results[0] : null))
       .catch(() => null as IAmazonImage);

--- a/app/scripts/modules/amazon/src/image/image.reader.ts
+++ b/app/scripts/modules/amazon/src/image/image.reader.ts
@@ -26,16 +26,15 @@ export class AwsImageReader {
       return $q.when([{ message: 'Please enter at least 3 characters...', disabled: true }]) as any;
     }
 
-    return REST()
-      .path('images', 'find')
+    return REST('/images/find')
       .query(params)
       .get()
       .catch(() => [] as IAmazonImage[]);
   }
 
   public getImage(amiName: string, region: string, credentials: string): PromiseLike<IAmazonImage> {
-    return REST()
-      .path('images', credentials, region, amiName)
+    return REST('/images')
+      .path(credentials, region, amiName)
       .query({ provider: 'aws' })
       .get()
       .then((results: any[]) => (results && results.length ? results[0] : null))

--- a/app/scripts/modules/amazon/src/image/image.reader.ts
+++ b/app/scripts/modules/amazon/src/image/image.reader.ts
@@ -33,10 +33,7 @@ export class AwsImageReader {
   }
 
   public getImage(amiName: string, region: string, credentials: string): PromiseLike<IAmazonImage> {
-    return API.path('images')
-      .path(credentials)
-      .path(region)
-      .path(amiName)
+    return API.path('images', credentials, region, amiName)
       .query({ provider: 'aws' })
       .get()
       .then((results: any[]) => (results && results.length ? results[0] : null))

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
@@ -3,7 +3,7 @@
 import { module } from 'angular';
 import _ from 'lodash';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 import { AWSProviderSettings } from 'amazon/aws.settings';
 
@@ -286,7 +286,8 @@ module(AMAZON_INSTANCE_AWSINSTANCETYPE_SERVICE, []).factory('awsInstanceTypeServ
     }
 
     const getAllTypesByRegion = function getAllTypesByRegion() {
-      return API.path('instanceTypes')
+      return REST()
+        .path('instanceTypes')
         .get()
         .then(function (types) {
           return _.chain(types)

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
@@ -286,7 +286,7 @@ module(AMAZON_INSTANCE_AWSINSTANCETYPE_SERVICE, []).factory('awsInstanceTypeServ
     }
 
     const getAllTypesByRegion = function getAllTypesByRegion() {
-      return API.one('instanceTypes')
+      return API.path('instanceTypes')
         .get()
         .then(function (types) {
           return _.chain(types)

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
@@ -286,8 +286,7 @@ module(AMAZON_INSTANCE_AWSINSTANCETYPE_SERVICE, []).factory('awsInstanceTypeServ
     }
 
     const getAllTypesByRegion = function getAllTypesByRegion() {
-      return REST()
-        .path('instanceTypes')
+      return REST('/instanceTypes')
         .get()
         .then(function (types) {
           return _.chain(types)

--- a/app/scripts/modules/amazon/src/keyPairs/KeyPairsReader.ts
+++ b/app/scripts/modules/amazon/src/keyPairs/KeyPairsReader.ts
@@ -1,10 +1,11 @@
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 import { IKeyPair } from 'amazon/domain';
 
 export class KeyPairsReader {
   public static listKeyPairs(): PromiseLike<IKeyPair[]> {
-    return API.path('keyPairs')
+    return REST()
+      .path('keyPairs')
       .useCache()
       .get()
       .then((keyPairs: IKeyPair[]) => keyPairs.sort((a, b) => a.keyName.localeCompare(b.keyName)));

--- a/app/scripts/modules/amazon/src/keyPairs/KeyPairsReader.ts
+++ b/app/scripts/modules/amazon/src/keyPairs/KeyPairsReader.ts
@@ -4,8 +4,7 @@ import { IKeyPair } from 'amazon/domain';
 
 export class KeyPairsReader {
   public static listKeyPairs(): PromiseLike<IKeyPair[]> {
-    return REST()
-      .path('keyPairs')
+    return REST('/keyPairs')
       .useCache()
       .get()
       .then((keyPairs: IKeyPair[]) => keyPairs.sort((a, b) => a.keyName.localeCompare(b.keyName)));

--- a/app/scripts/modules/amazon/src/keyPairs/KeyPairsReader.ts
+++ b/app/scripts/modules/amazon/src/keyPairs/KeyPairsReader.ts
@@ -1,14 +1,12 @@
-
-
 import { API } from '@spinnaker/core';
 
 import { IKeyPair } from 'amazon/domain';
 
 export class KeyPairsReader {
   public static listKeyPairs(): PromiseLike<IKeyPair[]> {
-    return API.all('keyPairs')
+    return API.path('keyPairs')
       .useCache()
-      .getList()
+      .get()
       .then((keyPairs: IKeyPair[]) => keyPairs.sort((a, b) => a.keyName.localeCompare(b.keyName)));
   }
 }

--- a/app/scripts/modules/amazon/src/loadBalancer/OidcConfigReader.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/OidcConfigReader.ts
@@ -16,6 +16,6 @@ export interface IAuthenticateOidcActionConfig {
 
 export class OidcConfigReader {
   public static getOidcConfigsByApp(app: string): PromiseLike<IAuthenticateOidcActionConfig[]> {
-    return REST().path('oidcConfigs').query({ app }).get();
+    return REST('/oidcConfigs').query({ app }).get();
   }
 }

--- a/app/scripts/modules/amazon/src/loadBalancer/OidcConfigReader.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/OidcConfigReader.ts
@@ -1,4 +1,4 @@
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 export interface IAuthenticateOidcActionConfig {
   authorizationEndpoint: string;
@@ -16,6 +16,6 @@ export interface IAuthenticateOidcActionConfig {
 
 export class OidcConfigReader {
   public static getOidcConfigsByApp(app: string): PromiseLike<IAuthenticateOidcActionConfig[]> {
-    return API.path('oidcConfigs').query({ app }).get();
+    return REST().path('oidcConfigs').query({ app }).get();
   }
 }

--- a/app/scripts/modules/amazon/src/loadBalancer/OidcConfigReader.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/OidcConfigReader.ts
@@ -16,6 +16,6 @@ export interface IAuthenticateOidcActionConfig {
 
 export class OidcConfigReader {
   public static getOidcConfigsByApp(app: string): PromiseLike<IAuthenticateOidcActionConfig[]> {
-    return API.one('oidcConfigs').withParams({ app }).getList();
+    return API.path('oidcConfigs').query({ app }).get();
   }
 }

--- a/app/scripts/modules/azure/src/image/image.reader.js
+++ b/app/scripts/modules/azure/src/image/image.reader.js
@@ -9,7 +9,8 @@ export const name = AZURE_IMAGE_IMAGE_READER; // for backwards compatibility
 module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   function findImages(params) {
     return API.path('images', 'find')
-      .get(params)
+      .query(params)
+      .get()
       .then(
         function (results) {
           return results;

--- a/app/scripts/modules/azure/src/image/image.reader.js
+++ b/app/scripts/modules/azure/src/image/image.reader.js
@@ -22,10 +22,7 @@ module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   }
 
   function getImage(amiName, region, credentials) {
-    return API.path('images')
-      .path(credentials)
-      .path(region)
-      .path(amiName)
+    return API.path('images', credentials, region, amiName)
       .query({ provider: 'azure' })
       .get()
       .then(

--- a/app/scripts/modules/azure/src/image/image.reader.js
+++ b/app/scripts/modules/azure/src/image/image.reader.js
@@ -8,8 +8,7 @@ export const AZURE_IMAGE_IMAGE_READER = 'spinnaker.azure.image.reader';
 export const name = AZURE_IMAGE_IMAGE_READER; // for backwards compatibility
 module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   function findImages(params) {
-    return REST()
-      .path('images', 'find')
+    return REST('/images/find')
       .query(params)
       .get()
       .then(
@@ -23,8 +22,8 @@ module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   }
 
   function getImage(amiName, region, credentials) {
-    return REST()
-      .path('images', credentials, region, amiName)
+    return REST('/images')
+      .path(credentials, region, amiName)
       .query({ provider: 'azure' })
       .get()
       .then(

--- a/app/scripts/modules/azure/src/image/image.reader.js
+++ b/app/scripts/modules/azure/src/image/image.reader.js
@@ -2,13 +2,14 @@
 
 import { module } from 'angular';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 export const AZURE_IMAGE_IMAGE_READER = 'spinnaker.azure.image.reader';
 export const name = AZURE_IMAGE_IMAGE_READER; // for backwards compatibility
 module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   function findImages(params) {
-    return API.path('images', 'find')
+    return REST()
+      .path('images', 'find')
       .query(params)
       .get()
       .then(
@@ -22,7 +23,8 @@ module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   }
 
   function getImage(amiName, region, credentials) {
-    return API.path('images', credentials, region, amiName)
+    return REST()
+      .path('images', credentials, region, amiName)
       .query({ provider: 'azure' })
       .get()
       .then(

--- a/app/scripts/modules/azure/src/image/image.reader.js
+++ b/app/scripts/modules/azure/src/image/image.reader.js
@@ -8,7 +8,7 @@ export const AZURE_IMAGE_IMAGE_READER = 'spinnaker.azure.image.reader';
 export const name = AZURE_IMAGE_IMAGE_READER; // for backwards compatibility
 module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   function findImages(params) {
-    return API.one('images', 'find')
+    return API.path('images', 'find')
       .get(params)
       .then(
         function (results) {
@@ -21,11 +21,11 @@ module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   }
 
   function getImage(amiName, region, credentials) {
-    return API.one('images')
-      .one(credentials)
-      .one(region)
-      .one(amiName)
-      .withParams({ provider: 'azure' })
+    return API.path('images')
+      .path(credentials)
+      .path(region)
+      .path(amiName)
+      .query({ provider: 'azure' })
       .get()
       .then(
         function (results) {

--- a/app/scripts/modules/canary/canary/actions/endCanary.controller.js
+++ b/app/scripts/modules/canary/canary/actions/endCanary.controller.js
@@ -1,8 +1,7 @@
 'use strict';
 
 import { module } from 'angular';
-
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 
 export const CANARY_CANARY_ACTIONS_ENDCANARY_CONTROLLER = 'spinnaker.canary.actions.override.result.controller';
@@ -21,7 +20,8 @@ module(CANARY_CANARY_ACTIONS_ENDCANARY_CONTROLLER, [UIROUTER_ANGULARJS]).control
 
     this.endCanary = function () {
       $scope.state = 'submitting';
-      API.one('canaries', canaryId, 'end')
+      REST('/canaries')
+        .path(canaryId, 'end')
         .put($scope.command)
         .then(function onSuccess() {
           $scope.state = 'success';

--- a/app/scripts/modules/canary/canary/actions/generateScore.controller.js
+++ b/app/scripts/modules/canary/canary/actions/generateScore.controller.js
@@ -1,8 +1,7 @@
 'use strict';
 
 import { module } from 'angular';
-
-import { API, SETTINGS } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 
 export const CANARY_CANARY_ACTIONS_GENERATESCORE_CONTROLLER = 'spinnaker.canary.actions.generate.score.controller';
@@ -21,7 +20,8 @@ module(CANARY_CANARY_ACTIONS_GENERATESCORE_CONTROLLER, [UIROUTER_ANGULARJS]).con
 
     this.generateCanaryScore = function () {
       $scope.state = 'submitting';
-      API.one('canaries', canaryId, 'generateCanaryResult')
+      REST('/canaries')
+        .path(canaryId, 'generateCanaryResult')
         .post($scope.command)
         .then(function onSuccess() {
           $scope.state = 'success';

--- a/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
+++ b/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
@@ -8,9 +8,9 @@ class CanaryAnalysisNameSelectorController implements IController {
 
   public $onInit(): void {
     this.queryListUrl = SETTINGS.canaryConfig ? SETTINGS.canaryConfig.queryListUrl : null;
-    API.one('canaryConfig')
-      .all('names')
-      .getList()
+    API.path('canaryConfig')
+      .path('names')
+      .get()
       .then((results: string[]) => (this.nameList = results.sort()))
       .catch(() => {
         this.nameList = [];

--- a/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
+++ b/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
@@ -1,6 +1,6 @@
 import { IController, IComponentOptions, module } from 'angular';
 
-import { API, SETTINGS } from '@spinnaker/core';
+import { REST, SETTINGS } from '@spinnaker/core';
 
 class CanaryAnalysisNameSelectorController implements IController {
   public nameList: string[] = [];
@@ -8,7 +8,8 @@ class CanaryAnalysisNameSelectorController implements IController {
 
   public $onInit(): void {
     this.queryListUrl = SETTINGS.canaryConfig ? SETTINGS.canaryConfig.queryListUrl : null;
-    API.path('canaryConfig', 'names')
+    REST()
+      .path('canaryConfig', 'names')
       .get()
       .then((results: string[]) => (this.nameList = results.sort()))
       .catch(() => {

--- a/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
+++ b/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
@@ -8,8 +8,7 @@ class CanaryAnalysisNameSelectorController implements IController {
 
   public $onInit(): void {
     this.queryListUrl = SETTINGS.canaryConfig ? SETTINGS.canaryConfig.queryListUrl : null;
-    REST()
-      .path('canaryConfig', 'names')
+    REST('/canaryConfig/names')
       .get()
       .then((results: string[]) => (this.nameList = results.sort()))
       .catch(() => {

--- a/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
+++ b/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
@@ -8,8 +8,7 @@ class CanaryAnalysisNameSelectorController implements IController {
 
   public $onInit(): void {
     this.queryListUrl = SETTINGS.canaryConfig ? SETTINGS.canaryConfig.queryListUrl : null;
-    API.path('canaryConfig')
-      .path('names')
+    API.path('canaryConfig', 'names')
       .get()
       .then((results: string[]) => (this.nameList = results.sort()))
       .catch(() => {

--- a/app/scripts/modules/canary/canary/canaryDeployment/canaryDeploymentHistory.service.js
+++ b/app/scripts/modules/canary/canary/canaryDeployment/canaryDeploymentHistory.service.js
@@ -11,7 +11,7 @@ module(CANARY_CANARY_CANARYDEPLOYMENT_CANARYDEPLOYMENTHISTORY_SERVICE, []).facto
   'canaryDeploymentHistoryService',
   function () {
     function getAnalysisHistory(canaryDeploymentId) {
-      return REST().path('canaryDeployments', canaryDeploymentId, 'canaryAnalysisHistory').get();
+      return REST('/canaryDeployments').path(canaryDeploymentId, 'canaryAnalysisHistory').get();
     }
 
     return {

--- a/app/scripts/modules/canary/canary/canaryDeployment/canaryDeploymentHistory.service.js
+++ b/app/scripts/modules/canary/canary/canaryDeployment/canaryDeploymentHistory.service.js
@@ -11,7 +11,7 @@ module(CANARY_CANARY_CANARYDEPLOYMENT_CANARYDEPLOYMENTHISTORY_SERVICE, []).facto
   'canaryDeploymentHistoryService',
   function () {
     function getAnalysisHistory(canaryDeploymentId) {
-      return API.path('canaryDeployments').path(canaryDeploymentId).path('canaryAnalysisHistory').get();
+      return API.path('canaryDeployments', canaryDeploymentId, 'canaryAnalysisHistory').get();
     }
 
     return {

--- a/app/scripts/modules/canary/canary/canaryDeployment/canaryDeploymentHistory.service.js
+++ b/app/scripts/modules/canary/canary/canaryDeployment/canaryDeploymentHistory.service.js
@@ -11,7 +11,7 @@ module(CANARY_CANARY_CANARYDEPLOYMENT_CANARYDEPLOYMENTHISTORY_SERVICE, []).facto
   'canaryDeploymentHistoryService',
   function () {
     function getAnalysisHistory(canaryDeploymentId) {
-      return API.one('canaryDeployments').one(canaryDeploymentId).all('canaryAnalysisHistory').getList();
+      return API.path('canaryDeployments').path(canaryDeploymentId).path('canaryAnalysisHistory').get();
     }
 
     return {

--- a/app/scripts/modules/canary/canary/canaryDeployment/canaryDeploymentHistory.service.js
+++ b/app/scripts/modules/canary/canary/canaryDeployment/canaryDeploymentHistory.service.js
@@ -2,7 +2,7 @@
 
 import { module } from 'angular';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 export const CANARY_CANARY_CANARYDEPLOYMENT_CANARYDEPLOYMENTHISTORY_SERVICE =
   'spinnaker.canary.deployment.history.service';
@@ -11,7 +11,7 @@ module(CANARY_CANARY_CANARYDEPLOYMENT_CANARYDEPLOYMENTHISTORY_SERVICE, []).facto
   'canaryDeploymentHistoryService',
   function () {
     function getAnalysisHistory(canaryDeploymentId) {
-      return API.path('canaryDeployments', canaryDeploymentId, 'canaryAnalysisHistory').get();
+      return REST().path('canaryDeployments', canaryDeploymentId, 'canaryAnalysisHistory').get();
     }
 
     return {

--- a/app/scripts/modules/cloudfoundry/src/image/image.reader.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/image/image.reader.cf.ts
@@ -1,10 +1,11 @@
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 import { ICloudFoundryCluster } from 'cloudfoundry/domain';
 
 export class CloudFoundryImageReader {
   public static findImages(account: string): PromiseLike<ICloudFoundryCluster[]> {
-    return API.path('images', 'find')
+    return REST()
+      .path('images', 'find')
       .query({
         account,
         provider: 'cloudfoundry',

--- a/app/scripts/modules/cloudfoundry/src/image/image.reader.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/image/image.reader.cf.ts
@@ -4,8 +4,7 @@ import { ICloudFoundryCluster } from 'cloudfoundry/domain';
 
 export class CloudFoundryImageReader {
   public static findImages(account: string): PromiseLike<ICloudFoundryCluster[]> {
-    return REST()
-      .path('images', 'find')
+    return REST('/images/find')
       .query({
         account,
         provider: 'cloudfoundry',

--- a/app/scripts/modules/cloudfoundry/src/image/image.reader.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/image/image.reader.cf.ts
@@ -4,8 +4,8 @@ import { ICloudFoundryCluster } from 'cloudfoundry/domain';
 
 export class CloudFoundryImageReader {
   public static findImages(account: string): PromiseLike<ICloudFoundryCluster[]> {
-    return API.one('images', 'find')
-      .withParams({
+    return API.path('images', 'find')
+      .query({
         account,
         provider: 'cloudfoundry',
       })

--- a/app/scripts/modules/core/src/account/AccountService.ts
+++ b/app/scripts/modules/core/src/account/AccountService.ts
@@ -65,7 +65,7 @@ export class AccountService {
 
   public static initialize(): void {
     this.accounts$ = Observable.defer(() => {
-      const promise = REST().path('credentials').useCache().query({ expand: true }).get();
+      const promise = REST('/credentials').useCache().query({ expand: true }).get();
       return Observable.fromPromise<IAccountDetails[]>(promise);
     })
       .publishReplay(1)
@@ -96,7 +96,7 @@ export class AccountService {
   }
 
   public static getArtifactAccounts(): PromiseLike<IArtifactAccount[]> {
-    return REST().path('artifacts', 'credentials').useCache().get();
+    return REST('/artifacts/credentials').useCache().get();
   }
 
   public static getAccountDetails(account: string): PromiseLike<IAccountDetails> {

--- a/app/scripts/modules/core/src/account/AccountService.ts
+++ b/app/scripts/modules/core/src/account/AccountService.ts
@@ -96,7 +96,7 @@ export class AccountService {
   }
 
   public static getArtifactAccounts(): PromiseLike<IArtifactAccount[]> {
-    return API.path('artifacts').path('credentials').useCache().get();
+    return API.path('artifacts', 'credentials').useCache().get();
   }
 
   public static getAccountDetails(account: string): PromiseLike<IAccountDetails> {

--- a/app/scripts/modules/core/src/account/AccountService.ts
+++ b/app/scripts/modules/core/src/account/AccountService.ts
@@ -4,7 +4,7 @@ import { $log, $q } from 'ngimport';
 import { Observable } from 'rxjs';
 
 import { Application } from 'core/application/application.model';
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { CloudProviderRegistry } from '../cloudProvider/CloudProviderRegistry';
 import { SETTINGS } from 'core/config/settings';
 import { ILoadBalancer, IServerGroup } from 'core/domain';
@@ -65,7 +65,7 @@ export class AccountService {
 
   public static initialize(): void {
     this.accounts$ = Observable.defer(() => {
-      const promise = API.path('credentials').useCache().query({ expand: true }).get();
+      const promise = REST().path('credentials').useCache().query({ expand: true }).get();
       return Observable.fromPromise<IAccountDetails[]>(promise);
     })
       .publishReplay(1)
@@ -96,7 +96,7 @@ export class AccountService {
   }
 
   public static getArtifactAccounts(): PromiseLike<IArtifactAccount[]> {
-    return API.path('artifacts', 'credentials').useCache().get();
+    return REST().path('artifacts', 'credentials').useCache().get();
   }
 
   public static getAccountDetails(account: string): PromiseLike<IAccountDetails> {

--- a/app/scripts/modules/core/src/account/AccountService.ts
+++ b/app/scripts/modules/core/src/account/AccountService.ts
@@ -65,7 +65,7 @@ export class AccountService {
 
   public static initialize(): void {
     this.accounts$ = Observable.defer(() => {
-      const promise = API.one('credentials').useCache().withParams({ expand: true }).get();
+      const promise = API.path('credentials').useCache().query({ expand: true }).get();
       return Observable.fromPromise<IAccountDetails[]>(promise);
     })
       .publishReplay(1)
@@ -96,7 +96,7 @@ export class AccountService {
   }
 
   public static getArtifactAccounts(): PromiseLike<IArtifactAccount[]> {
-    return API.one('artifacts').one('credentials').useCache().get();
+    return API.path('artifacts').path('credentials').useCache().get();
   }
 
   public static getAccountDetails(account: string): PromiseLike<IAccountDetails> {
@@ -202,7 +202,11 @@ export class AccountService {
     return $q.when(this.listProviders$(application).toPromise());
   }
 
-  public static getAccountForInstance(cloudProvider: string, instanceId: string, app: Application): PromiseLike<string> {
+  public static getAccountForInstance(
+    cloudProvider: string,
+    instanceId: string,
+    app: Application,
+  ): PromiseLike<string> {
     return app.ready().then(() => {
       const serverGroups = app.getDataSource('serverGroups').data as IServerGroup[];
       const loadBalancers = app.getDataSource('loadBalancers').data as ILoadBalancer[];

--- a/app/scripts/modules/core/src/application/service/ApplicationReader.spec.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.spec.ts
@@ -1,8 +1,8 @@
 import { mock } from 'angular';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 
 import Spy = jasmine.Spy;
 import { IApplicationDataSourceAttribute, ApplicationReader } from './ApplicationReader';
-import { API } from 'core/api/ApiService';
 import { ApplicationDataSourceRegistry } from './ApplicationDataSourceRegistry';
 import { Application } from '../application.model';
 import { LOAD_BALANCER_DATA_SOURCE } from 'core/loadBalancer/loadBalancer.dataSource';
@@ -17,7 +17,6 @@ describe('ApplicationReader', function () {
   let loadBalancerReader: any;
   let clusterService: ClusterService;
   let $q: ng.IQService;
-  let $scope: ng.IScope;
 
   beforeEach(() => ApplicationDataSourceRegistry.clearDataSources());
 
@@ -38,29 +37,24 @@ describe('ApplicationReader', function () {
       _clusterService_: ClusterService,
       _$q_: ng.IQService,
       _loadBalancerReader_: LoadBalancerReader,
-      $rootScope: ng.IRootScopeService,
     ) {
       securityGroupReader = _securityGroupReader_;
       clusterService = _clusterService_;
       loadBalancerReader = _loadBalancerReader_;
       $q = _$q_;
-      $scope = $rootScope.$new();
     }),
   );
 
   describe('load application', function () {
     let application: Application = null;
 
-    function loadApplication(dataSources?: IApplicationDataSourceAttribute) {
+    async function loadApplication(dataSources?: IApplicationDataSourceAttribute) {
+      const http = mockHttpClient();
       const response = { applicationName: 'deck', attributes: {} as any };
       if (dataSources !== undefined) {
         response.attributes['dataSources'] = dataSources;
       }
-      spyOn(API, 'one').and.returnValue({
-        withParams: () => {
-          return { get: () => $q.when(response) };
-        },
-      });
+      http.expectGET('/applications/deck').respond(200, response);
       spyOn(securityGroupReader, 'loadSecurityGroupsByApplicationName').and.returnValue($q.when([]));
       spyOn(loadBalancerReader, 'loadLoadBalancers').and.returnValue($q.when([]));
       spyOn(clusterService, 'loadServerGroups').and.returnValue($q.when([]));
@@ -75,27 +69,27 @@ describe('ApplicationReader', function () {
       ApplicationReader.getApplication('deck').then((app) => {
         application = app;
       });
-      $scope.$digest();
+      await http.flush();
     }
 
-    it('loads all data sources if dataSource attribute is missing', function () {
-      loadApplication();
+    it('loads all data sources if dataSource attribute is missing', async function () {
+      await loadApplication();
       expect(application.attributes.dataSources).toBeUndefined();
       expect((clusterService.loadServerGroups as Spy).calls.count()).toBe(1);
       expect((securityGroupReader.getApplicationSecurityGroups as Spy).calls.count()).toBe(1);
       expect(loadBalancerReader.loadLoadBalancers.calls.count()).toBe(1);
     });
 
-    it('loads all data sources if disabled dataSource attribute is an empty array', function () {
-      loadApplication({ enabled: [], disabled: [] });
+    it('loads all data sources if disabled dataSource attribute is an empty array', async function () {
+      await loadApplication({ enabled: [], disabled: [] });
       expect((clusterService.loadServerGroups as Spy).calls.count()).toBe(1);
       expect((securityGroupReader.getApplicationSecurityGroups as Spy).calls.count()).toBe(1);
       expect(loadBalancerReader.loadLoadBalancers.calls.count()).toBe(1);
     });
 
-    it('only loads configured dataSources if attribute is non-empty', function () {
+    it('only loads configured dataSources if attribute is non-empty', async function () {
       const dataSources = { enabled: ['serverGroups'], disabled: ['securityGroups', 'loadBalancers'] };
-      loadApplication(dataSources);
+      await loadApplication(dataSources);
       expect((clusterService.loadServerGroups as Spy).calls.count()).toBe(1);
       expect((securityGroupReader.getApplicationSecurityGroups as Spy).calls.count()).toBe(0);
       expect(loadBalancerReader.loadLoadBalancers.calls.count()).toBe(0);
@@ -116,18 +110,18 @@ describe('ApplicationReader', function () {
         });
       });
 
-      it('disables opt-in data sources when nothing configured on application dataSources attribute', function () {
-        loadApplication();
+      it('disables opt-in data sources when nothing configured on application dataSources attribute', async function () {
+        await loadApplication();
         expect(application.getDataSource('optInSource').disabled).toBe(true);
       });
 
-      it('disables opt-in data sources when nothing configured on application dataSources.disabled attribute', function () {
-        loadApplication({ enabled: [], disabled: [] });
+      it('disables opt-in data sources when nothing configured on application dataSources.disabled attribute', async function () {
+        await loadApplication({ enabled: [], disabled: [] });
         expect(application.getDataSource('optInSource').disabled).toBe(true);
       });
 
-      it('enables opt-in data source when configured on application dataSources.disabled attribute', function () {
-        loadApplication({ enabled: ['optInSource'], disabled: [] });
+      it('enables opt-in data source when configured on application dataSources.disabled attribute', async function () {
+        await loadApplication({ enabled: ['optInSource'], disabled: [] });
         expect(application.getDataSource('optInSource').disabled).toBe(false);
       });
     });

--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { SchedulerFactory } from 'core/scheduler';
 import { Application } from '../application.model';
 import { ApplicationDataSource } from '../service/applicationDataSource';
@@ -24,11 +24,12 @@ export interface IApplicationSummary {
 
 export class ApplicationReader {
   public static listApplications(): PromiseLike<IApplicationSummary[]> {
-    return API.path('applications').useCache().get();
+    return REST().path('applications').useCache().get();
   }
 
   public static getApplicationAttributes(name: string): PromiseLike<any> {
-    return API.path('applications', name)
+    return REST()
+      .path('applications', name)
       .query({ expand: false })
       .get()
       .then((fromServer: Application) => {
@@ -49,7 +50,8 @@ export class ApplicationReader {
   }
 
   public static getApplication(name: string, expand = true): PromiseLike<Application> {
-    return API.path('applications', name)
+    return REST()
+      .path('applications', name)
       .query({ expand: expand })
       .get()
       .then((fromServer: Application) => {

--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -7,7 +7,7 @@ import { InferredApplicationWarningService } from './InferredApplicationWarningS
 
 export interface IApplicationDataSourceAttribute {
   enabled: string[];
-  disabled: string[];
+  disabled: string[]; ///./app/scripts/modules/core/src/pipeline/service/execution.service.ts;
 }
 
 export interface IApplicationSummary {
@@ -38,15 +38,16 @@ export class ApplicationReader {
       });
   }
 
-  public static getApplicationPermissions(applicationName: string): PromiseLike < any > {
-      return API.one('applications', applicationName)
-          .withParams({
-              expand: false,
-          })
-          .get()
-          .then((application: Application) => {
-              return application.attributes.permissions;
-          });
+  public static getApplicationPermissions(applicationName: string): PromiseLike<any> {
+    return REST('/applications')
+      .path(applicationName)
+      .query({
+        expand: false,
+      })
+      .get()
+      .then((application: Application) => {
+        return application.attributes.permissions;
+      });
   }
 
   public static getApplication(name: string, expand = true): PromiseLike<Application> {

--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -24,12 +24,12 @@ export interface IApplicationSummary {
 
 export class ApplicationReader {
   public static listApplications(): PromiseLike<IApplicationSummary[]> {
-    return API.all('applications').useCache().getList();
+    return API.path('applications').useCache().get();
   }
 
   public static getApplicationAttributes(name: string): PromiseLike<any> {
-    return API.one('applications', name)
-      .withParams({ expand: false })
+    return API.path('applications', name)
+      .query({ expand: false })
       .get()
       .then((fromServer: Application) => {
         this.splitAttributes(fromServer.attributes, ['accounts', 'cloudProviders']);
@@ -49,8 +49,8 @@ export class ApplicationReader {
   }
 
   public static getApplication(name: string, expand = true): PromiseLike<Application> {
-    return API.one('applications', name)
-      .withParams({ expand: expand })
+    return API.path('applications', name)
+      .query({ expand: expand })
       .get()
       .then((fromServer: Application) => {
         const configs = ApplicationDataSourceRegistry.getDataSources();

--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -24,12 +24,12 @@ export interface IApplicationSummary {
 
 export class ApplicationReader {
   public static listApplications(): PromiseLike<IApplicationSummary[]> {
-    return REST().path('applications').useCache().get();
+    return REST('/applications').useCache().get();
   }
 
   public static getApplicationAttributes(name: string): PromiseLike<any> {
-    return REST()
-      .path('applications', name)
+    return REST('/applications')
+      .path(name)
       .query({ expand: false })
       .get()
       .then((fromServer: Application) => {
@@ -50,8 +50,8 @@ export class ApplicationReader {
   }
 
   public static getApplication(name: string, expand = true): PromiseLike<Application> {
-    return REST()
-      .path('applications', name)
+    return REST('/applications')
+      .path(name)
       .query({ expand: expand })
       .get()
       .then((fromServer: Application) => {

--- a/app/scripts/modules/core/src/certificates/certificate.read.service.ts
+++ b/app/scripts/modules/core/src/certificates/certificate.read.service.ts
@@ -14,6 +14,6 @@ export class CertificateReader {
   }
 
   public static listCertificatesByProvider(cloudProvider: string): PromiseLike<ICertificate[]> {
-    return API.path('certificates').path(cloudProvider).get();
+    return API.path('certificates', cloudProvider).get();
   }
 }

--- a/app/scripts/modules/core/src/certificates/certificate.read.service.ts
+++ b/app/scripts/modules/core/src/certificates/certificate.read.service.ts
@@ -10,10 +10,10 @@ export interface ICertificate {
 
 export class CertificateReader {
   public static listCertificates(): PromiseLike<ICertificate[]> {
-    return REST().path('certificates').get();
+    return REST('/certificates').get();
   }
 
   public static listCertificatesByProvider(cloudProvider: string): PromiseLike<ICertificate[]> {
-    return REST().path('certificates', cloudProvider).get();
+    return REST('/certificates').path(cloudProvider).get();
   }
 }

--- a/app/scripts/modules/core/src/certificates/certificate.read.service.ts
+++ b/app/scripts/modules/core/src/certificates/certificate.read.service.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export interface ICertificate {
   expiration: number;
@@ -10,10 +10,10 @@ export interface ICertificate {
 
 export class CertificateReader {
   public static listCertificates(): PromiseLike<ICertificate[]> {
-    return API.path('certificates').get();
+    return REST().path('certificates').get();
   }
 
   public static listCertificatesByProvider(cloudProvider: string): PromiseLike<ICertificate[]> {
-    return API.path('certificates', cloudProvider).get();
+    return REST().path('certificates', cloudProvider).get();
   }
 }

--- a/app/scripts/modules/core/src/certificates/certificate.read.service.ts
+++ b/app/scripts/modules/core/src/certificates/certificate.read.service.ts
@@ -1,5 +1,3 @@
-
-
 import { API } from 'core/api/ApiService';
 
 export interface ICertificate {
@@ -12,10 +10,10 @@ export interface ICertificate {
 
 export class CertificateReader {
   public static listCertificates(): PromiseLike<ICertificate[]> {
-    return API.one('certificates').getList();
+    return API.path('certificates').get();
   }
 
   public static listCertificatesByProvider(cloudProvider: string): PromiseLike<ICertificate[]> {
-    return API.one('certificates').one(cloudProvider).getList();
+    return API.path('certificates').path(cloudProvider).get();
   }
 }

--- a/app/scripts/modules/core/src/ci/igor.service.ts
+++ b/app/scripts/modules/core/src/ci/igor.service.ts
@@ -12,7 +12,7 @@ export enum BuildServiceType {
 
 export class IgorService {
   public static listMasters(buildType: BuildServiceType = null): PromiseLike<string[]> {
-    const allMasters: PromiseLike<string[]> = API.path('v2').path('builds').query({ type: buildType }).get();
+    const allMasters: PromiseLike<string[]> = API.path('v2', 'builds').query({ type: buildType }).get();
     if (!allMasters) {
       return $q.reject('An error occurred when retrieving build masters');
     }
@@ -29,30 +29,30 @@ export class IgorService {
   }
 
   public static listJobsForMaster(master: string): PromiseLike<string[]> {
-    return API.path('v2').path('builds').path(master).path('jobs').get();
+    return API.path('v2', 'builds', master, 'jobs').get();
   }
 
   public static listBuildsForJob(master: string, job: string): PromiseLike<IBuild[]> {
-    return API.path('v2').path('builds').path(master).path('builds').path(job).get();
+    return API.path('v2', 'builds', master, 'builds', job).get();
   }
 
   public static getJobConfig(master: string, job: string): PromiseLike<IJobConfig> {
-    return API.path('v2').path('builds').path(master).path('jobs').path(job).get();
+    return API.path('v2', 'builds', master, 'jobs', job).get();
   }
 
   public static getGcbAccounts(): PromiseLike<string[]> {
-    return API.path('gcb').path('accounts').get();
+    return API.path('gcb', 'accounts').get();
   }
 
   public static getGcbTriggers(account: string): PromiseLike<IGcbTrigger[]> {
-    return API.path('gcb').path('triggers').path(account).get();
+    return API.path('gcb', 'triggers', account).get();
   }
 
   public static getCodeBuildAccounts(): PromiseLike<string[]> {
-    return API.path('codebuild').path('accounts').get();
+    return API.path('codebuild', 'accounts').get();
   }
 
   public static getCodeBuildProjects(account: string): PromiseLike<string[]> {
-    return API.path('codebuild').path('projects').path(account).get();
+    return API.path('codebuild', 'projects', account).get();
   }
 }

--- a/app/scripts/modules/core/src/ci/igor.service.ts
+++ b/app/scripts/modules/core/src/ci/igor.service.ts
@@ -1,4 +1,3 @@
-
 import { $q } from 'ngimport';
 
 import { API } from 'core/api/ApiService';
@@ -13,7 +12,7 @@ export enum BuildServiceType {
 
 export class IgorService {
   public static listMasters(buildType: BuildServiceType = null): PromiseLike<string[]> {
-    const allMasters: PromiseLike<string[]> = API.one('v2').one('builds').withParams({ type: buildType }).get();
+    const allMasters: PromiseLike<string[]> = API.path('v2').path('builds').query({ type: buildType }).get();
     if (!allMasters) {
       return $q.reject('An error occurred when retrieving build masters');
     }
@@ -30,30 +29,30 @@ export class IgorService {
   }
 
   public static listJobsForMaster(master: string): PromiseLike<string[]> {
-    return API.one('v2').one('builds').one(master).one('jobs').get();
+    return API.path('v2').path('builds').path(master).path('jobs').get();
   }
 
   public static listBuildsForJob(master: string, job: string): PromiseLike<IBuild[]> {
-    return API.one('v2').one('builds').one(master).one('builds').one(job).get();
+    return API.path('v2').path('builds').path(master).path('builds').path(job).get();
   }
 
   public static getJobConfig(master: string, job: string): PromiseLike<IJobConfig> {
-    return API.one('v2').one('builds').one(master).one('jobs').one(job).get();
+    return API.path('v2').path('builds').path(master).path('jobs').path(job).get();
   }
 
   public static getGcbAccounts(): PromiseLike<string[]> {
-    return API.one('gcb').one('accounts').get();
+    return API.path('gcb').path('accounts').get();
   }
 
   public static getGcbTriggers(account: string): PromiseLike<IGcbTrigger[]> {
-    return API.one('gcb').one('triggers').one(account).get();
+    return API.path('gcb').path('triggers').path(account).get();
   }
 
   public static getCodeBuildAccounts(): PromiseLike<string[]> {
-    return API.one('codebuild').one('accounts').get();
+    return API.path('codebuild').path('accounts').get();
   }
 
   public static getCodeBuildProjects(account: string): PromiseLike<string[]> {
-    return API.one('codebuild').one('projects').one(account).get();
+    return API.path('codebuild').path('projects').path(account).get();
   }
 }

--- a/app/scripts/modules/core/src/ci/igor.service.ts
+++ b/app/scripts/modules/core/src/ci/igor.service.ts
@@ -12,7 +12,7 @@ export enum BuildServiceType {
 
 export class IgorService {
   public static listMasters(buildType: BuildServiceType = null): PromiseLike<string[]> {
-    const allMasters: PromiseLike<string[]> = REST().path('v2', 'builds').query({ type: buildType }).get();
+    const allMasters: PromiseLike<string[]> = REST('/v2/builds').query({ type: buildType }).get();
     if (!allMasters) {
       return $q.reject('An error occurred when retrieving build masters');
     }
@@ -29,30 +29,30 @@ export class IgorService {
   }
 
   public static listJobsForMaster(master: string): PromiseLike<string[]> {
-    return REST().path('v2', 'builds', master, 'jobs').get();
+    return REST('/v2/builds').path(master, 'jobs').get();
   }
 
   public static listBuildsForJob(master: string, job: string): PromiseLike<IBuild[]> {
-    return REST().path('v2', 'builds', master, 'builds', job).get();
+    return REST('/v2/builds').path(master, 'builds', job).get();
   }
 
   public static getJobConfig(master: string, job: string): PromiseLike<IJobConfig> {
-    return REST().path('v2', 'builds', master, 'jobs', job).get();
+    return REST('/v2/builds').path(master, 'jobs', job).get();
   }
 
   public static getGcbAccounts(): PromiseLike<string[]> {
-    return REST().path('gcb', 'accounts').get();
+    return REST('/gcb/accounts').get();
   }
 
   public static getGcbTriggers(account: string): PromiseLike<IGcbTrigger[]> {
-    return REST().path('gcb', 'triggers', account).get();
+    return REST('/gcb/triggers').path(account).get();
   }
 
   public static getCodeBuildAccounts(): PromiseLike<string[]> {
-    return REST().path('codebuild', 'accounts').get();
+    return REST('/codebuild/accounts').get();
   }
 
   public static getCodeBuildProjects(account: string): PromiseLike<string[]> {
-    return REST().path('codebuild', 'projects', account).get();
+    return REST('/codebuild/projects').path(account).get();
   }
 }

--- a/app/scripts/modules/core/src/ci/igor.service.ts
+++ b/app/scripts/modules/core/src/ci/igor.service.ts
@@ -1,6 +1,6 @@
 import { $q } from 'ngimport';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IBuild, IJobConfig, IGcbTrigger } from 'core/domain';
 
 export enum BuildServiceType {
@@ -12,7 +12,7 @@ export enum BuildServiceType {
 
 export class IgorService {
   public static listMasters(buildType: BuildServiceType = null): PromiseLike<string[]> {
-    const allMasters: PromiseLike<string[]> = API.path('v2', 'builds').query({ type: buildType }).get();
+    const allMasters: PromiseLike<string[]> = REST().path('v2', 'builds').query({ type: buildType }).get();
     if (!allMasters) {
       return $q.reject('An error occurred when retrieving build masters');
     }
@@ -29,30 +29,30 @@ export class IgorService {
   }
 
   public static listJobsForMaster(master: string): PromiseLike<string[]> {
-    return API.path('v2', 'builds', master, 'jobs').get();
+    return REST().path('v2', 'builds', master, 'jobs').get();
   }
 
   public static listBuildsForJob(master: string, job: string): PromiseLike<IBuild[]> {
-    return API.path('v2', 'builds', master, 'builds', job).get();
+    return REST().path('v2', 'builds', master, 'builds', job).get();
   }
 
   public static getJobConfig(master: string, job: string): PromiseLike<IJobConfig> {
-    return API.path('v2', 'builds', master, 'jobs', job).get();
+    return REST().path('v2', 'builds', master, 'jobs', job).get();
   }
 
   public static getGcbAccounts(): PromiseLike<string[]> {
-    return API.path('gcb', 'accounts').get();
+    return REST().path('gcb', 'accounts').get();
   }
 
   public static getGcbTriggers(account: string): PromiseLike<IGcbTrigger[]> {
-    return API.path('gcb', 'triggers', account).get();
+    return REST().path('gcb', 'triggers', account).get();
   }
 
   public static getCodeBuildAccounts(): PromiseLike<string[]> {
-    return API.path('codebuild', 'accounts').get();
+    return REST().path('codebuild', 'accounts').get();
   }
 
   public static getCodeBuildProjects(account: string): PromiseLike<string[]> {
-    return API.path('codebuild', 'projects', account).get();
+    return REST().path('codebuild', 'projects', account).get();
   }
 }

--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -35,7 +35,7 @@ export class ClusterService {
   public loadServerGroups(application: Application): PromiseLike<IServerGroup[]> {
     return this.getClusters(application.name).then((clusters: IClusterSummary[]) => {
       const dataSource = application.getDataSource('serverGroups');
-      let serverGroupLoader = REST().path('applications', application.name, 'serverGroups');
+      let serverGroupLoader = REST('/applications').path(application.name, 'serverGroups');
       dataSource.fetchOnDemand = clusters.length > SETTINGS.onDemandClusterThreshold;
       if (dataSource.fetchOnDemand) {
         dataSource.clusters = clusters;
@@ -223,8 +223,8 @@ export class ClusterService {
   }
 
   private getClusters(application: string): PromiseLike<IClusterSummary[]> {
-    return REST()
-      .path('applications', application, 'clusters')
+    return REST('/applications')
+      .path(application, 'clusters')
       .get()
       .then((clustersMap: { [account: string]: string[] }) => {
         const clusters: IClusterSummary[] = [];

--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -2,7 +2,7 @@ import { IQService, module } from 'angular';
 import { flatten, forOwn, groupBy, has, head, keys, values, keyBy } from 'lodash';
 
 import { ArtifactReferenceService } from 'core/artifact';
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { Application } from 'core/application';
 import { NameUtils } from 'core/naming';
 import { FilterModelService } from 'core/filterModel';
@@ -35,7 +35,7 @@ export class ClusterService {
   public loadServerGroups(application: Application): PromiseLike<IServerGroup[]> {
     return this.getClusters(application.name).then((clusters: IClusterSummary[]) => {
       const dataSource = application.getDataSource('serverGroups');
-      let serverGroupLoader = API.path('applications', application.name, 'serverGroups');
+      let serverGroupLoader = REST().path('applications', application.name, 'serverGroups');
       dataSource.fetchOnDemand = clusters.length > SETTINGS.onDemandClusterThreshold;
       if (dataSource.fetchOnDemand) {
         dataSource.clusters = clusters;
@@ -223,7 +223,8 @@ export class ClusterService {
   }
 
   private getClusters(application: string): PromiseLike<IClusterSummary[]> {
-    return API.path('applications', application, 'clusters')
+    return REST()
+      .path('applications', application, 'clusters')
       .get()
       .then((clustersMap: { [account: string]: string[] }) => {
         const clusters: IClusterSummary[] = [];

--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -35,11 +35,11 @@ export class ClusterService {
   public loadServerGroups(application: Application): PromiseLike<IServerGroup[]> {
     return this.getClusters(application.name).then((clusters: IClusterSummary[]) => {
       const dataSource = application.getDataSource('serverGroups');
-      let serverGroupLoader = API.one('applications').one(application.name).all('serverGroups');
+      let serverGroupLoader = API.path('applications').path(application.name).path('serverGroups');
       dataSource.fetchOnDemand = clusters.length > SETTINGS.onDemandClusterThreshold;
       if (dataSource.fetchOnDemand) {
         dataSource.clusters = clusters;
-        serverGroupLoader = serverGroupLoader.withParams({
+        serverGroupLoader = serverGroupLoader.query({
           clusters: FilterModelService.getCheckValues(
             ClusterState.filterModel.asFilterModel.sortFilter.clusters,
           ).join(),
@@ -47,7 +47,7 @@ export class ClusterService {
       } else {
         this.reconcileClusterDeepLink();
       }
-      return serverGroupLoader.getList().then((serverGroups: IServerGroup[]) => {
+      return serverGroupLoader.get().then((serverGroups: IServerGroup[]) => {
         serverGroups.forEach((sg) => this.addHealthStatusCheck(sg));
         serverGroups.forEach((sg) => this.addNameParts(sg));
         return this.$q
@@ -223,9 +223,9 @@ export class ClusterService {
   }
 
   private getClusters(application: string): PromiseLike<IClusterSummary[]> {
-    return API.one('applications')
-      .one(application)
-      .one('clusters')
+    return API.path('applications')
+      .path(application)
+      .path('clusters')
       .get()
       .then((clustersMap: { [account: string]: string[] }) => {
         const clusters: IClusterSummary[] = [];

--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -35,7 +35,7 @@ export class ClusterService {
   public loadServerGroups(application: Application): PromiseLike<IServerGroup[]> {
     return this.getClusters(application.name).then((clusters: IClusterSummary[]) => {
       const dataSource = application.getDataSource('serverGroups');
-      let serverGroupLoader = API.path('applications').path(application.name).path('serverGroups');
+      let serverGroupLoader = API.path('applications', application.name, 'serverGroups');
       dataSource.fetchOnDemand = clusters.length > SETTINGS.onDemandClusterThreshold;
       if (dataSource.fetchOnDemand) {
         dataSource.clusters = clusters;
@@ -223,9 +223,7 @@ export class ClusterService {
   }
 
   private getClusters(application: string): PromiseLike<IClusterSummary[]> {
-    return API.path('applications')
-      .path(application)
-      .path('clusters')
+    return API.path('applications', application, 'clusters')
       .get()
       .then((clustersMap: { [account: string]: string[] }) => {
         const clusters: IClusterSummary[] = [];

--- a/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
+++ b/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
@@ -1,6 +1,6 @@
 import { $q } from 'ngimport';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IEntityTags, IEntityTag, ICreationMetadataTag } from '../domain/IEntityTags';
 import { Application } from 'core/application/application.model';
 import {
@@ -16,7 +16,8 @@ import { SETTINGS } from 'core/config/settings';
 
 export class EntityTagsReader {
   public static getAllEntityTagsForApplication(application: string): PromiseLike<IEntityTags[]> {
-    return API.path('tags')
+    return REST()
+      .path('tags')
       .query({ maxResults: SETTINGS.entityTags.maxResults || 5000, application })
       .get()
       .then((allTags: IEntityTags[]) => this.flattenTagsAndAddMetadata(allTags));
@@ -146,7 +147,8 @@ export class EntityTagsReader {
     if (!entityId) {
       return $q.when([]);
     }
-    return API.path('tags')
+    return REST()
+      .path('tags')
       .query({
         entityType: entityType.toLowerCase(),
         entityId,

--- a/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
+++ b/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
@@ -16,8 +16,7 @@ import { SETTINGS } from 'core/config/settings';
 
 export class EntityTagsReader {
   public static getAllEntityTagsForApplication(application: string): PromiseLike<IEntityTags[]> {
-    return REST()
-      .path('tags')
+    return REST('/tags')
       .query({ maxResults: SETTINGS.entityTags.maxResults || 5000, application })
       .get()
       .then((allTags: IEntityTags[]) => this.flattenTagsAndAddMetadata(allTags));
@@ -147,8 +146,7 @@ export class EntityTagsReader {
     if (!entityId) {
       return $q.when([]);
     }
-    return REST()
-      .path('tags')
+    return REST('/tags')
       .query({
         entityType: entityType.toLowerCase(),
         entityId,

--- a/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
+++ b/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
@@ -1,5 +1,3 @@
-
-
 import { $q } from 'ngimport';
 
 import { API } from 'core/api/ApiService';
@@ -18,9 +16,9 @@ import { SETTINGS } from 'core/config/settings';
 
 export class EntityTagsReader {
   public static getAllEntityTagsForApplication(application: string): PromiseLike<IEntityTags[]> {
-    return API.one('tags')
-      .withParams({ maxResults: SETTINGS.entityTags.maxResults || 5000, application })
-      .getList()
+    return API.path('tags')
+      .query({ maxResults: SETTINGS.entityTags.maxResults || 5000, application })
+      .get()
       .then((allTags: IEntityTags[]) => this.flattenTagsAndAddMetadata(allTags));
   }
 
@@ -148,12 +146,12 @@ export class EntityTagsReader {
     if (!entityId) {
       return $q.when([]);
     }
-    return API.one('tags')
-      .withParams({
+    return API.path('tags')
+      .query({
         entityType: entityType.toLowerCase(),
         entityId,
       })
-      .getList()
+      .get()
       .then((entityTagGroups: IEntityTags[]) => {
         return this.flattenTagsAndAddMetadata(entityTagGroups);
       })

--- a/app/scripts/modules/core/src/function/function.read.service.ts
+++ b/app/scripts/modules/core/src/function/function.read.service.ts
@@ -21,9 +21,9 @@ export class FunctionReader {
   public constructor(private functionTransformer: IFunctionTransformer) {}
 
   public loadFunctions(applicationName: string): PromiseLike<IFunctionSourceData[]> {
-    return API.one('applications', applicationName)
-      .all('functions')
-      .getList()
+    return API.path('applications', applicationName)
+      .path('functions')
+      .get()
       .then((functions: IFunctionSourceData[]) => {
         functions = this.functionTransformer.normalizeFunctionSet(functions);
         return functions.map((fn) => this.normalizeFunction(fn));
@@ -36,8 +36,8 @@ export class FunctionReader {
     region: string,
     name: string,
   ): PromiseLike<IFunctionSourceData[]> {
-    return API.all('functions')
-      .withParams({ provider: cloudProvider, functionName: name, region: region, account: account })
+    return API.path('functions')
+      .query({ provider: cloudProvider, functionName: name, region: region, account: account })
       .get()
       .then((functions: IFunctionSourceData[]) => {
         functions = this.functionTransformer.normalizeFunctionSet(functions);
@@ -46,7 +46,7 @@ export class FunctionReader {
   }
 
   public listFunctions(cloudProvider: string): PromiseLike<IFunctionByAccount[]> {
-    return API.all('functions').withParams({ provider: cloudProvider }).getList();
+    return API.path('functions').query({ provider: cloudProvider }).get();
   }
 
   private normalizeFunction(functionDef: IFunctionSourceData): IFunctionSourceData {

--- a/app/scripts/modules/core/src/function/function.read.service.ts
+++ b/app/scripts/modules/core/src/function/function.read.service.ts
@@ -21,8 +21,8 @@ export class FunctionReader {
   public constructor(private functionTransformer: IFunctionTransformer) {}
 
   public loadFunctions(applicationName: string): PromiseLike<IFunctionSourceData[]> {
-    return REST()
-      .path('applications', applicationName, 'functions')
+    return REST('/applications')
+      .path(applicationName, 'functions')
       .get()
       .then((functions: IFunctionSourceData[]) => {
         functions = this.functionTransformer.normalizeFunctionSet(functions);
@@ -36,8 +36,7 @@ export class FunctionReader {
     region: string,
     name: string,
   ): PromiseLike<IFunctionSourceData[]> {
-    return REST()
-      .path('functions')
+    return REST('/functions')
       .query({ provider: cloudProvider, functionName: name, region: region, account: account })
       .get()
       .then((functions: IFunctionSourceData[]) => {
@@ -47,7 +46,7 @@ export class FunctionReader {
   }
 
   public listFunctions(cloudProvider: string): PromiseLike<IFunctionByAccount[]> {
-    return REST().path('functions').query({ provider: cloudProvider }).get();
+    return REST('/functions').query({ provider: cloudProvider }).get();
   }
 
   private normalizeFunction(functionDef: IFunctionSourceData): IFunctionSourceData {

--- a/app/scripts/modules/core/src/function/function.read.service.ts
+++ b/app/scripts/modules/core/src/function/function.read.service.ts
@@ -21,8 +21,7 @@ export class FunctionReader {
   public constructor(private functionTransformer: IFunctionTransformer) {}
 
   public loadFunctions(applicationName: string): PromiseLike<IFunctionSourceData[]> {
-    return API.path('applications', applicationName)
-      .path('functions')
+    return API.path('applications', applicationName, 'functions')
       .get()
       .then((functions: IFunctionSourceData[]) => {
         functions = this.functionTransformer.normalizeFunctionSet(functions);

--- a/app/scripts/modules/core/src/function/function.read.service.ts
+++ b/app/scripts/modules/core/src/function/function.read.service.ts
@@ -1,6 +1,6 @@
 import { module } from 'angular';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IFunctionSourceData } from 'core/domain';
 import { CORE_FUNCTION_FUNCTION_TRANSFORMER, IFunctionTransformer } from './function.transformer';
 
@@ -21,7 +21,8 @@ export class FunctionReader {
   public constructor(private functionTransformer: IFunctionTransformer) {}
 
   public loadFunctions(applicationName: string): PromiseLike<IFunctionSourceData[]> {
-    return API.path('applications', applicationName, 'functions')
+    return REST()
+      .path('applications', applicationName, 'functions')
       .get()
       .then((functions: IFunctionSourceData[]) => {
         functions = this.functionTransformer.normalizeFunctionSet(functions);
@@ -35,7 +36,8 @@ export class FunctionReader {
     region: string,
     name: string,
   ): PromiseLike<IFunctionSourceData[]> {
-    return API.path('functions')
+    return REST()
+      .path('functions')
       .query({ provider: cloudProvider, functionName: name, region: region, account: account })
       .get()
       .then((functions: IFunctionSourceData[]) => {
@@ -45,7 +47,7 @@ export class FunctionReader {
   }
 
   public listFunctions(cloudProvider: string): PromiseLike<IFunctionByAccount[]> {
-    return API.path('functions').query({ provider: cloudProvider }).get();
+    return REST().path('functions').query({ provider: cloudProvider }).get();
   }
 
   private normalizeFunction(functionDef: IFunctionSourceData): IFunctionSourceData {

--- a/app/scripts/modules/core/src/instance/InstanceReader.ts
+++ b/app/scripts/modules/core/src/instance/InstanceReader.ts
@@ -13,7 +13,7 @@ export interface IInstanceMultiOutputLog {
 
 export class InstanceReader {
   public static getInstanceDetails(account: string, region: string, id: string): PromiseLike<IInstance> {
-    return API.path('instances').path(account).path(region).path(id).get();
+    return API.path('instances', account, region, id).get();
   }
 
   public static getConsoleOutput(
@@ -22,11 +22,6 @@ export class InstanceReader {
     id: string,
     cloudProvider: string,
   ): PromiseLike<IInstanceConsoleOutput> {
-    return API.path('instances')
-      .path(account)
-      .path(region)
-      .path(id, 'console')
-      .query({ provider: cloudProvider })
-      .get();
+    return API.path('instances', account, region, id, 'console').query({ provider: cloudProvider }).get();
   }
 }

--- a/app/scripts/modules/core/src/instance/InstanceReader.ts
+++ b/app/scripts/modules/core/src/instance/InstanceReader.ts
@@ -1,4 +1,3 @@
-
 import { API } from 'core/api/ApiService';
 import { IInstance } from 'core/domain';
 
@@ -14,7 +13,7 @@ export interface IInstanceMultiOutputLog {
 
 export class InstanceReader {
   public static getInstanceDetails(account: string, region: string, id: string): PromiseLike<IInstance> {
-    return API.one('instances').one(account).one(region).one(id).get();
+    return API.path('instances').path(account).path(region).path(id).get();
   }
 
   public static getConsoleOutput(
@@ -23,11 +22,11 @@ export class InstanceReader {
     id: string,
     cloudProvider: string,
   ): PromiseLike<IInstanceConsoleOutput> {
-    return API.one('instances')
-      .all(account)
-      .all(region)
-      .one(id, 'console')
-      .withParams({ provider: cloudProvider })
+    return API.path('instances')
+      .path(account)
+      .path(region)
+      .path(id, 'console')
+      .query({ provider: cloudProvider })
       .get();
   }
 }

--- a/app/scripts/modules/core/src/instance/InstanceReader.ts
+++ b/app/scripts/modules/core/src/instance/InstanceReader.ts
@@ -13,7 +13,7 @@ export interface IInstanceMultiOutputLog {
 
 export class InstanceReader {
   public static getInstanceDetails(account: string, region: string, id: string): PromiseLike<IInstance> {
-    return REST().path('instances', account, region, id).get();
+    return REST('/instances').path(account, region, id).get();
   }
 
   public static getConsoleOutput(
@@ -22,6 +22,6 @@ export class InstanceReader {
     id: string,
     cloudProvider: string,
   ): PromiseLike<IInstanceConsoleOutput> {
-    return REST().path('instances', account, region, id, 'console').query({ provider: cloudProvider }).get();
+    return REST('/instances').path(account, region, id, 'console').query({ provider: cloudProvider }).get();
   }
 }

--- a/app/scripts/modules/core/src/instance/InstanceReader.ts
+++ b/app/scripts/modules/core/src/instance/InstanceReader.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IInstance } from 'core/domain';
 
 export interface IInstanceConsoleOutput {
@@ -13,7 +13,7 @@ export interface IInstanceMultiOutputLog {
 
 export class InstanceReader {
   public static getInstanceDetails(account: string, region: string, id: string): PromiseLike<IInstance> {
-    return API.path('instances', account, region, id).get();
+    return REST().path('instances', account, region, id).get();
   }
 
   public static getConsoleOutput(
@@ -22,6 +22,6 @@ export class InstanceReader {
     id: string,
     cloudProvider: string,
   ): PromiseLike<IInstanceConsoleOutput> {
-    return API.path('instances', account, region, id, 'console').query({ provider: cloudProvider }).get();
+    return REST().path('instances', account, region, id, 'console').query({ provider: cloudProvider }).get();
   }
 }

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
@@ -21,8 +21,8 @@ export class LoadBalancerReader {
   public constructor(private $q: IQService, private loadBalancerTransformer: any) {}
 
   public loadLoadBalancers(applicationName: string): PromiseLike<ILoadBalancerSourceData[]> {
-    return REST()
-      .path('applications', applicationName, 'loadBalancers')
+    return REST('/applications')
+      .path(applicationName, 'loadBalancers')
       .get()
       .then((loadBalancers: ILoadBalancerSourceData[]) => {
         loadBalancers = this.loadBalancerTransformer.normalizeLoadBalancerSet(loadBalancers);
@@ -36,11 +36,11 @@ export class LoadBalancerReader {
     region: string,
     name: string,
   ): PromiseLike<ILoadBalancerSourceData[]> {
-    return REST().path('loadBalancers', account, region, name).query({ provider: cloudProvider }).get();
+    return REST('/loadBalancers').path(account, region, name).query({ provider: cloudProvider }).get();
   }
 
   public listLoadBalancers(cloudProvider: string): PromiseLike<ILoadBalancersByAccount[]> {
-    return REST().path('loadBalancers').query({ provider: cloudProvider }).get();
+    return REST('/loadBalancers').query({ provider: cloudProvider }).get();
   }
 
   private normalizeLoadBalancer(loadBalancer: ILoadBalancerSourceData): PromiseLike<ILoadBalancer> {

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
@@ -21,9 +21,9 @@ export class LoadBalancerReader {
   public constructor(private $q: IQService, private loadBalancerTransformer: any) {}
 
   public loadLoadBalancers(applicationName: string): PromiseLike<ILoadBalancerSourceData[]> {
-    return API.one('applications', applicationName)
-      .all('loadBalancers')
-      .getList()
+    return API.path('applications', applicationName)
+      .path('loadBalancers')
+      .get()
       .then((loadBalancers: ILoadBalancerSourceData[]) => {
         loadBalancers = this.loadBalancerTransformer.normalizeLoadBalancerSet(loadBalancers);
         return this.$q.all(loadBalancers.map((lb) => this.normalizeLoadBalancer(lb)));
@@ -36,11 +36,11 @@ export class LoadBalancerReader {
     region: string,
     name: string,
   ): PromiseLike<ILoadBalancerSourceData[]> {
-    return API.all('loadBalancers').all(account).all(region).all(name).withParams({ provider: cloudProvider }).get();
+    return API.path('loadBalancers').path(account).path(region).path(name).query({ provider: cloudProvider }).get();
   }
 
   public listLoadBalancers(cloudProvider: string): PromiseLike<ILoadBalancersByAccount[]> {
-    return API.all('loadBalancers').withParams({ provider: cloudProvider }).getList();
+    return API.path('loadBalancers').query({ provider: cloudProvider }).get();
   }
 
   private normalizeLoadBalancer(loadBalancer: ILoadBalancerSourceData): PromiseLike<ILoadBalancer> {

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
@@ -1,6 +1,6 @@
 import { IQService, module } from 'angular';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IComponentName, NameUtils } from 'core/naming';
 import { ILoadBalancer, ILoadBalancerSourceData } from 'core/domain';
 import { CORE_LOADBALANCER_LOADBALANCER_TRANSFORMER } from './loadBalancer.transformer';
@@ -21,7 +21,8 @@ export class LoadBalancerReader {
   public constructor(private $q: IQService, private loadBalancerTransformer: any) {}
 
   public loadLoadBalancers(applicationName: string): PromiseLike<ILoadBalancerSourceData[]> {
-    return API.path('applications', applicationName, 'loadBalancers')
+    return REST()
+      .path('applications', applicationName, 'loadBalancers')
       .get()
       .then((loadBalancers: ILoadBalancerSourceData[]) => {
         loadBalancers = this.loadBalancerTransformer.normalizeLoadBalancerSet(loadBalancers);
@@ -35,11 +36,11 @@ export class LoadBalancerReader {
     region: string,
     name: string,
   ): PromiseLike<ILoadBalancerSourceData[]> {
-    return API.path('loadBalancers', account, region, name).query({ provider: cloudProvider }).get();
+    return REST().path('loadBalancers', account, region, name).query({ provider: cloudProvider }).get();
   }
 
   public listLoadBalancers(cloudProvider: string): PromiseLike<ILoadBalancersByAccount[]> {
-    return API.path('loadBalancers').query({ provider: cloudProvider }).get();
+    return REST().path('loadBalancers').query({ provider: cloudProvider }).get();
   }
 
   private normalizeLoadBalancer(loadBalancer: ILoadBalancerSourceData): PromiseLike<ILoadBalancer> {

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
@@ -21,8 +21,7 @@ export class LoadBalancerReader {
   public constructor(private $q: IQService, private loadBalancerTransformer: any) {}
 
   public loadLoadBalancers(applicationName: string): PromiseLike<ILoadBalancerSourceData[]> {
-    return API.path('applications', applicationName)
-      .path('loadBalancers')
+    return API.path('applications', applicationName, 'loadBalancers')
       .get()
       .then((loadBalancers: ILoadBalancerSourceData[]) => {
         loadBalancers = this.loadBalancerTransformer.normalizeLoadBalancerSet(loadBalancers);
@@ -36,7 +35,7 @@ export class LoadBalancerReader {
     region: string,
     name: string,
   ): PromiseLike<ILoadBalancerSourceData[]> {
-    return API.path('loadBalancers').path(account).path(region).path(name).query({ provider: cloudProvider }).get();
+    return API.path('loadBalancers', account, region, name).query({ provider: cloudProvider }).get();
   }
 
   public listLoadBalancers(cloudProvider: string): PromiseLike<ILoadBalancersByAccount[]> {

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -81,24 +81,20 @@ export class ManagedReader {
   }
 
   public static getApplicationSummary(app: string): PromiseLike<IManagedApplicationSummary<'resources'>> {
-    return REST()
-      .path('managed', 'application', app)
-      .query({ entities: 'resources' })
-      .get()
-      .then(this.decorateResources);
+    return REST('/managed/application').path(app).query({ entities: 'resources' }).get().then(this.decorateResources);
   }
 
   public static getEnvironmentsSummary(app: string): PromiseLike<IManagedApplicationSummary> {
-    return REST()
-      .path('managed', 'application', app)
+    return REST('/managed/application')
+      .path(app)
       .query({ entities: ['resources', 'artifacts', 'environments'], maxArtifactVersions: 30 })
       .get()
       .then(this.decorateResources);
   }
 
   public static getResourceHistory(resourceId: string): PromiseLike<IManagedResourceEventHistory> {
-    return REST()
-      .path('history', resourceId)
+    return REST('/history')
+      .path(resourceId)
       .query({ limit: 100 })
       .get()
       .then((response: IManagedResourceEventHistoryResponse) => {

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -1,6 +1,6 @@
 import { get, set, flatMap } from 'lodash';
 
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import {
   IManagedApplicationSummary,
   ManagedResourceStatus,
@@ -81,18 +81,24 @@ export class ManagedReader {
   }
 
   public static getApplicationSummary(app: string): PromiseLike<IManagedApplicationSummary<'resources'>> {
-    return API.path('managed', 'application', app).query({ entities: 'resources' }).get().then(this.decorateResources);
+    return REST()
+      .path('managed', 'application', app)
+      .query({ entities: 'resources' })
+      .get()
+      .then(this.decorateResources);
   }
 
   public static getEnvironmentsSummary(app: string): PromiseLike<IManagedApplicationSummary> {
-    return API.path('managed', 'application', app)
+    return REST()
+      .path('managed', 'application', app)
       .query({ entities: ['resources', 'artifacts', 'environments'], maxArtifactVersions: 30 })
       .get()
       .then(this.decorateResources);
   }
 
   public static getResourceHistory(resourceId: string): PromiseLike<IManagedResourceEventHistory> {
-    return API.path('history', resourceId)
+    return REST()
+      .path('history', resourceId)
       .query({ limit: 100 })
       .get()
       .then((response: IManagedResourceEventHistoryResponse) => {

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -81,24 +81,24 @@ export class ManagedReader {
   }
 
   public static getApplicationSummary(app: string): PromiseLike<IManagedApplicationSummary<'resources'>> {
-    return API.one('managed')
-      .one('application', app)
-      .withParams({ entities: 'resources' })
+    return API.path('managed')
+      .path('application', app)
+      .query({ entities: 'resources' })
       .get()
       .then(this.decorateResources);
   }
 
   public static getEnvironmentsSummary(app: string): PromiseLike<IManagedApplicationSummary> {
-    return API.one('managed')
-      .one('application', app)
-      .withParams({ entities: ['resources', 'artifacts', 'environments'], maxArtifactVersions: 30 })
+    return API.path('managed')
+      .path('application', app)
+      .query({ entities: ['resources', 'artifacts', 'environments'], maxArtifactVersions: 30 })
       .get()
       .then(this.decorateResources);
   }
 
   public static getResourceHistory(resourceId: string): PromiseLike<IManagedResourceEventHistory> {
-    return API.one('history', resourceId)
-      .withParams({ limit: 100 })
+    return API.path('history', resourceId)
+      .query({ limit: 100 })
       .get()
       .then((response: IManagedResourceEventHistoryResponse) => {
         response.forEach((event) => {

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -81,16 +81,11 @@ export class ManagedReader {
   }
 
   public static getApplicationSummary(app: string): PromiseLike<IManagedApplicationSummary<'resources'>> {
-    return API.path('managed')
-      .path('application', app)
-      .query({ entities: 'resources' })
-      .get()
-      .then(this.decorateResources);
+    return API.path('managed', 'application', app).query({ entities: 'resources' }).get().then(this.decorateResources);
   }
 
   public static getEnvironmentsSummary(app: string): PromiseLike<IManagedApplicationSummary> {
-    return API.path('managed')
-      .path('application', app)
+    return API.path('managed', 'application', app)
       .query({ entities: ['resources', 'artifacts', 'environments'], maxArtifactVersions: 30 })
       .get()
       .then(this.decorateResources);

--- a/app/scripts/modules/core/src/managed/ManagedWriter.ts
+++ b/app/scripts/modules/core/src/managed/ManagedWriter.ts
@@ -32,7 +32,7 @@ export class ManagedWriter {
     version,
     comment,
   }: IArtifactVersionRequest): PromiseLike<void> {
-    return API.path('managed').path('application', application).path('pin').post({
+    return API.path('managed', 'application', application, 'pin').post({
       targetEnvironment: environment,
       reference,
       version,
@@ -45,12 +45,7 @@ export class ManagedWriter {
     environment,
     reference,
   }: IUnpinArtifactVersionRequest): PromiseLike<void> {
-    return API.path('managed')
-      .path('application', application)
-      .path('pin')
-      .path(environment)
-      .query({ reference })
-      .delete();
+    return API.path('managed', 'application', application, 'pin', environment).query({ reference }).delete();
   }
 
   public static markArtifactVersionAsBad({
@@ -60,7 +55,7 @@ export class ManagedWriter {
     version,
     comment,
   }: IArtifactVersionRequest): PromiseLike<void> {
-    return API.path('managed').path('application', application).path('veto').post({
+    return API.path('managed', 'application', application, 'veto').post({
       targetEnvironment: environment,
       reference,
       version,
@@ -76,31 +71,27 @@ export class ManagedWriter {
     version,
     status,
   }: IUpdateConstraintStatusRequest): PromiseLike<void> {
-    return API.path('managed')
-      .path('application', application)
-      .path('environment', environment)
-      .path('constraint')
-      .post({
-        type,
-        artifactReference: reference,
-        artifactVersion: version,
-        status,
-      });
+    return API.path('managed', 'application', application, 'environment', environment, 'constraint').post({
+      type,
+      artifactReference: reference,
+      artifactVersion: version,
+      status,
+    });
   }
 
   public static pauseApplicationManagement(applicationName: string): PromiseLike<void> {
-    return API.path('managed').path('application', applicationName).path('pause').post();
+    return API.path('managed', 'application', applicationName, 'pause').post();
   }
 
   public static resumeApplicationManagement(applicationName: string): PromiseLike<void> {
-    return API.path('managed').path('application', applicationName).path('pause').delete();
+    return API.path('managed', 'application', applicationName, 'pause').delete();
   }
 
   public static pauseResourceManagement(resourceId: string): PromiseLike<void> {
-    return API.path('managed').path('resources', resourceId).path('pause').post();
+    return API.path('managed', 'resources', resourceId, 'pause').post();
   }
 
   public static resumeResourceManagement(resourceId: string): PromiseLike<void> {
-    return API.path('managed').path('resources', resourceId).path('pause').delete();
+    return API.path('managed', 'resources', resourceId, 'pause').delete();
   }
 }

--- a/app/scripts/modules/core/src/managed/ManagedWriter.ts
+++ b/app/scripts/modules/core/src/managed/ManagedWriter.ts
@@ -1,5 +1,3 @@
-
-
 import { API } from 'core/api';
 import { StatefulConstraintStatus } from 'core/domain';
 
@@ -34,7 +32,7 @@ export class ManagedWriter {
     version,
     comment,
   }: IArtifactVersionRequest): PromiseLike<void> {
-    return API.one('managed').one('application', application).one('pin').post({
+    return API.path('managed').path('application', application).path('pin').post({
       targetEnvironment: environment,
       reference,
       version,
@@ -47,12 +45,12 @@ export class ManagedWriter {
     environment,
     reference,
   }: IUnpinArtifactVersionRequest): PromiseLike<void> {
-    return API.one('managed')
-      .one('application', application)
-      .one('pin')
-      .one(environment)
-      .withParams({ reference })
-      .remove();
+    return API.path('managed')
+      .path('application', application)
+      .path('pin')
+      .path(environment)
+      .query({ reference })
+      .delete();
   }
 
   public static markArtifactVersionAsBad({
@@ -62,7 +60,7 @@ export class ManagedWriter {
     version,
     comment,
   }: IArtifactVersionRequest): PromiseLike<void> {
-    return API.one('managed').one('application', application).one('veto').post({
+    return API.path('managed').path('application', application).path('veto').post({
       targetEnvironment: environment,
       reference,
       version,
@@ -78,27 +76,31 @@ export class ManagedWriter {
     version,
     status,
   }: IUpdateConstraintStatusRequest): PromiseLike<void> {
-    return API.one('managed').one('application', application).one('environment', environment).one('constraint').post({
-      type,
-      artifactReference: reference,
-      artifactVersion: version,
-      status,
-    });
+    return API.path('managed')
+      .path('application', application)
+      .path('environment', environment)
+      .path('constraint')
+      .post({
+        type,
+        artifactReference: reference,
+        artifactVersion: version,
+        status,
+      });
   }
 
   public static pauseApplicationManagement(applicationName: string): PromiseLike<void> {
-    return API.one('managed').one('application', applicationName).one('pause').post();
+    return API.path('managed').path('application', applicationName).path('pause').post();
   }
 
   public static resumeApplicationManagement(applicationName: string): PromiseLike<void> {
-    return API.one('managed').one('application', applicationName).one('pause').remove();
+    return API.path('managed').path('application', applicationName).path('pause').delete();
   }
 
   public static pauseResourceManagement(resourceId: string): PromiseLike<void> {
-    return API.one('managed').one('resources', resourceId).one('pause').post();
+    return API.path('managed').path('resources', resourceId).path('pause').post();
   }
 
   public static resumeResourceManagement(resourceId: string): PromiseLike<void> {
-    return API.one('managed').one('resources', resourceId).one('pause').remove();
+    return API.path('managed').path('resources', resourceId).path('pause').delete();
   }
 }

--- a/app/scripts/modules/core/src/managed/ManagedWriter.ts
+++ b/app/scripts/modules/core/src/managed/ManagedWriter.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { StatefulConstraintStatus } from 'core/domain';
 
 export interface IArtifactVersionRequest {
@@ -32,7 +32,7 @@ export class ManagedWriter {
     version,
     comment,
   }: IArtifactVersionRequest): PromiseLike<void> {
-    return API.path('managed', 'application', application, 'pin').post({
+    return REST().path('managed', 'application', application, 'pin').post({
       targetEnvironment: environment,
       reference,
       version,
@@ -45,7 +45,7 @@ export class ManagedWriter {
     environment,
     reference,
   }: IUnpinArtifactVersionRequest): PromiseLike<void> {
-    return API.path('managed', 'application', application, 'pin', environment).query({ reference }).delete();
+    return REST().path('managed', 'application', application, 'pin', environment).query({ reference }).delete();
   }
 
   public static markArtifactVersionAsBad({
@@ -55,7 +55,7 @@ export class ManagedWriter {
     version,
     comment,
   }: IArtifactVersionRequest): PromiseLike<void> {
-    return API.path('managed', 'application', application, 'veto').post({
+    return REST().path('managed', 'application', application, 'veto').post({
       targetEnvironment: environment,
       reference,
       version,
@@ -71,7 +71,7 @@ export class ManagedWriter {
     version,
     status,
   }: IUpdateConstraintStatusRequest): PromiseLike<void> {
-    return API.path('managed', 'application', application, 'environment', environment, 'constraint').post({
+    return REST().path('managed', 'application', application, 'environment', environment, 'constraint').post({
       type,
       artifactReference: reference,
       artifactVersion: version,
@@ -80,18 +80,18 @@ export class ManagedWriter {
   }
 
   public static pauseApplicationManagement(applicationName: string): PromiseLike<void> {
-    return API.path('managed', 'application', applicationName, 'pause').post();
+    return REST().path('managed', 'application', applicationName, 'pause').post();
   }
 
   public static resumeApplicationManagement(applicationName: string): PromiseLike<void> {
-    return API.path('managed', 'application', applicationName, 'pause').delete();
+    return REST().path('managed', 'application', applicationName, 'pause').delete();
   }
 
   public static pauseResourceManagement(resourceId: string): PromiseLike<void> {
-    return API.path('managed', 'resources', resourceId, 'pause').post();
+    return REST().path('managed', 'resources', resourceId, 'pause').post();
   }
 
   public static resumeResourceManagement(resourceId: string): PromiseLike<void> {
-    return API.path('managed', 'resources', resourceId, 'pause').delete();
+    return REST().path('managed', 'resources', resourceId, 'pause').delete();
   }
 }

--- a/app/scripts/modules/core/src/managed/ManagedWriter.ts
+++ b/app/scripts/modules/core/src/managed/ManagedWriter.ts
@@ -32,7 +32,7 @@ export class ManagedWriter {
     version,
     comment,
   }: IArtifactVersionRequest): PromiseLike<void> {
-    return REST().path('managed', 'application', application, 'pin').post({
+    return REST('/managed/application').path(application, 'pin').post({
       targetEnvironment: environment,
       reference,
       version,
@@ -45,7 +45,7 @@ export class ManagedWriter {
     environment,
     reference,
   }: IUnpinArtifactVersionRequest): PromiseLike<void> {
-    return REST().path('managed', 'application', application, 'pin', environment).query({ reference }).delete();
+    return REST('/managed/application').path(application, 'pin', environment).query({ reference }).delete();
   }
 
   public static markArtifactVersionAsBad({
@@ -55,7 +55,7 @@ export class ManagedWriter {
     version,
     comment,
   }: IArtifactVersionRequest): PromiseLike<void> {
-    return REST().path('managed', 'application', application, 'veto').post({
+    return REST('/managed/application').path(application, 'veto').post({
       targetEnvironment: environment,
       reference,
       version,
@@ -71,7 +71,7 @@ export class ManagedWriter {
     version,
     status,
   }: IUpdateConstraintStatusRequest): PromiseLike<void> {
-    return REST().path('managed', 'application', application, 'environment', environment, 'constraint').post({
+    return REST('/managed/application').path(application, 'environment', environment, 'constraint').post({
       type,
       artifactReference: reference,
       artifactVersion: version,
@@ -80,18 +80,18 @@ export class ManagedWriter {
   }
 
   public static pauseApplicationManagement(applicationName: string): PromiseLike<void> {
-    return REST().path('managed', 'application', applicationName, 'pause').post();
+    return REST('/managed/application').path(applicationName, 'pause').post();
   }
 
   public static resumeApplicationManagement(applicationName: string): PromiseLike<void> {
-    return REST().path('managed', 'application', applicationName, 'pause').delete();
+    return REST('/managed/application').path(applicationName, 'pause').delete();
   }
 
   public static pauseResourceManagement(resourceId: string): PromiseLike<void> {
-    return REST().path('managed', 'resources', resourceId, 'pause').post();
+    return REST('/managed/resources').path(resourceId, 'pause').post();
   }
 
   public static resumeResourceManagement(resourceId: string): PromiseLike<void> {
-    return REST().path('managed', 'resources', resourceId, 'pause').delete();
+    return REST('/managed/resources').path(resourceId, 'pause').delete();
   }
 }

--- a/app/scripts/modules/core/src/manifest/ManifestReader.ts
+++ b/app/scripts/modules/core/src/manifest/ManifestReader.ts
@@ -3,6 +3,6 @@ import { IManifest } from 'core/domain';
 
 export class ManifestReader {
   public static getManifest(account: string, location: string, name: string): PromiseLike<IManifest> {
-    return API.path('manifests').path(account).path(location).path(name).get();
+    return API.path('manifests', account, location, name).get();
   }
 }

--- a/app/scripts/modules/core/src/manifest/ManifestReader.ts
+++ b/app/scripts/modules/core/src/manifest/ManifestReader.ts
@@ -1,8 +1,8 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IManifest } from 'core/domain';
 
 export class ManifestReader {
   public static getManifest(account: string, location: string, name: string): PromiseLike<IManifest> {
-    return API.path('manifests', account, location, name).get();
+    return REST().path('manifests', account, location, name).get();
   }
 }

--- a/app/scripts/modules/core/src/manifest/ManifestReader.ts
+++ b/app/scripts/modules/core/src/manifest/ManifestReader.ts
@@ -3,6 +3,6 @@ import { IManifest } from 'core/domain';
 
 export class ManifestReader {
   public static getManifest(account: string, location: string, name: string): PromiseLike<IManifest> {
-    return REST().path('manifests', account, location, name).get();
+    return REST('/manifests').path(account, location, name).get();
   }
 }

--- a/app/scripts/modules/core/src/manifest/ManifestReader.ts
+++ b/app/scripts/modules/core/src/manifest/ManifestReader.ts
@@ -1,9 +1,8 @@
-
 import { API } from 'core/api/ApiService';
 import { IManifest } from 'core/domain';
 
 export class ManifestReader {
   public static getManifest(account: string, location: string, name: string): PromiseLike<IManifest> {
-    return API.all('manifests').all(account).all(location).one(name).get();
+    return API.path('manifests').path(account).path(location).path(name).get();
   }
 }

--- a/app/scripts/modules/core/src/network/NetworkReader.ts
+++ b/app/scripts/modules/core/src/network/NetworkReader.ts
@@ -11,10 +11,10 @@ export interface INetwork {
 
 export class NetworkReader {
   public static listNetworks(): PromiseLike<INetwork[]> {
-    return API.one('networks').getList();
+    return API.path('networks').get();
   }
 
   public static listNetworksByProvider(cloudProvider: string) {
-    return API.one('networks').one(cloudProvider).getList();
+    return API.path('networks').path(cloudProvider).get();
   }
 }

--- a/app/scripts/modules/core/src/network/NetworkReader.ts
+++ b/app/scripts/modules/core/src/network/NetworkReader.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export interface INetwork {
   cloudProvider: string;
@@ -11,10 +11,10 @@ export interface INetwork {
 
 export class NetworkReader {
   public static listNetworks(): PromiseLike<INetwork[]> {
-    return API.path('networks').get();
+    return REST().path('networks').get();
   }
 
   public static listNetworksByProvider(cloudProvider: string) {
-    return API.path('networks', cloudProvider).get();
+    return REST().path('networks', cloudProvider).get();
   }
 }

--- a/app/scripts/modules/core/src/network/NetworkReader.ts
+++ b/app/scripts/modules/core/src/network/NetworkReader.ts
@@ -15,6 +15,6 @@ export class NetworkReader {
   }
 
   public static listNetworksByProvider(cloudProvider: string) {
-    return API.path('networks').path(cloudProvider).get();
+    return API.path('networks', cloudProvider).get();
   }
 }

--- a/app/scripts/modules/core/src/network/NetworkReader.ts
+++ b/app/scripts/modules/core/src/network/NetworkReader.ts
@@ -11,10 +11,10 @@ export interface INetwork {
 
 export class NetworkReader {
   public static listNetworks(): PromiseLike<INetwork[]> {
-    return REST().path('networks').get();
+    return REST('/networks').get();
   }
 
   public static listNetworksByProvider(cloudProvider: string) {
-    return REST().path('networks', cloudProvider).get();
+    return REST('/networks').path(cloudProvider).get();
   }
 }

--- a/app/scripts/modules/core/src/notification/AppNotificationsService.ts
+++ b/app/scripts/modules/core/src/notification/AppNotificationsService.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { INotification } from 'core/domain';
 
 export interface IAppNotifications {
@@ -8,13 +8,13 @@ export interface IAppNotifications {
 
 export class AppNotificationsService {
   public static getNotificationsForApplication(applicationName: string): PromiseLike<IAppNotifications> {
-    return API.path('notifications', 'application', applicationName).get();
+    return REST().path('notifications', 'application', applicationName).get();
   }
 
   public static saveNotificationsForApplication(
     applicationName: string,
     notifications: IAppNotifications,
   ): PromiseLike<void> {
-    return API.path('notifications', 'application', applicationName).post(notifications);
+    return REST().path('notifications', 'application', applicationName).post(notifications);
   }
 }

--- a/app/scripts/modules/core/src/notification/AppNotificationsService.ts
+++ b/app/scripts/modules/core/src/notification/AppNotificationsService.ts
@@ -15,6 +15,6 @@ export class AppNotificationsService {
     applicationName: string,
     notifications: IAppNotifications,
   ): PromiseLike<void> {
-    return API.path('notifications').path('application', applicationName).data(notifications).post();
+    return API.path('notifications').path('application', applicationName).post(notifications);
   }
 }

--- a/app/scripts/modules/core/src/notification/AppNotificationsService.ts
+++ b/app/scripts/modules/core/src/notification/AppNotificationsService.ts
@@ -1,5 +1,3 @@
-
-
 import { API } from 'core/api/ApiService';
 import { INotification } from 'core/domain';
 
@@ -10,13 +8,13 @@ export interface IAppNotifications {
 
 export class AppNotificationsService {
   public static getNotificationsForApplication(applicationName: string): PromiseLike<IAppNotifications> {
-    return API.one('notifications').one('application', applicationName).get();
+    return API.path('notifications').path('application', applicationName).get();
   }
 
   public static saveNotificationsForApplication(
     applicationName: string,
     notifications: IAppNotifications,
   ): PromiseLike<void> {
-    return API.one('notifications').one('application', applicationName).data(notifications).post();
+    return API.path('notifications').path('application', applicationName).data(notifications).post();
   }
 }

--- a/app/scripts/modules/core/src/notification/AppNotificationsService.ts
+++ b/app/scripts/modules/core/src/notification/AppNotificationsService.ts
@@ -8,13 +8,13 @@ export interface IAppNotifications {
 
 export class AppNotificationsService {
   public static getNotificationsForApplication(applicationName: string): PromiseLike<IAppNotifications> {
-    return REST().path('notifications', 'application', applicationName).get();
+    return REST('/notifications/application').path(applicationName).get();
   }
 
   public static saveNotificationsForApplication(
     applicationName: string,
     notifications: IAppNotifications,
   ): PromiseLike<void> {
-    return REST().path('notifications', 'application', applicationName).post(notifications);
+    return REST('/notifications/application').path(applicationName).post(notifications);
   }
 }

--- a/app/scripts/modules/core/src/notification/AppNotificationsService.ts
+++ b/app/scripts/modules/core/src/notification/AppNotificationsService.ts
@@ -8,13 +8,13 @@ export interface IAppNotifications {
 
 export class AppNotificationsService {
   public static getNotificationsForApplication(applicationName: string): PromiseLike<IAppNotifications> {
-    return API.path('notifications').path('application', applicationName).get();
+    return API.path('notifications', 'application', applicationName).get();
   }
 
   public static saveNotificationsForApplication(
     applicationName: string,
     notifications: IAppNotifications,
   ): PromiseLike<void> {
-    return API.path('notifications').path('application', applicationName).post(notifications);
+    return API.path('notifications', 'application', applicationName).post(notifications);
   }
 }

--- a/app/scripts/modules/core/src/notification/NotificationService.ts
+++ b/app/scripts/modules/core/src/notification/NotificationService.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export interface INotificationParameter {
   name: string;
@@ -16,6 +16,6 @@ export interface INotificationTypeMetadata {
 
 export class NotificationService {
   public static getNotificationTypeMetadata(): PromiseLike<INotificationTypeMetadata[]> {
-    return API.path('notifications', 'metadata').useCache().get();
+    return REST().path('notifications', 'metadata').useCache().get();
   }
 }

--- a/app/scripts/modules/core/src/notification/NotificationService.ts
+++ b/app/scripts/modules/core/src/notification/NotificationService.ts
@@ -16,6 +16,6 @@ export interface INotificationTypeMetadata {
 
 export class NotificationService {
   public static getNotificationTypeMetadata(): PromiseLike<INotificationTypeMetadata[]> {
-    return API.one('notifications').all('metadata').useCache().getList();
+    return API.path('notifications').path('metadata').useCache().get();
   }
 }

--- a/app/scripts/modules/core/src/notification/NotificationService.ts
+++ b/app/scripts/modules/core/src/notification/NotificationService.ts
@@ -16,6 +16,6 @@ export interface INotificationTypeMetadata {
 
 export class NotificationService {
   public static getNotificationTypeMetadata(): PromiseLike<INotificationTypeMetadata[]> {
-    return REST().path('notifications', 'metadata').useCache().get();
+    return REST('/notifications/metadata').useCache().get();
   }
 }

--- a/app/scripts/modules/core/src/notification/NotificationService.ts
+++ b/app/scripts/modules/core/src/notification/NotificationService.ts
@@ -16,6 +16,6 @@ export interface INotificationTypeMetadata {
 
 export class NotificationService {
   public static getNotificationTypeMetadata(): PromiseLike<INotificationTypeMetadata[]> {
-    return API.path('notifications').path('metadata').useCache().get();
+    return API.path('notifications', 'metadata').useCache().get();
   }
 }

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
@@ -24,10 +24,10 @@ export interface IOnCall {
 
 export class PagerDutyReader {
   public static listServices(): Observable<IPagerDutyService[]> {
-    return Observable.fromPromise(API.one('pagerDuty', 'services').getList());
+    return Observable.fromPromise(API.path('pagerDuty', 'services').get());
   }
 
   public static listOnCalls(): Observable<{ [id: string]: IOnCall[] }> {
-    return Observable.fromPromise(API.one('pagerDuty', 'oncalls').getList());
+    return Observable.fromPromise(API.path('pagerDuty', 'oncalls').get());
   }
 }

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export interface IPagerDutyService {
   id: string;
@@ -24,10 +24,10 @@ export interface IOnCall {
 
 export class PagerDutyReader {
   public static listServices(): Observable<IPagerDutyService[]> {
-    return Observable.fromPromise(API.path('pagerDuty', 'services').get());
+    return Observable.fromPromise(REST().path('pagerDuty', 'services').get());
   }
 
   public static listOnCalls(): Observable<{ [id: string]: IOnCall[] }> {
-    return Observable.fromPromise(API.path('pagerDuty', 'oncalls').get());
+    return Observable.fromPromise(REST().path('pagerDuty', 'oncalls').get());
   }
 }

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
@@ -24,10 +24,10 @@ export interface IOnCall {
 
 export class PagerDutyReader {
   public static listServices(): Observable<IPagerDutyService[]> {
-    return Observable.fromPromise(REST().path('pagerDuty', 'services').get());
+    return Observable.fromPromise(REST('/pagerDuty/services').get());
   }
 
   public static listOnCalls(): Observable<{ [id: string]: IOnCall[] }> {
-    return Observable.fromPromise(REST().path('pagerDuty', 'oncalls').get());
+    return Observable.fromPromise(REST('/pagerDuty/oncalls').get());
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/copyStage/CopyStageModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/copyStage/CopyStageModal.tsx
@@ -45,8 +45,8 @@ export function CopyStageModal(props: ICopyStageModalProps) {
   function getStagesForApplication(applicationName: string): PromiseLike<ICopyStageCardProps[]> {
     const configType = forStrategyConfig ? 'strategyConfigs' : 'pipelineConfigs';
 
-    return REST()
-      .path('applications', applicationName, configType)
+    return REST('/applications')
+      .path(applicationName, configType)
       .get()
       .then((configs: Array<IPipeline | IStrategy>) => {
         const nestedStageWrappers = configs.map((config) => {

--- a/app/scripts/modules/core/src/pipeline/config/copyStage/CopyStageModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/copyStage/CopyStageModal.tsx
@@ -4,7 +4,7 @@ import { Form } from 'formik';
 import { flatten, isEmpty } from 'lodash';
 import { Option } from 'react-select';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { Application } from 'core/application';
 import { ApplicationReader } from 'core/application/service/ApplicationReader';
 import { ModalClose } from 'core/modal';
@@ -45,7 +45,8 @@ export function CopyStageModal(props: ICopyStageModalProps) {
   function getStagesForApplication(applicationName: string): PromiseLike<ICopyStageCardProps[]> {
     const configType = forStrategyConfig ? 'strategyConfigs' : 'pipelineConfigs';
 
-    return API.path('applications', applicationName, configType)
+    return REST()
+      .path('applications', applicationName, configType)
       .get()
       .then((configs: Array<IPipeline | IStrategy>) => {
         const nestedStageWrappers = configs.map((config) => {

--- a/app/scripts/modules/core/src/pipeline/config/copyStage/CopyStageModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/copyStage/CopyStageModal.tsx
@@ -45,9 +45,7 @@ export function CopyStageModal(props: ICopyStageModalProps) {
   function getStagesForApplication(applicationName: string): PromiseLike<ICopyStageCardProps[]> {
     const configType = forStrategyConfig ? 'strategyConfigs' : 'pipelineConfigs';
 
-    return API.path('applications')
-      .path(applicationName)
-      .path(configType)
+    return API.path('applications', applicationName, configType)
       .get()
       .then((configs: Array<IPipeline | IStrategy>) => {
         const nestedStageWrappers = configs.map((config) => {

--- a/app/scripts/modules/core/src/pipeline/config/copyStage/CopyStageModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/copyStage/CopyStageModal.tsx
@@ -45,10 +45,10 @@ export function CopyStageModal(props: ICopyStageModalProps) {
   function getStagesForApplication(applicationName: string): PromiseLike<ICopyStageCardProps[]> {
     const configType = forStrategyConfig ? 'strategyConfigs' : 'pipelineConfigs';
 
-    return API.one('applications')
-      .one(applicationName)
-      .all(configType)
-      .getList()
+    return API.path('applications')
+      .path(applicationName)
+      .path(configType)
+      .get()
       .then((configs: Array<IPipeline | IStrategy>) => {
         const nestedStageWrappers = configs.map((config) => {
           return (config.stages || [])

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -68,9 +68,7 @@ export class PipelineConfigService {
       pipeline = PipelineTemplateV2Service.filterInheritedConfig(pipeline) as IPipeline;
     }
 
-    return API.path(pipeline.strategy ? 'strategies' : 'pipelines')
-      .data(pipeline)
-      .post();
+    return API.path(pipeline.strategy ? 'strategies' : 'pipelines').post(pipeline);
   }
 
   public static reorderPipelines(
@@ -79,12 +77,10 @@ export class PipelineConfigService {
     isStrategy = false,
   ): PromiseLike<void> {
     const type = isStrategy ? 'strategies' : 'pipelines';
-    return API.path('actions', type, 'reorder')
-      .data({
-        application,
-        idsToIndices,
-      })
-      .post();
+    return API.path('actions', type, 'reorder').post({
+      application,
+      idsToIndices,
+    });
   }
 
   public static renamePipeline(
@@ -97,8 +93,7 @@ export class PipelineConfigService {
     pipeline.name = newName.trim();
     return API.path(pipeline.strategy ? 'strategies' : 'pipelines')
       .path(pipeline.id)
-      .data(pipeline)
-      .put();
+      .put(pipeline);
   }
 
   public static triggerPipeline(applicationName: string, pipelineName: string, body: any = {}): PromiseLike<string> {
@@ -107,8 +102,7 @@ export class PipelineConfigService {
       .path('v2')
       .path(applicationName)
       .path(encodeURIComponent(pipelineName))
-      .data(body)
-      .post()
+      .post(body)
       .then((result: ITriggerPipelineResponse) => {
         return result.ref.split('/').pop();
       });

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -41,13 +41,12 @@ export class PipelineConfigService {
 
   public static getHistory(id: string, isStrategy: boolean, count = 20): PromiseLike<IPipeline[]> {
     const endpoint = isStrategy ? 'strategyConfigs' : 'pipelineConfigs';
-    return REST().path(endpoint, id, 'history').query({ limit: count }).get();
+    return REST(endpoint).path(id, 'history').query({ limit: count }).get();
   }
 
   public static deletePipeline(applicationName: string, pipeline: IPipeline, pipelineName: string): PromiseLike<void> {
-    return REST()
-      .path(pipeline.strategy ? 'strategies' : 'pipelines', applicationName, encodeURIComponent(pipelineName.trim()))
-      .delete();
+    const endpoint = pipeline.strategy ? 'strategies' : 'pipelines';
+    return REST(endpoint).path(applicationName, encodeURIComponent(pipelineName.trim())).delete();
   }
 
   public static savePipeline(toSave: IPipeline): PromiseLike<void> {
@@ -66,9 +65,8 @@ export class PipelineConfigService {
       pipeline = PipelineTemplateV2Service.filterInheritedConfig(pipeline) as IPipeline;
     }
 
-    return REST()
-      .path(pipeline.strategy ? 'strategies' : 'pipelines')
-      .post(pipeline);
+    const endpoint = pipeline.strategy ? 'strategies' : 'pipelines';
+    return REST(endpoint).post(pipeline);
   }
 
   public static reorderPipelines(
@@ -91,9 +89,8 @@ export class PipelineConfigService {
   ): PromiseLike<void> {
     this.configViewStateCache.remove(this.buildViewStateCacheKey(applicationName, currentName));
     pipeline.name = newName.trim();
-    return REST()
-      .path(pipeline.strategy ? 'strategies' : 'pipelines', pipeline.id)
-      .put(pipeline);
+    const endpoint = pipeline.strategy ? 'strategies' : 'pipelines';
+    return REST(endpoint).path(pipeline.id).put(pipeline);
   }
 
   public static triggerPipeline(applicationName: string, pipelineName: string, body: any = {}): PromiseLike<string> {

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -20,8 +20,8 @@ export class PipelineConfigService {
   }
 
   public static getPipelinesForApplication(applicationName: string): PromiseLike<IPipeline[]> {
-    return REST()
-      .path('applications', applicationName, 'pipelineConfigs')
+    return REST('/applications')
+      .path(applicationName, 'pipelineConfigs')
       .get()
       .then((pipelines: IPipeline[]) => {
         pipelines.forEach((p) => (p.stages = p.stages || []));
@@ -30,8 +30,8 @@ export class PipelineConfigService {
   }
 
   public static getStrategiesForApplication(applicationName: string): PromiseLike<IPipeline[]> {
-    return REST()
-      .path('applications', applicationName, 'strategyConfigs')
+    return REST('/applications')
+      .path(applicationName, 'strategyConfigs')
       .get()
       .then((pipelines: IPipeline[]) => {
         pipelines.forEach((p) => (p.stages = p.stages || []));
@@ -77,7 +77,7 @@ export class PipelineConfigService {
     isStrategy = false,
   ): PromiseLike<void> {
     const type = isStrategy ? 'strategies' : 'pipelines';
-    return REST().path('actions', type, 'reorder').post({
+    return REST('/actions').path(type, 'reorder').post({
       application,
       idsToIndices,
     });
@@ -98,8 +98,8 @@ export class PipelineConfigService {
 
   public static triggerPipeline(applicationName: string, pipelineName: string, body: any = {}): PromiseLike<string> {
     body.user = AuthenticationService.getAuthenticatedUser().name;
-    return REST()
-      .path('pipelines', 'v2', applicationName, encodeURIComponent(pipelineName))
+    return REST('/pipelines/v2')
+      .path(applicationName, encodeURIComponent(pipelineName))
       .post(body)
       .then((result: ITriggerPipelineResponse) => {
         return result.ref.split('/').pop();

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -20,9 +20,7 @@ export class PipelineConfigService {
   }
 
   public static getPipelinesForApplication(applicationName: string): PromiseLike<IPipeline[]> {
-    return API.path('applications')
-      .path(applicationName)
-      .path('pipelineConfigs')
+    return API.path('applications', applicationName, 'pipelineConfigs')
       .get()
       .then((pipelines: IPipeline[]) => {
         pipelines.forEach((p) => (p.stages = p.stages || []));
@@ -31,9 +29,7 @@ export class PipelineConfigService {
   }
 
   public static getStrategiesForApplication(applicationName: string): PromiseLike<IPipeline[]> {
-    return API.path('applications')
-      .path(applicationName)
-      .path('strategyConfigs')
+    return API.path('applications', applicationName, 'strategyConfigs')
       .get()
       .then((pipelines: IPipeline[]) => {
         pipelines.forEach((p) => (p.stages = p.stages || []));
@@ -43,13 +39,15 @@ export class PipelineConfigService {
 
   public static getHistory(id: string, isStrategy: boolean, count = 20): PromiseLike<IPipeline[]> {
     const endpoint = isStrategy ? 'strategyConfigs' : 'pipelineConfigs';
-    return API.path(endpoint, id).path('history').query({ limit: count }).get();
+    return API.path(endpoint, id, 'history').query({ limit: count }).get();
   }
 
   public static deletePipeline(applicationName: string, pipeline: IPipeline, pipelineName: string): PromiseLike<void> {
-    return API.path(pipeline.strategy ? 'strategies' : 'pipelines')
-      .path(applicationName, encodeURIComponent(pipelineName.trim()))
-      .delete();
+    return API.path(
+      pipeline.strategy ? 'strategies' : 'pipelines',
+      applicationName,
+      encodeURIComponent(pipelineName.trim()),
+    ).delete();
   }
 
   public static savePipeline(toSave: IPipeline): PromiseLike<void> {
@@ -91,17 +89,12 @@ export class PipelineConfigService {
   ): PromiseLike<void> {
     this.configViewStateCache.remove(this.buildViewStateCacheKey(applicationName, currentName));
     pipeline.name = newName.trim();
-    return API.path(pipeline.strategy ? 'strategies' : 'pipelines')
-      .path(pipeline.id)
-      .put(pipeline);
+    return API.path(pipeline.strategy ? 'strategies' : 'pipelines', pipeline.id).put(pipeline);
   }
 
   public static triggerPipeline(applicationName: string, pipelineName: string, body: any = {}): PromiseLike<string> {
     body.user = AuthenticationService.getAuthenticatedUser().name;
-    return API.path('pipelines')
-      .path('v2')
-      .path(applicationName)
-      .path(encodeURIComponent(pipelineName))
+    return API.path('pipelines', 'v2', applicationName, encodeURIComponent(pipelineName))
       .post(body)
       .then((result: ITriggerPipelineResponse) => {
         return result.ref.split('/').pop();

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/BakeryReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/BakeryReader.ts
@@ -3,7 +3,7 @@ import { get, has } from 'lodash';
 import { $q } from 'ngimport';
 
 import { AccountService } from 'core/account/AccountService';
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { SETTINGS } from 'core/config/settings';
 
 export interface IBaseImage {
@@ -36,7 +36,7 @@ export class BakeryReader {
   }
 
   private static getAllBaseOsOptions(): PromiseLike<IBaseOsOptions[]> {
-    return API.path('bakery', 'options').useCache().get();
+    return REST().path('bakery', 'options').useCache().get();
   }
 
   public static getBaseLabelOptions(): PromiseLike<string[]> {

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/BakeryReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/BakeryReader.ts
@@ -36,7 +36,7 @@ export class BakeryReader {
   }
 
   private static getAllBaseOsOptions(): PromiseLike<IBaseOsOptions[]> {
-    return API.one('bakery', 'options').useCache().getList();
+    return API.path('bakery', 'options').useCache().get();
   }
 
   public static getBaseLabelOptions(): PromiseLike<string[]> {

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/BakeryReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/BakeryReader.ts
@@ -36,7 +36,7 @@ export class BakeryReader {
   }
 
   private static getAllBaseOsOptions(): PromiseLike<IBaseOsOptions[]> {
-    return REST().path('bakery', 'options').useCache().get();
+    return REST('/bakery/options').useCache().get();
   }
 
   public static getBaseLabelOptions(): PromiseLike<string[]> {

--- a/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
@@ -43,8 +43,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
 
   private fetchCommands = (apiKey: string) => {
     return Observable.fromPromise(
-      REST()
-        .path('integrations', 'gremlin', 'templates', 'command')
+      REST('/integrations/gremlin/templates/command')
         .post({
           apiKey,
         })
@@ -62,8 +61,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
 
   private fetchTargets = (apiKey: string) => {
     return Observable.fromPromise(
-      REST()
-        .path('integrations', 'gremlin', 'templates', 'target')
+      REST('/integrations/gremlin/templates/target')
         .post({
           apiKey,
         })

--- a/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IStageConfigProps, StageConfigField } from '../common';
 import { Observable } from 'rxjs';
 import Select from 'react-select';
@@ -43,7 +43,8 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
 
   private fetchCommands = (apiKey: string) => {
     return Observable.fromPromise(
-      API.path('integrations', 'gremlin', 'templates', 'command')
+      REST()
+        .path('integrations', 'gremlin', 'templates', 'command')
         .post({
           apiKey,
         })
@@ -61,7 +62,8 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
 
   private fetchTargets = (apiKey: string) => {
     return Observable.fromPromise(
-      API.path('integrations', 'gremlin', 'templates', 'target')
+      REST()
+        .path('integrations', 'gremlin', 'templates', 'target')
         .post({
           apiKey,
         })

--- a/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
@@ -43,7 +43,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
 
   private fetchCommands = (apiKey: string) => {
     return Observable.fromPromise(
-      API.one('integrations', 'gremlin', 'templates', 'command')
+      API.path('integrations', 'gremlin', 'templates', 'command')
         .post({
           apiKey,
         })
@@ -61,7 +61,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
 
   private fetchTargets = (apiKey: string) => {
     return Observable.fromPromise(
-      API.one('integrations', 'gremlin', 'templates', 'target')
+      API.path('integrations', 'gremlin', 'templates', 'target')
         .post({
           apiKey,
         })

--- a/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorReader.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api';
+import { REST } from 'core/api';
 
 export interface IDeploymentMonitorDefinition {
   id: string;
@@ -8,6 +8,6 @@ export interface IDeploymentMonitorDefinition {
 
 export class DeploymentMonitorReader {
   public static getDeploymentMonitors(): PromiseLike<IDeploymentMonitorDefinition[]> {
-    return API.path('capabilities', 'deploymentMonitors').useCache(true).get();
+    return REST().path('capabilities', 'deploymentMonitors').useCache(true).get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorReader.ts
@@ -1,5 +1,3 @@
-
-
 import { API } from 'core/api';
 
 export interface IDeploymentMonitorDefinition {
@@ -10,6 +8,6 @@ export interface IDeploymentMonitorDefinition {
 
 export class DeploymentMonitorReader {
   public static getDeploymentMonitors(): PromiseLike<IDeploymentMonitorDefinition[]> {
-    return API.all('capabilities').all('deploymentMonitors').useCache(true).get();
+    return API.path('capabilities').path('deploymentMonitors').useCache(true).get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorReader.ts
@@ -8,6 +8,6 @@ export interface IDeploymentMonitorDefinition {
 
 export class DeploymentMonitorReader {
   public static getDeploymentMonitors(): PromiseLike<IDeploymentMonitorDefinition[]> {
-    return API.path('capabilities').path('deploymentMonitors').useCache(true).get();
+    return API.path('capabilities', 'deploymentMonitors').useCache(true).get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorReader.ts
@@ -8,6 +8,6 @@ export interface IDeploymentMonitorDefinition {
 
 export class DeploymentMonitorReader {
   public static getDeploymentMonitors(): PromiseLike<IDeploymentMonitorDefinition[]> {
-    return REST().path('capabilities', 'deploymentMonitors').useCache(true).get();
+    return REST('/capabilities/deploymentMonitors').useCache(true).get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJob.reader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJob.reader.ts
@@ -21,6 +21,6 @@ export interface IPreconfiguredJob {
 
 export const PreconfiguredJobReader = {
   list(): PromiseLike<IPreconfiguredJob[]> {
-    return API.path('jobs').path('preconfigured').useCache().get();
+    return API.path('jobs', 'preconfigured').useCache().get();
   },
 };

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJob.reader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJob.reader.ts
@@ -21,6 +21,6 @@ export interface IPreconfiguredJob {
 
 export const PreconfiguredJobReader = {
   list(): PromiseLike<IPreconfiguredJob[]> {
-    return REST().path('jobs', 'preconfigured').useCache().get();
+    return REST('/jobs/preconfigured').useCache().get();
   },
 };

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJob.reader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJob.reader.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api';
+import { REST } from 'core/api';
 
 export interface IPreconfiguredJobParameter {
   name: string;
@@ -21,6 +21,6 @@ export interface IPreconfiguredJob {
 
 export const PreconfiguredJobReader = {
   list(): PromiseLike<IPreconfiguredJob[]> {
-    return API.path('jobs', 'preconfigured').useCache().get();
+    return REST().path('jobs', 'preconfigured').useCache().get();
   },
 };

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJob.reader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJob.reader.ts
@@ -1,4 +1,3 @@
-
 import { API } from 'core/api';
 
 export interface IPreconfiguredJobParameter {
@@ -22,6 +21,6 @@ export interface IPreconfiguredJob {
 
 export const PreconfiguredJobReader = {
   list(): PromiseLike<IPreconfiguredJob[]> {
-    return API.one('jobs').all('preconfigured').useCache().getList();
+    return API.path('jobs').path('preconfigured').useCache().get();
   },
 };

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -342,10 +342,7 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
     '$stateParams',
     function ($scope, $stateParams) {
       const restartStage = function () {
-        return API.path('pipelines')
-          .path($stateParams.executionId)
-          .path('stages', $scope.stage.id)
-          .path('restart')
+        return API.path('pipelines', $stateParams.executionId, 'stages', $scope.stage.id, 'restart')
           .put({ skip: false })
           .then(function () {
             $scope.stage.isRestarting = true;

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -342,10 +342,10 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
     '$stateParams',
     function ($scope, $stateParams) {
       const restartStage = function () {
-        return API.one('pipelines')
-          .one($stateParams.executionId)
-          .one('stages', $scope.stage.id)
-          .one('restart')
+        return API.path('pipelines')
+          .path($stateParams.executionId)
+          .path('stages', $scope.stage.id)
+          .path('restart')
           .data({ skip: false })
           .put()
           .then(function () {

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -342,8 +342,8 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
     '$stateParams',
     function ($scope, $stateParams) {
       const restartStage = function () {
-        return REST()
-          .path('pipelines', $stateParams.executionId, 'stages', $scope.stage.id, 'restart')
+        return REST('/pipelines')
+          .path($stateParams.executionId, 'stages', $scope.stage.id, 'restart')
           .put({ skip: false })
           .then(function () {
             $scope.stage.isRestarting = true;

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -346,8 +346,7 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
           .path($stateParams.executionId)
           .path('stages', $scope.stage.id)
           .path('restart')
-          .data({ skip: false })
-          .put()
+          .put({ skip: false })
           .then(function () {
             $scope.stage.isRestarting = true;
           });

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -6,7 +6,7 @@ import ReactDOM from 'react-dom';
 import { defaultsDeep, extend, omit } from 'lodash';
 
 import { AccountService } from 'core/account/AccountService';
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { BASE_EXECUTION_DETAILS_CTRL } from './common/baseExecutionDetails.controller';
 import { ConfirmationModalService } from 'core/confirmationModal';
 import { STAGE_NAME } from './StageName';
@@ -342,7 +342,8 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
     '$stateParams',
     function ($scope, $stateParams) {
       const restartStage = function () {
-        return API.path('pipelines', $stateParams.executionId, 'stages', $scope.stage.id, 'restart')
+        return REST()
+          .path('pipelines', $stateParams.executionId, 'stages', $scope.stage.id, 'restart')
           .put({ skip: false })
           .then(function () {
             $scope.stage.isRestarting = true;

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -1,7 +1,7 @@
 import { IController, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { JsonUtils } from 'core/utils';
 import { Registry } from 'core/registry';
 
@@ -210,7 +210,8 @@ module(WEBHOOK_STAGE, [])
     });
   })
   .run(() => {
-    API.path('webhooks', 'preconfigured')
+    REST()
+      .path('webhooks', 'preconfigured')
       .get()
       .then((preconfiguredWebhooks: IPreconfiguredWebhook[]) => {
         preconfiguredWebhooks.forEach((preconfiguredWebhook: IPreconfiguredWebhook) =>

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -210,9 +210,9 @@ module(WEBHOOK_STAGE, [])
     });
   })
   .run(() => {
-    API.one('webhooks')
-      .all('preconfigured')
-      .getList()
+    API.path('webhooks')
+      .path('preconfigured')
+      .get()
       .then((preconfiguredWebhooks: IPreconfiguredWebhook[]) => {
         preconfiguredWebhooks.forEach((preconfiguredWebhook: IPreconfiguredWebhook) =>
           Registry.pipeline.registerStage({

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -210,8 +210,7 @@ module(WEBHOOK_STAGE, [])
     });
   })
   .run(() => {
-    REST()
-      .path('webhooks', 'preconfigured')
+    REST('/webhooks/preconfigured')
       .get()
       .then((preconfiguredWebhooks: IPreconfiguredWebhook[]) => {
         preconfiguredWebhooks.forEach((preconfiguredWebhook: IPreconfiguredWebhook) =>

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -210,8 +210,7 @@ module(WEBHOOK_STAGE, [])
     });
   })
   .run(() => {
-    API.path('webhooks')
-      .path('preconfigured')
+    API.path('webhooks', 'preconfigured')
       .get()
       .then((preconfiguredWebhooks: IPreconfiguredWebhook[]) => {
         preconfiguredWebhooks.forEach((preconfiguredWebhook: IPreconfiguredWebhook) =>

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
@@ -1,6 +1,6 @@
 import { $q } from 'ngimport';
 import { flatten } from 'lodash';
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IPipeline } from 'core/domain/IPipeline';
 import { IPipelineTemplateV2Collections } from 'core/domain/IPipelineTemplateV2';
 import { IPipelineTemplateConfigV2 } from 'core/domain';
@@ -83,7 +83,8 @@ export class PipelineTemplateReader {
     executionId?: string,
     pipelineConfigId?: string,
   ): PromiseLike<IPipelineTemplate> {
-    return API.path('pipelineTemplates', 'resolve')
+    return REST()
+      .path('pipelineTemplates', 'resolve')
       .query({ source, executionId, pipelineConfigId })
       .get()
       .then((template: IPipelineTemplate) => {
@@ -100,11 +101,13 @@ export class PipelineTemplateReader {
       ? ['v2', 'pipelineTemplates', 'plan']
       : ['pipelines', 'start'];
 
-    return API.path(...urls).post({ ...config, plan: true, executionId });
+    return REST()
+      .path(...urls)
+      .post({ ...config, plan: true, executionId });
   }
 
   public static getPipelineTemplatesByScope = (scope: string): PromiseLike<IPipelineTemplate[]> => {
-    return API.path('pipelineTemplates').query({ scope }).get();
+    return REST().path('pipelineTemplates').query({ scope }).get();
   };
 
   public static getPipelineTemplatesByScopes(scopes: string[]): PromiseLike<IPipelineTemplate[]> {
@@ -139,6 +142,6 @@ export class PipelineTemplateReader {
   }
 
   public static getV2PipelineTemplateList(): PromiseLike<IPipelineTemplateV2Collections> {
-    return API.path('v2', 'pipelineTemplates', 'versions').get();
+    return REST().path('v2', 'pipelineTemplates', 'versions').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
@@ -83,8 +83,7 @@ export class PipelineTemplateReader {
     executionId?: string,
     pipelineConfigId?: string,
   ): PromiseLike<IPipelineTemplate> {
-    return API.path('pipelineTemplates')
-      .path('resolve')
+    return API.path('pipelineTemplates', 'resolve')
       .query({ source, executionId, pipelineConfigId })
       .get()
       .then((template: IPipelineTemplate) => {

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
@@ -96,13 +96,10 @@ export class PipelineTemplateReader {
     config: IPipelineTemplateConfig | IPipelineTemplateConfigV2,
     executionId?: string,
   ): PromiseLike<IPipeline> {
-    const urls = PipelineTemplateV2Service.isV2PipelineConfig(config)
-      ? ['v2', 'pipelineTemplates', 'plan']
-      : ['pipelines', 'start'];
-
-    return REST()
-      .path(...urls)
-      .post({ ...config, plan: true, executionId });
+    const endpoint = PipelineTemplateV2Service.isV2PipelineConfig(config)
+      ? '/v2/pipelineTemplates/plan'
+      : '/pipelines/start';
+    return REST(endpoint).post({ ...config, plan: true, executionId });
   }
 
   public static getPipelineTemplatesByScope = (scope: string): PromiseLike<IPipelineTemplate[]> => {

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
@@ -1,4 +1,3 @@
-
 import { $q } from 'ngimport';
 import { flatten } from 'lodash';
 import { API } from 'core/api/ApiService';
@@ -84,9 +83,9 @@ export class PipelineTemplateReader {
     executionId?: string,
     pipelineConfigId?: string,
   ): PromiseLike<IPipelineTemplate> {
-    return API.one('pipelineTemplates')
-      .one('resolve')
-      .withParams({ source, executionId, pipelineConfigId })
+    return API.path('pipelineTemplates')
+      .path('resolve')
+      .query({ source, executionId, pipelineConfigId })
       .get()
       .then((template: IPipelineTemplate) => {
         template.selfLink = source;
@@ -102,11 +101,11 @@ export class PipelineTemplateReader {
       ? ['v2', 'pipelineTemplates', 'plan']
       : ['pipelines', 'start'];
 
-    return API.one(...urls).post({ ...config, plan: true, executionId });
+    return API.path(...urls).post({ ...config, plan: true, executionId });
   }
 
   public static getPipelineTemplatesByScope = (scope: string): PromiseLike<IPipelineTemplate[]> => {
-    return API.one('pipelineTemplates').withParams({ scope }).get();
+    return API.path('pipelineTemplates').query({ scope }).get();
   };
 
   public static getPipelineTemplatesByScopes(scopes: string[]): PromiseLike<IPipelineTemplate[]> {
@@ -141,6 +140,6 @@ export class PipelineTemplateReader {
   }
 
   public static getV2PipelineTemplateList(): PromiseLike<IPipelineTemplateV2Collections> {
-    return API.one('v2', 'pipelineTemplates', 'versions').get();
+    return API.path('v2', 'pipelineTemplates', 'versions').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
@@ -83,8 +83,7 @@ export class PipelineTemplateReader {
     executionId?: string,
     pipelineConfigId?: string,
   ): PromiseLike<IPipelineTemplate> {
-    return REST()
-      .path('pipelineTemplates', 'resolve')
+    return REST('/pipelineTemplates/resolve')
       .query({ source, executionId, pipelineConfigId })
       .get()
       .then((template: IPipelineTemplate) => {
@@ -107,7 +106,7 @@ export class PipelineTemplateReader {
   }
 
   public static getPipelineTemplatesByScope = (scope: string): PromiseLike<IPipelineTemplate[]> => {
-    return REST().path('pipelineTemplates').query({ scope }).get();
+    return REST('/pipelineTemplates').query({ scope }).get();
   };
 
   public static getPipelineTemplatesByScopes(scopes: string[]): PromiseLike<IPipelineTemplate[]> {
@@ -142,6 +141,6 @@ export class PipelineTemplateReader {
   }
 
   public static getV2PipelineTemplateList(): PromiseLike<IPipelineTemplateV2Collections> {
-    return REST().path('v2', 'pipelineTemplates', 'versions').get();
+    return REST('/v2/pipelineTemplates/versions').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
@@ -5,12 +5,12 @@ import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 export class PipelineTemplateWriter {
   public static savePipelineTemplateV2(template: IPipelineTemplateV2): PromiseLike<any> {
     return $q((resolve, reject) => {
-      REST().path('v2', 'pipelineTemplates', 'create').post(template).then(resolve, reject);
+      REST('/v2/pipelineTemplates/create').post(template).then(resolve, reject);
     });
   }
 
   public static deleteTemplate(template: { id: string; digest?: string; tag?: string }): PromiseLike<any> {
-    let request = REST().path('v2', 'pipelineTemplates', template.id);
+    let request = REST('/v2/pipelineTemplates').path(template.id);
 
     const params: { digest?: string; tag?: string } = {};
     if (template.digest) {

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
@@ -1,4 +1,3 @@
-
 import { $q } from 'ngimport';
 import { API } from 'core/api/ApiService';
 import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
@@ -6,12 +5,12 @@ import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 export class PipelineTemplateWriter {
   public static savePipelineTemplateV2(template: IPipelineTemplateV2): PromiseLike<any> {
     return $q((resolve, reject) => {
-      API.one('v2').one('pipelineTemplates').one('create').post(template).then(resolve, reject);
+      API.path('v2').path('pipelineTemplates').path('create').post(template).then(resolve, reject);
     });
   }
 
   public static deleteTemplate(template: { id: string; digest?: string; tag?: string }): PromiseLike<any> {
-    let request = API.one('v2').one('pipelineTemplates').one(template.id);
+    let request = API.path('v2').path('pipelineTemplates').path(template.id);
 
     const params: { digest?: string; tag?: string } = {};
     if (template.digest) {
@@ -20,7 +19,7 @@ export class PipelineTemplateWriter {
       params.tag = template.tag;
     }
 
-    request = request.withParams(params);
-    return request.remove();
+    request = request.query(params);
+    return request.delete();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
@@ -1,16 +1,16 @@
 import { $q } from 'ngimport';
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 
 export class PipelineTemplateWriter {
   public static savePipelineTemplateV2(template: IPipelineTemplateV2): PromiseLike<any> {
     return $q((resolve, reject) => {
-      API.path('v2', 'pipelineTemplates', 'create').post(template).then(resolve, reject);
+      REST().path('v2', 'pipelineTemplates', 'create').post(template).then(resolve, reject);
     });
   }
 
   public static deleteTemplate(template: { id: string; digest?: string; tag?: string }): PromiseLike<any> {
-    let request = API.path('v2', 'pipelineTemplates', template.id);
+    let request = REST().path('v2', 'pipelineTemplates', template.id);
 
     const params: { digest?: string; tag?: string } = {};
     if (template.digest) {

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
@@ -5,12 +5,12 @@ import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 export class PipelineTemplateWriter {
   public static savePipelineTemplateV2(template: IPipelineTemplateV2): PromiseLike<any> {
     return $q((resolve, reject) => {
-      API.path('v2').path('pipelineTemplates').path('create').post(template).then(resolve, reject);
+      API.path('v2', 'pipelineTemplates', 'create').post(template).then(resolve, reject);
     });
   }
 
   public static deleteTemplate(template: { id: string; digest?: string; tag?: string }): PromiseLike<any> {
-    let request = API.path('v2').path('pipelineTemplates').path(template.id);
+    let request = API.path('v2', 'pipelineTemplates', template.id);
 
     const params: { digest?: string; tag?: string } = {};
     if (template.digest) {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifactory/artifactoryReader.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifactory/artifactoryReader.service.ts
@@ -1,7 +1,7 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export class ArtifactoryReaderService {
   public static getArtifactoryNames(): PromiseLike<string[]> {
-    return API.path('artifactory', 'names').get();
+    return REST().path('artifactory', 'names').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifactory/artifactoryReader.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifactory/artifactoryReader.service.ts
@@ -2,6 +2,6 @@ import { REST } from 'core/api/ApiService';
 
 export class ArtifactoryReaderService {
   public static getArtifactoryNames(): PromiseLike<string[]> {
-    return REST().path('artifactory', 'names').get();
+    return REST('/artifactory/names').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifactory/artifactoryReader.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifactory/artifactoryReader.service.ts
@@ -2,6 +2,6 @@ import { API } from 'core/api/ApiService';
 
 export class ArtifactoryReaderService {
   public static getArtifactoryNames(): PromiseLike<string[]> {
-    return API.path('artifactory').path('names').get();
+    return API.path('artifactory', 'names').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifactory/artifactoryReader.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifactory/artifactoryReader.service.ts
@@ -2,6 +2,6 @@ import { API } from 'core/api/ApiService';
 
 export class ArtifactoryReaderService {
   public static getArtifactoryNames(): PromiseLike<string[]> {
-    return API.one('artifactory').one('names').get();
+    return API.path('artifactory').path('names').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
@@ -2,12 +2,12 @@ import { REST } from 'core/api/ApiService';
 
 export class ArtifactService {
   public static getArtifactNames(type: string, accountName: string): PromiseLike<string[]> {
-    return REST().path('artifacts', 'account', accountName, 'names').query({ type: type }).get();
+    return REST('/artifacts/account').path(accountName, 'names').query({ type: type }).get();
   }
 
   public static getArtifactVersions(type: string, accountName: string, artifactName: string): PromiseLike<string[]> {
-    return REST()
-      .path('artifacts', 'account', accountName, 'versions')
+    return REST('/artifacts/account')
+      .path(accountName, 'versions')
       .query({ type: type, artifactName: artifactName })
       .get();
   }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
@@ -1,12 +1,13 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export class ArtifactService {
   public static getArtifactNames(type: string, accountName: string): PromiseLike<string[]> {
-    return API.path('artifacts', 'account', accountName, 'names').query({ type: type }).get();
+    return REST().path('artifacts', 'account', accountName, 'names').query({ type: type }).get();
   }
 
   public static getArtifactVersions(type: string, accountName: string, artifactName: string): PromiseLike<string[]> {
-    return API.path('artifacts', 'account', accountName, 'versions')
+    return REST()
+      .path('artifacts', 'account', accountName, 'versions')
       .query({ type: type, artifactName: artifactName })
       .get();
   }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
@@ -2,14 +2,11 @@ import { API } from 'core/api/ApiService';
 
 export class ArtifactService {
   public static getArtifactNames(type: string, accountName: string): PromiseLike<string[]> {
-    return API.path('artifacts').path('account').path(accountName).path('names').query({ type: type }).get();
+    return API.path('artifacts', 'account', accountName, 'names').query({ type: type }).get();
   }
 
   public static getArtifactVersions(type: string, accountName: string, artifactName: string): PromiseLike<string[]> {
-    return API.path('artifacts')
-      .path('account')
-      .path(accountName)
-      .path('versions')
+    return API.path('artifacts', 'account', accountName, 'versions')
       .query({ type: type, artifactName: artifactName })
       .get();
   }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
@@ -1,17 +1,16 @@
 import { API } from 'core/api/ApiService';
 
-
 export class ArtifactService {
   public static getArtifactNames(type: string, accountName: string): PromiseLike<string[]> {
-    return API.one('artifacts').one('account').one(accountName).one('names').withParams({ type: type }).get();
+    return API.path('artifacts').path('account').path(accountName).path('names').query({ type: type }).get();
   }
 
   public static getArtifactVersions(type: string, accountName: string, artifactName: string): PromiseLike<string[]> {
-    return API.one('artifacts')
-      .one('account')
-      .one(accountName)
-      .one('versions')
-      .withParams({ type: type, artifactName: artifactName })
+    return API.path('artifacts')
+      .path('account')
+      .path(accountName)
+      .path('versions')
+      .query({ type: type, artifactName: artifactName })
       .get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/concourse/concourse.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/concourse/concourse.service.ts
@@ -1,19 +1,19 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export class ConcourseService {
   public static listTeamsForMaster(master: string): PromiseLike<string[]> {
-    return API.path('concourse', master, 'teams').get();
+    return REST().path('concourse', master, 'teams').get();
   }
 
   public static listPipelinesForTeam(master: string, team: string): PromiseLike<string[]> {
-    return API.path('concourse', master, 'teams', team, 'pipelines').get();
+    return REST().path('concourse', master, 'teams', team, 'pipelines').get();
   }
 
   public static listJobsForPipeline(master: string, team: string, pipeline: string): PromiseLike<string[]> {
-    return API.path('concourse', master, 'teams', team, 'pipelines', pipeline, 'jobs').get();
+    return REST().path('concourse', master, 'teams', team, 'pipelines', pipeline, 'jobs').get();
   }
 
   public static listResourcesForPipeline(master: string, team: string, pipeline: string): PromiseLike<string[]> {
-    return API.path('concourse', master, 'teams', team, 'pipelines', pipeline, 'resources').get();
+    return REST().path('concourse', master, 'teams', team, 'pipelines', pipeline, 'resources').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/concourse/concourse.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/concourse/concourse.service.ts
@@ -1,28 +1,33 @@
-
-
 import { API } from 'core/api/ApiService';
 
 export class ConcourseService {
   public static listTeamsForMaster(master: string): PromiseLike<string[]> {
-    return API.one('concourse').one(master).one('teams').get();
+    return API.path('concourse').path(master).path('teams').get();
   }
 
   public static listPipelinesForTeam(master: string, team: string): PromiseLike<string[]> {
-    return API.one('concourse').one(master).one('teams').one(team).one('pipelines').get();
+    return API.path('concourse').path(master).path('teams').path(team).path('pipelines').get();
   }
 
   public static listJobsForPipeline(master: string, team: string, pipeline: string): PromiseLike<string[]> {
-    return API.one('concourse').one(master).one('teams').one(team).one('pipelines').one(pipeline).one('jobs').get();
+    return API.path('concourse')
+      .path(master)
+      .path('teams')
+      .path(team)
+      .path('pipelines')
+      .path(pipeline)
+      .path('jobs')
+      .get();
   }
 
   public static listResourcesForPipeline(master: string, team: string, pipeline: string): PromiseLike<string[]> {
-    return API.one('concourse')
-      .one(master)
-      .one('teams')
-      .one(team)
-      .one('pipelines')
-      .one(pipeline)
-      .one('resources')
+    return API.path('concourse')
+      .path(master)
+      .path('teams')
+      .path(team)
+      .path('pipelines')
+      .path(pipeline)
+      .path('resources')
       .get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/concourse/concourse.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/concourse/concourse.service.ts
@@ -2,32 +2,18 @@ import { API } from 'core/api/ApiService';
 
 export class ConcourseService {
   public static listTeamsForMaster(master: string): PromiseLike<string[]> {
-    return API.path('concourse').path(master).path('teams').get();
+    return API.path('concourse', master, 'teams').get();
   }
 
   public static listPipelinesForTeam(master: string, team: string): PromiseLike<string[]> {
-    return API.path('concourse').path(master).path('teams').path(team).path('pipelines').get();
+    return API.path('concourse', master, 'teams', team, 'pipelines').get();
   }
 
   public static listJobsForPipeline(master: string, team: string, pipeline: string): PromiseLike<string[]> {
-    return API.path('concourse')
-      .path(master)
-      .path('teams')
-      .path(team)
-      .path('pipelines')
-      .path(pipeline)
-      .path('jobs')
-      .get();
+    return API.path('concourse', master, 'teams', team, 'pipelines', pipeline, 'jobs').get();
   }
 
   public static listResourcesForPipeline(master: string, team: string, pipeline: string): PromiseLike<string[]> {
-    return API.path('concourse')
-      .path(master)
-      .path('teams')
-      .path(team)
-      .path('pipelines')
-      .path(pipeline)
-      .path('resources')
-      .get();
+    return API.path('concourse', master, 'teams', team, 'pipelines', pipeline, 'resources').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/concourse/concourse.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/concourse/concourse.service.ts
@@ -2,18 +2,18 @@ import { REST } from 'core/api/ApiService';
 
 export class ConcourseService {
   public static listTeamsForMaster(master: string): PromiseLike<string[]> {
-    return REST().path('concourse', master, 'teams').get();
+    return REST('/concourse').path(master, 'teams').get();
   }
 
   public static listPipelinesForTeam(master: string, team: string): PromiseLike<string[]> {
-    return REST().path('concourse', master, 'teams', team, 'pipelines').get();
+    return REST('/concourse').path(master, 'teams', team, 'pipelines').get();
   }
 
   public static listJobsForPipeline(master: string, team: string, pipeline: string): PromiseLike<string[]> {
-    return REST().path('concourse', master, 'teams', team, 'pipelines', pipeline, 'jobs').get();
+    return REST('/concourse').path(master, 'teams', team, 'pipelines', pipeline, 'jobs').get();
   }
 
   public static listResourcesForPipeline(master: string, team: string, pipeline: string): PromiseLike<string[]> {
-    return REST().path('concourse', master, 'teams', team, 'pipelines', pipeline, 'resources').get();
+    return REST('/concourse').path(master, 'teams', team, 'pipelines', pipeline, 'resources').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/cron/cronValidator.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/cron/cronValidator.service.ts
@@ -8,6 +8,6 @@ export class CronValidatorService {
       segments.pop();
       expression = segments.join(' ');
     }
-    return API.path('cron').path('validate').query({ expression: expression }).get();
+    return API.path('cron', 'validate').query({ expression: expression }).get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/cron/cronValidator.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/cron/cronValidator.service.ts
@@ -8,6 +8,6 @@ export class CronValidatorService {
       segments.pop();
       expression = segments.join(' ');
     }
-    return REST().path('cron', 'validate').query({ expression: expression }).get();
+    return REST('/cron/validate').query({ expression: expression }).get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/cron/cronValidator.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/cron/cronValidator.service.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export class CronValidatorService {
   public static validate(expression: string) {
@@ -8,6 +8,6 @@ export class CronValidatorService {
       segments.pop();
       expression = segments.join(' ');
     }
-    return API.path('cron', 'validate').query({ expression: expression }).get();
+    return REST().path('cron', 'validate').query({ expression: expression }).get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/cron/cronValidator.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/cron/cronValidator.service.ts
@@ -8,6 +8,6 @@ export class CronValidatorService {
       segments.pop();
       expression = segments.join(' ');
     }
-    return API.one('cron').one('validate').withParams({ expression: expression }).get();
+    return API.path('cron').path('validate').query({ expression: expression }).get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/nexus/nexusReader.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/nexus/nexusReader.service.ts
@@ -2,6 +2,6 @@ import { API } from 'core/api/ApiService';
 
 export class NexusReaderService {
   public static getNexusNames(): PromiseLike<string[]> {
-    return API.path('nexus').path('names').get();
+    return API.path('nexus', 'names').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/nexus/nexusReader.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/nexus/nexusReader.service.ts
@@ -2,6 +2,6 @@ import { REST } from 'core/api/ApiService';
 
 export class NexusReaderService {
   public static getNexusNames(): PromiseLike<string[]> {
-    return REST().path('nexus', 'names').get();
+    return REST('/nexus/names').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/nexus/nexusReader.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/nexus/nexusReader.service.ts
@@ -1,7 +1,7 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export class NexusReaderService {
   public static getNexusNames(): PromiseLike<string[]> {
-    return API.path('nexus', 'names').get();
+    return REST().path('nexus', 'names').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/nexus/nexusReader.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/nexus/nexusReader.service.ts
@@ -1,9 +1,7 @@
-
-
 import { API } from 'core/api/ApiService';
 
 export class NexusReaderService {
   public static getNexusNames(): PromiseLike<string[]> {
-    return API.one('nexus').one('names').get();
+    return API.path('nexus').path('names').get();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/executions/execution/executionInformation.service.ts
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/executionInformation.service.ts
@@ -23,8 +23,8 @@ export class ExecutionInformationService {
       return this.calledExecutions[executionId];
     }
 
-    return REST()
-      .path('pipelines', executionId)
+    return REST('/pipelines')
+      .path(executionId)
       .get()
       .then((execution: IExecution) => {
         this.calledExecutions[executionId] = execution;
@@ -58,8 +58,8 @@ export class ExecutionInformationService {
       Promise.resolve(pipelineConfig);
     }
 
-    return REST()
-      .path('applications', application, 'pipelineConfigs')
+    return REST('/applications')
+      .path(application, 'pipelineConfigs')
       .get()
       .then((pipelineConfigs: IPipeline[]) => {
         // store for later

--- a/app/scripts/modules/core/src/pipeline/executions/execution/executionInformation.service.ts
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/executionInformation.service.ts
@@ -23,7 +23,7 @@ export class ExecutionInformationService {
       return this.calledExecutions[executionId];
     }
 
-    return API.one('pipelines', executionId)
+    return API.path('pipelines', executionId)
       .get()
       .then((execution: IExecution) => {
         this.calledExecutions[executionId] = execution;
@@ -57,7 +57,7 @@ export class ExecutionInformationService {
       Promise.resolve(pipelineConfig);
     }
 
-    return API.one('applications', application, 'pipelineConfigs')
+    return API.path('applications', application, 'pipelineConfigs')
       .get()
       .then((pipelineConfigs: IPipeline[]) => {
         // store for later

--- a/app/scripts/modules/core/src/pipeline/executions/execution/executionInformation.service.ts
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/executionInformation.service.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { ExecutionsTransformer } from '../../service/ExecutionsTransformer';
 import { IExecution, IPipeline } from 'core/domain';
 
@@ -23,7 +23,8 @@ export class ExecutionInformationService {
       return this.calledExecutions[executionId];
     }
 
-    return API.path('pipelines', executionId)
+    return REST()
+      .path('pipelines', executionId)
       .get()
       .then((execution: IExecution) => {
         this.calledExecutions[executionId] = execution;
@@ -57,7 +58,8 @@ export class ExecutionInformationService {
       Promise.resolve(pipelineConfig);
     }
 
-    return API.path('applications', application, 'pipelineConfigs')
+    return REST()
+      .path('applications', application, 'pipelineConfigs')
       .get()
       .then((pipelineConfigs: IPipeline[]) => {
         // store for later

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -52,8 +52,7 @@ export class ExecutionService {
     const statusString = statuses.map((status) => status.toUpperCase()).join(',') || null;
     const call = pipelineConfigIds
       ? API.path('executions').query({ limit, pipelineConfigIds, statuses }).get()
-      : API.path('applications', applicationName)
-          .path('pipelines')
+      : API.path('applications', applicationName, 'pipelines')
           .query({ limit, statuses: statusString, pipelineConfigIds, expand })
           .get();
 
@@ -312,8 +311,7 @@ export class ExecutionService {
   }
 
   public getProjectExecutions(project: string, limit = 1): PromiseLike<IExecution[]> {
-    return API.path('projects', project)
-      .path('pipelines')
+    return API.path('projects', project, 'pipelines')
       .query({ limit })
       .get()
       .then((executions: IExecution[]) => {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -51,10 +51,10 @@ export class ExecutionService {
   ): PromiseLike<IExecution[]> {
     const statusString = statuses.map((status) => status.toUpperCase()).join(',') || null;
     const call = pipelineConfigIds
-      ? API.all('executions').getList({ limit, pipelineConfigIds, statuses })
-      : API.one('applications', applicationName)
-          .all('pipelines')
-          .getList({ limit, statuses: statusString, pipelineConfigIds, expand });
+      ? API.path('executions').get({ limit, pipelineConfigIds, statuses })
+      : API.path('applications', applicationName)
+          .path('pipelines')
+          .get({ limit, statuses: statusString, pipelineConfigIds, expand });
 
     return call.then((data: IExecution[]) => {
       if (data) {
@@ -95,14 +95,14 @@ export class ExecutionService {
   }
 
   public getExecution(executionId: string): PromiseLike<IExecution> {
-    return API.one('pipelines', executionId)
+    return API.path('pipelines', executionId)
       .get()
       .then((execution: IExecution) => {
         const { application, name } = execution;
         execution.hydrated = true;
         this.cleanExecutionForDiffing(execution);
         if (application && name) {
-          return API.one('applications', application, 'pipelineConfigs', encodeURIComponent(name))
+          return API.path('applications', application, 'pipelineConfigs', encodeURIComponent(name))
             .get()
             .then((pipelineConfig: IPipeline) => {
               execution.pipelineConfig = pipelineConfig;
@@ -311,9 +311,9 @@ export class ExecutionService {
   }
 
   public getProjectExecutions(project: string, limit = 1): PromiseLike<IExecution[]> {
-    return API.one('projects', project)
-      .all('pipelines')
-      .getList({ limit })
+    return API.path('projects', project)
+      .path('pipelines')
+      .get({ limit })
       .then((executions: IExecution[]) => {
         if (!executions || !executions.length) {
           return [];
@@ -502,8 +502,8 @@ export class ExecutionService {
     options: { limit?: number; statuses?: string; transform?: boolean; application?: Application } = {},
   ): PromiseLike<IExecution[]> {
     const { limit, statuses, transform, application } = options;
-    return API.all('executions')
-      .getList({ limit, pipelineConfigIds: (pipelineConfigIds || []).join(','), statuses })
+    return API.path('executions')
+      .get({ limit, pipelineConfigIds: (pipelineConfigIds || []).join(','), statuses })
       .then((data: IExecution[]) => {
         if (data) {
           if (transform && application) {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -51,9 +51,9 @@ export class ExecutionService {
   ): PromiseLike<IExecution[]> {
     const statusString = statuses.map((status) => status.toUpperCase()).join(',') || null;
     const call = pipelineConfigIds
-      ? REST().path('executions').query({ limit, pipelineConfigIds, statuses }).get()
-      : REST()
-          .path('applications', applicationName, 'pipelines')
+      ? REST('/executions').query({ limit, pipelineConfigIds, statuses }).get()
+      : REST('/applications')
+          .path(applicationName, 'pipelines')
           .query({ limit, statuses: statusString, pipelineConfigIds, expand })
           .get();
 
@@ -96,16 +96,16 @@ export class ExecutionService {
   }
 
   public getExecution(executionId: string): PromiseLike<IExecution> {
-    return REST()
-      .path('pipelines', executionId)
+    return REST('/pipelines')
+      .path(executionId)
       .get()
       .then((execution: IExecution) => {
         const { application, name } = execution;
         execution.hydrated = true;
         this.cleanExecutionForDiffing(execution);
         if (application && name) {
-          return REST()
-            .path('applications', application, 'pipelineConfigs', encodeURIComponent(name))
+          return REST('/applications')
+            .path(application, 'pipelineConfigs', encodeURIComponent(name))
             .get()
             .then((pipelineConfig: IPipeline) => {
               execution.pipelineConfig = pipelineConfig;
@@ -314,8 +314,8 @@ export class ExecutionService {
   }
 
   public getProjectExecutions(project: string, limit = 1): PromiseLike<IExecution[]> {
-    return REST()
-      .path('projects', project, 'pipelines')
+    return REST('/projects')
+      .path(project, 'pipelines')
       .query({ limit })
       .get()
       .then((executions: IExecution[]) => {
@@ -506,8 +506,7 @@ export class ExecutionService {
     options: { limit?: number; statuses?: string; transform?: boolean; application?: Application } = {},
   ): PromiseLike<IExecution[]> {
     const { limit, statuses, transform, application } = options;
-    return REST()
-      .path('executions')
+    return REST('/executions')
       .query({ limit, pipelineConfigIds: (pipelineConfigIds || []).join(','), statuses })
       .get()
       .then((data: IExecution[]) => {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -257,8 +257,9 @@ export class ExecutionService {
     force?: boolean,
     reason?: string,
   ): PromiseLike<any> {
-    return API.one('pipelines', executionId, 'cancel')
-      .withParams({ force, reason })
+    return REST('/pipelines')
+      .path(executionId, 'cancel')
+      .query({ force, reason })
       .put()
       .then(() => this.waitUntilPipelineIsCancelled(application, executionId))
       .catch((exception) => {
@@ -267,7 +268,8 @@ export class ExecutionService {
   }
 
   public pauseExecution(application: Application, executionId: string): PromiseLike<any> {
-    return API.one('pipelines', executionId, 'pause')
+    return REST('/pipelines')
+      .path(executionId, 'pause')
       .put()
       .then(() => this.waitUntilExecutionMatches(executionId, (execution) => execution.status === 'PAUSED'))
       .then(() => application.executions.refresh())
@@ -277,7 +279,8 @@ export class ExecutionService {
   }
 
   public resumeExecution(application: Application, executionId: string): PromiseLike<any> {
-    return API.one('pipelines', executionId, 'resume')
+    return REST('/pipelines')
+      .path(executionId, 'resume')
       .put()
       .then(() => this.waitUntilExecutionMatches(executionId, (execution) => execution.status === 'RUNNING'))
       .then(() => application.executions.refresh())
@@ -287,7 +290,8 @@ export class ExecutionService {
   }
 
   public deleteExecution(application: Application, executionId: string): PromiseLike<any> {
-    const promiseLike = API.one('pipelines', executionId)
+    const promiseLike = REST('/pipelines')
+      .path(executionId)
       .delete()
       .then(() => this.waitUntilPipelineIsDeleted(application, executionId))
       .then(() => application.executions.refresh())
@@ -522,7 +526,7 @@ export class ExecutionService {
   }
 
   public patchExecution(executionId: string, stageId: string, data: any): PromiseLike<any> {
-    return API.one('pipelines', executionId, 'stages', stageId).patch(data);
+    return REST('/pipelines').path(executionId, 'stages', stageId).patch(data);
   }
 
   private stringifyExecution(execution: IExecution): string {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -2,7 +2,7 @@ import { IQService, ITimeoutService, module } from 'angular';
 import { get, identity, pickBy } from 'lodash';
 import { StateService } from '@uirouter/core';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { Application } from 'core/application/application.model';
 import { ExecutionsTransformer } from './ExecutionsTransformer';
 import { IExecution, IExecutionStage, IExecutionStageSummary } from 'core/domain';
@@ -51,8 +51,9 @@ export class ExecutionService {
   ): PromiseLike<IExecution[]> {
     const statusString = statuses.map((status) => status.toUpperCase()).join(',') || null;
     const call = pipelineConfigIds
-      ? API.path('executions').query({ limit, pipelineConfigIds, statuses }).get()
-      : API.path('applications', applicationName, 'pipelines')
+      ? REST().path('executions').query({ limit, pipelineConfigIds, statuses }).get()
+      : REST()
+          .path('applications', applicationName, 'pipelines')
           .query({ limit, statuses: statusString, pipelineConfigIds, expand })
           .get();
 
@@ -95,14 +96,16 @@ export class ExecutionService {
   }
 
   public getExecution(executionId: string): PromiseLike<IExecution> {
-    return API.path('pipelines', executionId)
+    return REST()
+      .path('pipelines', executionId)
       .get()
       .then((execution: IExecution) => {
         const { application, name } = execution;
         execution.hydrated = true;
         this.cleanExecutionForDiffing(execution);
         if (application && name) {
-          return API.path('applications', application, 'pipelineConfigs', encodeURIComponent(name))
+          return REST()
+            .path('applications', application, 'pipelineConfigs', encodeURIComponent(name))
             .get()
             .then((pipelineConfig: IPipeline) => {
               execution.pipelineConfig = pipelineConfig;
@@ -311,7 +314,8 @@ export class ExecutionService {
   }
 
   public getProjectExecutions(project: string, limit = 1): PromiseLike<IExecution[]> {
-    return API.path('projects', project, 'pipelines')
+    return REST()
+      .path('projects', project, 'pipelines')
       .query({ limit })
       .get()
       .then((executions: IExecution[]) => {
@@ -502,7 +506,8 @@ export class ExecutionService {
     options: { limit?: number; statuses?: string; transform?: boolean; application?: Application } = {},
   ): PromiseLike<IExecution[]> {
     const { limit, statuses, transform, application } = options;
-    return API.path('executions')
+    return REST()
+      .path('executions')
       .query({ limit, pipelineConfigIds: (pipelineConfigIds || []).join(','), statuses })
       .get()
       .then((data: IExecution[]) => {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -51,10 +51,11 @@ export class ExecutionService {
   ): PromiseLike<IExecution[]> {
     const statusString = statuses.map((status) => status.toUpperCase()).join(',') || null;
     const call = pipelineConfigIds
-      ? API.path('executions').get({ limit, pipelineConfigIds, statuses })
+      ? API.path('executions').query({ limit, pipelineConfigIds, statuses }).get()
       : API.path('applications', applicationName)
           .path('pipelines')
-          .get({ limit, statuses: statusString, pipelineConfigIds, expand });
+          .query({ limit, statuses: statusString, pipelineConfigIds, expand })
+          .get();
 
     return call.then((data: IExecution[]) => {
       if (data) {
@@ -313,7 +314,8 @@ export class ExecutionService {
   public getProjectExecutions(project: string, limit = 1): PromiseLike<IExecution[]> {
     return API.path('projects', project)
       .path('pipelines')
-      .get({ limit })
+      .query({ limit })
+      .get()
       .then((executions: IExecution[]) => {
         if (!executions || !executions.length) {
           return [];
@@ -503,7 +505,8 @@ export class ExecutionService {
   ): PromiseLike<IExecution[]> {
     const { limit, statuses, transform, application } = options;
     return API.path('executions')
-      .get({ limit, pipelineConfigIds: (pipelineConfigIds || []).join(','), statuses })
+      .query({ limit, pipelineConfigIds: (pipelineConfigIds || []).join(','), statuses })
+      .get()
       .then((data: IExecution[]) => {
         if (data) {
           if (transform && application) {

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -1,6 +1,6 @@
 import { $http } from 'ngimport';
 import { SETTINGS } from '../config/settings';
-import { API } from '../api/ApiService';
+import { REST } from '../api/ApiService';
 import { registerPluginExtensions, IDeckPlugin } from './deck.plugin';
 
 /** The shape of plugin metadata objects in plugin-manifest.json */
@@ -99,7 +99,8 @@ export class PluginRegistry {
   public loadPluginManifestFromGate() {
     const source = 'gate';
     const uri = 'plugins/deck/plugin-manifest.json';
-    const loadPromise: PromiseLike<IPluginMetaData[]> = API.path(...uri.split('/'))
+    const loadPromise: PromiseLike<IPluginMetaData[]> = REST()
+      .path(...uri.split('/'))
       .get()
       .catch((error: any) => {
         console.error(`Failed to load ${uri} from ${source}`);

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -98,9 +98,8 @@ export class PluginRegistry {
   /** Loads plugin manifest file served from gate */
   public loadPluginManifestFromGate() {
     const source = 'gate';
-    const uri = 'plugins/deck/plugin-manifest.json';
-    const loadPromise: PromiseLike<IPluginMetaData[]> = REST()
-      .path(...uri.split('/'))
+    const uri = '/plugins/deck/plugin-manifest.json';
+    const loadPromise: PromiseLike<IPluginMetaData[]> = REST(uri)
       .get()
       .catch((error: any) => {
         console.error(`Failed to load ${uri} from ${source}`);

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -99,7 +99,7 @@ export class PluginRegistry {
   public loadPluginManifestFromGate() {
     const source = 'gate';
     const uri = 'plugins/deck/plugin-manifest.json';
-    const loadPromise: PromiseLike<IPluginMetaData[]> = API.one(...uri.split('/'))
+    const loadPromise: PromiseLike<IPluginMetaData[]> = API.path(...uri.split('/'))
       .get()
       .catch((error: any) => {
         console.error(`Failed to load ${uri} from ${source}`);

--- a/app/scripts/modules/core/src/presentation/spel/SpelService.ts
+++ b/app/scripts/modules/core/src/presentation/spel/SpelService.ts
@@ -20,11 +20,11 @@ interface IServerSideEvaluatedExpression {
 export class SpelService {
   /** Evaluates a spel expression on the server against a previous executionId and stageId */
   public static evaluateExpression(expression: string, executionId: string, stageId: string) {
-    return API.all('pipelines')
-      .one(executionId)
-      .one(stageId)
-      .one('evaluateExpression')
-      .withParams({ expression })
+    return API.path('pipelines')
+      .path(executionId)
+      .path(stageId)
+      .path('evaluateExpression')
+      .query({ expression })
       .get()
       .then((result: IServerSideEvaluatedExpression) => {
         const errors = result.detail || {};

--- a/app/scripts/modules/core/src/presentation/spel/SpelService.ts
+++ b/app/scripts/modules/core/src/presentation/spel/SpelService.ts
@@ -20,10 +20,7 @@ interface IServerSideEvaluatedExpression {
 export class SpelService {
   /** Evaluates a spel expression on the server against a previous executionId and stageId */
   public static evaluateExpression(expression: string, executionId: string, stageId: string) {
-    return API.path('pipelines')
-      .path(executionId)
-      .path(stageId)
-      .path('evaluateExpression')
+    return API.path('pipelines', executionId, stageId, 'evaluateExpression')
       .query({ expression })
       .get()
       .then((result: IServerSideEvaluatedExpression) => {

--- a/app/scripts/modules/core/src/presentation/spel/SpelService.ts
+++ b/app/scripts/modules/core/src/presentation/spel/SpelService.ts
@@ -20,8 +20,8 @@ interface IServerSideEvaluatedExpression {
 export class SpelService {
   /** Evaluates a spel expression on the server against a previous executionId and stageId */
   public static evaluateExpression(expression: string, executionId: string, stageId: string) {
-    return REST()
-      .path('pipelines', executionId, stageId, 'evaluateExpression')
+    return REST('/pipelines')
+      .path(executionId, stageId, 'evaluateExpression')
       .query({ expression })
       .get()
       .then((result: IServerSideEvaluatedExpression) => {

--- a/app/scripts/modules/core/src/presentation/spel/SpelService.ts
+++ b/app/scripts/modules/core/src/presentation/spel/SpelService.ts
@@ -1,6 +1,6 @@
 import { isString } from 'lodash';
 
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { parseSpelExpressions } from '../forms/inputs/expression';
 
 interface IEvaluationException {
@@ -20,7 +20,8 @@ interface IServerSideEvaluatedExpression {
 export class SpelService {
   /** Evaluates a spel expression on the server against a previous executionId and stageId */
   public static evaluateExpression(expression: string, executionId: string, stageId: string) {
-    return API.path('pipelines', executionId, stageId, 'evaluateExpression')
+    return REST()
+      .path('pipelines', executionId, stageId, 'evaluateExpression')
       .query({ expression })
       .get()
       .then((result: IServerSideEvaluatedExpression) => {

--- a/app/scripts/modules/core/src/projects/service/ProjectReader.ts
+++ b/app/scripts/modules/core/src/projects/service/ProjectReader.ts
@@ -11,6 +11,6 @@ export class ProjectReader {
   }
 
   public static getProjectClusters(projectName: string): PromiseLike<IProjectCluster[]> {
-    return API.path('projects', projectName).path('clusters').get();
+    return API.path('projects', projectName, 'clusters').get();
   }
 }

--- a/app/scripts/modules/core/src/projects/service/ProjectReader.ts
+++ b/app/scripts/modules/core/src/projects/service/ProjectReader.ts
@@ -3,14 +3,14 @@ import { IProject, IProjectCluster } from 'core/domain';
 
 export class ProjectReader {
   public static listProjects(): PromiseLike<IProject[]> {
-    return REST().path('projects').get();
+    return REST('/projects').get();
   }
 
   public static getProjectConfig(projectName: string): PromiseLike<IProject> {
-    return REST().path('projects', projectName).get();
+    return REST('/projects').path(projectName).get();
   }
 
   public static getProjectClusters(projectName: string): PromiseLike<IProjectCluster[]> {
-    return REST().path('projects', projectName, 'clusters').get();
+    return REST('/projects').path(projectName, 'clusters').get();
   }
 }

--- a/app/scripts/modules/core/src/projects/service/ProjectReader.ts
+++ b/app/scripts/modules/core/src/projects/service/ProjectReader.ts
@@ -3,14 +3,14 @@ import { IProject, IProjectCluster } from 'core/domain';
 
 export class ProjectReader {
   public static listProjects(): PromiseLike<IProject[]> {
-    return API.all('projects').getList();
+    return API.path('projects').get();
   }
 
   public static getProjectConfig(projectName: string): PromiseLike<IProject> {
-    return API.one('projects', projectName).get();
+    return API.path('projects', projectName).get();
   }
 
   public static getProjectClusters(projectName: string): PromiseLike<IProjectCluster[]> {
-    return API.one('projects', projectName).all('clusters').getList();
+    return API.path('projects', projectName).path('clusters').get();
   }
 }

--- a/app/scripts/modules/core/src/projects/service/ProjectReader.ts
+++ b/app/scripts/modules/core/src/projects/service/ProjectReader.ts
@@ -1,16 +1,16 @@
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { IProject, IProjectCluster } from 'core/domain';
 
 export class ProjectReader {
   public static listProjects(): PromiseLike<IProject[]> {
-    return API.path('projects').get();
+    return REST().path('projects').get();
   }
 
   public static getProjectConfig(projectName: string): PromiseLike<IProject> {
-    return API.path('projects', projectName).get();
+    return REST().path('projects', projectName).get();
   }
 
   public static getProjectClusters(projectName: string): PromiseLike<IProjectCluster[]> {
-    return API.path('projects', projectName, 'clusters').get();
+    return REST().path('projects', projectName, 'clusters').get();
   }
 }

--- a/app/scripts/modules/core/src/pubsub/PubsubSubscriptionReader.ts
+++ b/app/scripts/modules/core/src/pubsub/PubsubSubscriptionReader.ts
@@ -1,8 +1,8 @@
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { IPubsubSubscription } from 'core/domain';
 
 export class PubsubSubscriptionReader {
   public static getPubsubSubscriptions(): PromiseLike<IPubsubSubscription[]> {
-    return API.path('pubsub', 'subscriptions').get();
+    return REST().path('pubsub', 'subscriptions').get();
   }
 }

--- a/app/scripts/modules/core/src/pubsub/PubsubSubscriptionReader.ts
+++ b/app/scripts/modules/core/src/pubsub/PubsubSubscriptionReader.ts
@@ -3,6 +3,6 @@ import { IPubsubSubscription } from 'core/domain';
 
 export class PubsubSubscriptionReader {
   public static getPubsubSubscriptions(): PromiseLike<IPubsubSubscription[]> {
-    return API.path('pubsub').path('subscriptions').get();
+    return API.path('pubsub', 'subscriptions').get();
   }
 }

--- a/app/scripts/modules/core/src/pubsub/PubsubSubscriptionReader.ts
+++ b/app/scripts/modules/core/src/pubsub/PubsubSubscriptionReader.ts
@@ -1,10 +1,8 @@
-
-
 import { API } from 'core/api';
 import { IPubsubSubscription } from 'core/domain';
 
 export class PubsubSubscriptionReader {
   public static getPubsubSubscriptions(): PromiseLike<IPubsubSubscription[]> {
-    return API.one('pubsub').one('subscriptions').get();
+    return API.path('pubsub').path('subscriptions').get();
   }
 }

--- a/app/scripts/modules/core/src/pubsub/PubsubSubscriptionReader.ts
+++ b/app/scripts/modules/core/src/pubsub/PubsubSubscriptionReader.ts
@@ -3,6 +3,6 @@ import { IPubsubSubscription } from 'core/domain';
 
 export class PubsubSubscriptionReader {
   public static getPubsubSubscriptions(): PromiseLike<IPubsubSubscription[]> {
-    return REST().path('pubsub', 'subscriptions').get();
+    return REST('/pubsub/subscriptions').get();
   }
 }

--- a/app/scripts/modules/core/src/search/search.service.ts
+++ b/app/scripts/modules/core/src/search/search.service.ts
@@ -49,7 +49,7 @@ export class SearchService {
 
     const params = { ...searchParams, ...defaultParams };
 
-    let requestBuilder = API.one('search').withParams(params);
+    let requestBuilder = API.path('search').query(params);
 
     if (cache) {
       requestBuilder = requestBuilder.useCache(cache);

--- a/app/scripts/modules/core/src/search/search.service.ts
+++ b/app/scripts/modules/core/src/search/search.service.ts
@@ -49,7 +49,7 @@ export class SearchService {
 
     const params = { ...searchParams, ...defaultParams };
 
-    let requestBuilder = REST().path('search').query(params);
+    let requestBuilder = REST('/search').query(params);
 
     if (cache) {
       requestBuilder = requestBuilder.useCache(cache);

--- a/app/scripts/modules/core/src/search/search.service.ts
+++ b/app/scripts/modules/core/src/search/search.service.ts
@@ -1,7 +1,7 @@
 import { IHttpPromiseCallbackArg } from 'angular';
 import { $log } from 'ngimport';
 
-import { REST } from 'core/api/ApiService';
+import { API } from 'core/api/ApiService';
 import { ICache } from 'core/cache';
 
 export interface ISearchParams {
@@ -49,9 +49,11 @@ export class SearchService {
 
     const params = { ...searchParams, ...defaultParams };
 
-    let requestBuilder = REST('/search').query(params);
+    // eslint-disable-next-line @spinnaker/api-deprecation
+    let requestBuilder = API.one('search').query(params);
 
     if (cache) {
+      // TODO: This is the only usage of ICache in deck, investigate how we can avoid this and migrate to REST()
       requestBuilder = requestBuilder.useCache(cache);
     }
 

--- a/app/scripts/modules/core/src/search/search.service.ts
+++ b/app/scripts/modules/core/src/search/search.service.ts
@@ -1,7 +1,7 @@
 import { IHttpPromiseCallbackArg } from 'angular';
 import { $log } from 'ngimport';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { ICache } from 'core/cache';
 
 export interface ISearchParams {
@@ -49,7 +49,7 @@ export class SearchService {
 
     const params = { ...searchParams, ...defaultParams };
 
-    let requestBuilder = API.path('search').query(params);
+    let requestBuilder = REST().path('search').query(params);
 
     if (cache) {
       requestBuilder = requestBuilder.useCache(cache);

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -391,10 +391,7 @@ export class SecurityGroupReader {
     vpcId: string,
     id: string,
   ): PromiseLike<ISecurityGroupDetail> {
-    return API.path('securityGroups')
-      .path(account)
-      .path(region)
-      .path(id)
+    return API.path('securityGroups', account, region, id)
       .query({ provider, vpcId })
       .get()
       .then((details: ISecurityGroupDetail) => {

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -300,8 +300,7 @@ export class SecurityGroupReader {
     if (cached) {
       return this.$q.resolve(this.decompress(cloneDeep(cached)));
     }
-    return REST()
-      .path('securityGroups')
+    return REST('/securityGroups')
       .get()
       .then((groupsByAccount: ISecurityGroupsByAccountSourceData) => {
         if (cache) {
@@ -392,8 +391,8 @@ export class SecurityGroupReader {
     vpcId: string,
     id: string,
   ): PromiseLike<ISecurityGroupDetail> {
-    return REST()
-      .path('securityGroups', account, region, id)
+    return REST('/securityGroups')
+      .path(account, region, id)
       .query({ provider, vpcId })
       .get()
       .then((details: ISecurityGroupDetail) => {

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -1,7 +1,7 @@
 import { filter, forOwn, has, uniq } from 'lodash';
 import { module, ILogService, IQService } from 'angular';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IComponentName, NameUtils } from 'core/naming';
 import { InfrastructureCaches } from 'core/cache';
 import { Application } from 'core/application/application.model';
@@ -300,7 +300,8 @@ export class SecurityGroupReader {
     if (cached) {
       return this.$q.resolve(this.decompress(cloneDeep(cached)));
     }
-    return API.path('securityGroups')
+    return REST()
+      .path('securityGroups')
       .get()
       .then((groupsByAccount: ISecurityGroupsByAccountSourceData) => {
         if (cache) {
@@ -391,7 +392,8 @@ export class SecurityGroupReader {
     vpcId: string,
     id: string,
   ): PromiseLike<ISecurityGroupDetail> {
-    return API.path('securityGroups', account, region, id)
+    return REST()
+      .path('securityGroups', account, region, id)
       .query({ provider, vpcId })
       .get()
       .then((details: ISecurityGroupDetail) => {

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -300,7 +300,7 @@ export class SecurityGroupReader {
     if (cached) {
       return this.$q.resolve(this.decompress(cloneDeep(cached)));
     }
-    return API.one('securityGroups')
+    return API.path('securityGroups')
       .get()
       .then((groupsByAccount: ISecurityGroupsByAccountSourceData) => {
         if (cache) {
@@ -391,11 +391,11 @@ export class SecurityGroupReader {
     vpcId: string,
     id: string,
   ): PromiseLike<ISecurityGroupDetail> {
-    return API.one('securityGroups')
-      .one(account)
-      .one(region)
-      .one(id)
-      .withParams({ provider, vpcId })
+    return API.path('securityGroups')
+      .path(account)
+      .path(region)
+      .path(id)
+      .query({ provider, vpcId })
       .get()
       .then((details: ISecurityGroupDetail) => {
         if (details && details.inboundRules) {

--- a/app/scripts/modules/core/src/serverGroup/metrics/CloudMetricsReader.ts
+++ b/app/scripts/modules/core/src/serverGroup/metrics/CloudMetricsReader.ts
@@ -8,7 +8,7 @@ export class CloudMetricsReader {
     region: string,
     filters: any,
   ): PromiseLike<ICloudMetricDescriptor[]> {
-    return REST().path('cloudMetrics', provider, account, region).query(filters).get();
+    return REST('/cloudMetrics').path(provider, account, region).query(filters).get();
   }
 
   public static getMetricStatistics(
@@ -18,6 +18,6 @@ export class CloudMetricsReader {
     name: string,
     filters: any,
   ): PromiseLike<ICloudMetricStatistics> {
-    return REST().path('cloudMetrics', provider, account, region, name, 'statistics').query(filters).get();
+    return REST('/cloudMetrics').path(provider, account, region, name, 'statistics').query(filters).get();
   }
 }

--- a/app/scripts/modules/core/src/serverGroup/metrics/CloudMetricsReader.ts
+++ b/app/scripts/modules/core/src/serverGroup/metrics/CloudMetricsReader.ts
@@ -8,7 +8,7 @@ export class CloudMetricsReader {
     region: string,
     filters: any,
   ): PromiseLike<ICloudMetricDescriptor[]> {
-    return API.all('cloudMetrics').all(provider).all(account).all(region).withParams(filters).getList();
+    return API.path('cloudMetrics').path(provider).path(account).path(region).query(filters).get();
   }
 
   public static getMetricStatistics(
@@ -18,12 +18,12 @@ export class CloudMetricsReader {
     name: string,
     filters: any,
   ): PromiseLike<ICloudMetricStatistics> {
-    return API.all('cloudMetrics')
-      .all(provider)
-      .all(account)
-      .all(region)
-      .one(name, 'statistics')
-      .withParams(filters)
+    return API.path('cloudMetrics')
+      .path(provider)
+      .path(account)
+      .path(region)
+      .path(name, 'statistics')
+      .query(filters)
       .get();
   }
 }

--- a/app/scripts/modules/core/src/serverGroup/metrics/CloudMetricsReader.ts
+++ b/app/scripts/modules/core/src/serverGroup/metrics/CloudMetricsReader.ts
@@ -8,7 +8,7 @@ export class CloudMetricsReader {
     region: string,
     filters: any,
   ): PromiseLike<ICloudMetricDescriptor[]> {
-    return API.path('cloudMetrics').path(provider).path(account).path(region).query(filters).get();
+    return API.path('cloudMetrics', provider, account, region).query(filters).get();
   }
 
   public static getMetricStatistics(
@@ -18,12 +18,6 @@ export class CloudMetricsReader {
     name: string,
     filters: any,
   ): PromiseLike<ICloudMetricStatistics> {
-    return API.path('cloudMetrics')
-      .path(provider)
-      .path(account)
-      .path(region)
-      .path(name, 'statistics')
-      .query(filters)
-      .get();
+    return API.path('cloudMetrics', provider, account, region, name, 'statistics').query(filters).get();
   }
 }

--- a/app/scripts/modules/core/src/serverGroup/metrics/CloudMetricsReader.ts
+++ b/app/scripts/modules/core/src/serverGroup/metrics/CloudMetricsReader.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { ICloudMetricDescriptor, ICloudMetricStatistics } from 'core/domain';
 
 export class CloudMetricsReader {
@@ -8,7 +8,7 @@ export class CloudMetricsReader {
     region: string,
     filters: any,
   ): PromiseLike<ICloudMetricDescriptor[]> {
-    return API.path('cloudMetrics', provider, account, region).query(filters).get();
+    return REST().path('cloudMetrics', provider, account, region).query(filters).get();
   }
 
   public static getMetricStatistics(
@@ -18,6 +18,6 @@ export class CloudMetricsReader {
     name: string,
     filters: any,
   ): PromiseLike<ICloudMetricStatistics> {
-    return API.path('cloudMetrics', provider, account, region, name, 'statistics').query(filters).get();
+    return REST().path('cloudMetrics', provider, account, region, name, 'statistics').query(filters).get();
   }
 }

--- a/app/scripts/modules/core/src/serverGroup/serverGroupReader.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupReader.service.ts
@@ -1,5 +1,3 @@
-
-
 import { $log } from 'ngimport';
 
 import { API } from 'core/api/ApiService';
@@ -7,18 +5,18 @@ import { IServerGroup } from 'core/domain';
 
 export class ServerGroupReader {
   public static getScalingActivities(serverGroup: IServerGroup): PromiseLike<any[]> {
-    return API.one('applications')
-      .one(serverGroup.app)
-      .all('clusters')
-      .all(serverGroup.account)
-      .all(serverGroup.cluster)
-      .one('serverGroups', serverGroup.name)
-      .all('scalingActivities')
-      .withParams({
+    return API.path('applications')
+      .path(serverGroup.app)
+      .path('clusters')
+      .path(serverGroup.account)
+      .path(serverGroup.cluster)
+      .path('serverGroups', serverGroup.name)
+      .path('scalingActivities')
+      .query({
         region: serverGroup.region,
         provider: serverGroup.cloudProvider,
       })
-      .getList()
+      .get()
       .catch((error: any): any[] => {
         $log.error(error, 'error retrieving scaling activities');
         return [];
@@ -31,13 +29,13 @@ export class ServerGroupReader {
     region: string,
     serverGroupName: string,
   ): PromiseLike<IServerGroup> {
-    return API.one('applications')
-      .one(application)
-      .all('serverGroups')
-      .all(account)
-      .all(region)
-      .one(serverGroupName)
-      .withParams({ includeDetails: 'false' })
+    return API.path('applications')
+      .path(application)
+      .path('serverGroups')
+      .path(account)
+      .path(region)
+      .path(serverGroupName)
+      .query({ includeDetails: 'false' })
       .get();
   }
 }

--- a/app/scripts/modules/core/src/serverGroup/serverGroupReader.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupReader.service.ts
@@ -1,20 +1,21 @@
 import { $log } from 'ngimport';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IServerGroup } from 'core/domain';
 
 export class ServerGroupReader {
   public static getScalingActivities(serverGroup: IServerGroup): PromiseLike<any[]> {
-    return API.path(
-      'applications',
-      serverGroup.app,
-      'clusters',
-      serverGroup.account,
-      serverGroup.cluster,
-      'serverGroups',
-      serverGroup.name,
-      'scalingActivities',
-    )
+    return REST()
+      .path(
+        'applications',
+        serverGroup.app,
+        'clusters',
+        serverGroup.account,
+        serverGroup.cluster,
+        'serverGroups',
+        serverGroup.name,
+        'scalingActivities',
+      )
       .query({
         region: serverGroup.region,
         provider: serverGroup.cloudProvider,
@@ -32,7 +33,8 @@ export class ServerGroupReader {
     region: string,
     serverGroupName: string,
   ): PromiseLike<IServerGroup> {
-    return API.path('applications', application, 'serverGroups', account, region, serverGroupName)
+    return REST()
+      .path('applications', application, 'serverGroups', account, region, serverGroupName)
       .query({ includeDetails: 'false' })
       .get();
   }

--- a/app/scripts/modules/core/src/serverGroup/serverGroupReader.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupReader.service.ts
@@ -5,13 +5,16 @@ import { IServerGroup } from 'core/domain';
 
 export class ServerGroupReader {
   public static getScalingActivities(serverGroup: IServerGroup): PromiseLike<any[]> {
-    return API.path('applications')
-      .path(serverGroup.app)
-      .path('clusters')
-      .path(serverGroup.account)
-      .path(serverGroup.cluster)
-      .path('serverGroups', serverGroup.name)
-      .path('scalingActivities')
+    return API.path(
+      'applications',
+      serverGroup.app,
+      'clusters',
+      serverGroup.account,
+      serverGroup.cluster,
+      'serverGroups',
+      serverGroup.name,
+      'scalingActivities',
+    )
       .query({
         region: serverGroup.region,
         provider: serverGroup.cloudProvider,
@@ -29,12 +32,7 @@ export class ServerGroupReader {
     region: string,
     serverGroupName: string,
   ): PromiseLike<IServerGroup> {
-    return API.path('applications')
-      .path(application)
-      .path('serverGroups')
-      .path(account)
-      .path(region)
-      .path(serverGroupName)
+    return API.path('applications', application, 'serverGroups', account, region, serverGroupName)
       .query({ includeDetails: 'false' })
       .get();
   }

--- a/app/scripts/modules/core/src/serverGroup/serverGroupReader.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupReader.service.ts
@@ -5,9 +5,8 @@ import { IServerGroup } from 'core/domain';
 
 export class ServerGroupReader {
   public static getScalingActivities(serverGroup: IServerGroup): PromiseLike<any[]> {
-    return REST()
+    return REST('/applications')
       .path(
-        'applications',
         serverGroup.app,
         'clusters',
         serverGroup.account,
@@ -33,8 +32,8 @@ export class ServerGroupReader {
     region: string,
     serverGroupName: string,
   ): PromiseLike<IServerGroup> {
-    return REST()
-      .path('applications', application, 'serverGroups', account, region, serverGroupName)
+    return REST('/applications')
+      .path(application, 'serverGroups', account, region, serverGroupName)
       .query({ includeDetails: 'false' })
       .get();
   }

--- a/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Observable, Subject, BehaviorSubject } from 'rxjs';
 
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { IServerGroup, IInstanceCounts } from 'core/domain';
 import {
   AccountCell,
@@ -58,7 +58,8 @@ const makeServerGroupTuples = (sgToFetch: IServerGroupSearchResult[], fetched: I
 };
 
 const fetchServerGroups = (toFetch: IServerGroupSearchResult[]): Observable<IServerGroupTuple[]> => {
-  const fetchPromise = API.path('serverGroups')
+  const fetchPromise = REST()
+    .path('serverGroups')
     .query({ ids: toFetch.map((sg) => `${sg.account}:${sg.region}:${sg.serverGroup}`) })
     .get()
     .then((fetched: IServerGroup[]) => makeServerGroupTuples(toFetch, fetched));

--- a/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
@@ -58,8 +58,8 @@ const makeServerGroupTuples = (sgToFetch: IServerGroupSearchResult[], fetched: I
 };
 
 const fetchServerGroups = (toFetch: IServerGroupSearchResult[]): Observable<IServerGroupTuple[]> => {
-  const fetchPromise = API.one('serverGroups')
-    .withParams({ ids: toFetch.map((sg) => `${sg.account}:${sg.region}:${sg.serverGroup}`) })
+  const fetchPromise = API.path('serverGroups')
+    .query({ ids: toFetch.map((sg) => `${sg.account}:${sg.region}:${sg.serverGroup}`) })
     .get()
     .then((fetched: IServerGroup[]) => makeServerGroupTuples(toFetch, fetched));
 

--- a/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
@@ -58,8 +58,7 @@ const makeServerGroupTuples = (sgToFetch: IServerGroupSearchResult[], fetched: I
 };
 
 const fetchServerGroups = (toFetch: IServerGroupSearchResult[]): Observable<IServerGroupTuple[]> => {
-  const fetchPromise = REST()
-    .path('serverGroups')
+  const fetchPromise = REST('/serverGroups')
     .query({ ids: toFetch.map((sg) => `${sg.account}:${sg.region}:${sg.serverGroup}`) })
     .get()
     .then((fetched: IServerGroup[]) => makeServerGroupTuples(toFetch, fetched));

--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
@@ -1,7 +1,5 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock, noop } from 'angular';
-
-import { API } from 'core/api/ApiService';
 import { MockHttpClient } from 'core/api/mock/mockHttpClient';
 import { SERVER_GROUP_WRITER, ServerGroupWriter } from './serverGroupWriter.service';
 import {
@@ -40,9 +38,6 @@ describe('serverGroupWriter', function () {
   });
 
   it('should inject defined objects', async function () {
-    const http = mockHttpClient();
-    expect(API).toBeDefined();
-    expect(http).toBeDefined();
     expect(serverGroupTransformer).toBeDefined();
     expect(serverGroupWriter).toBeDefined();
   });

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerReader.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerReader.ts
@@ -4,6 +4,6 @@ import { IServerGroupManager } from 'core/domain/IServerGroupManager';
 
 export class ServerGroupManagerReader {
   public static getServerGroupManagersForApplication(application: string): PromiseLike<IServerGroupManager[]> {
-    return REST().path('applications', application, 'serverGroupManagers').get();
+    return REST('/applications').path(application, 'serverGroupManagers').get();
   }
 }

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerReader.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerReader.ts
@@ -1,9 +1,9 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 import { IServerGroupManager } from 'core/domain/IServerGroupManager';
 
 export class ServerGroupManagerReader {
   public static getServerGroupManagersForApplication(application: string): PromiseLike<IServerGroupManager[]> {
-    return API.path('applications', application, 'serverGroupManagers').get();
+    return REST().path('applications', application, 'serverGroupManagers').get();
   }
 }

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerReader.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerReader.ts
@@ -4,6 +4,6 @@ import { IServerGroupManager } from 'core/domain/IServerGroupManager';
 
 export class ServerGroupManagerReader {
   public static getServerGroupManagersForApplication(application: string): PromiseLike<IServerGroupManager[]> {
-    return API.path('applications').path(application).path('serverGroupManagers').get();
+    return API.path('applications', application, 'serverGroupManagers').get();
   }
 }

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerReader.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerReader.ts
@@ -1,11 +1,9 @@
-
-
 import { API } from 'core/api/ApiService';
 
 import { IServerGroupManager } from 'core/domain/IServerGroupManager';
 
 export class ServerGroupManagerReader {
   public static getServerGroupManagersForApplication(application: string): PromiseLike<IServerGroupManager[]> {
-    return API.one('applications').one(application).one('serverGroupManagers').get();
+    return API.path('applications').path(application).path('serverGroupManagers').get();
   }
 }

--- a/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
+++ b/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
@@ -8,7 +8,7 @@ export class ServiceAccountReader {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {
-      return REST().path('auth', 'user', 'serviceAccounts').get();
+      return REST('/auth/user/serviceAccounts').get();
     }
   }
 
@@ -16,7 +16,7 @@ export class ServiceAccountReader {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {
-      return REST().path('auth', 'user', 'serviceAccounts').query({ application: application }).get();
+      return REST('/auth/user/serviceAccounts').query({ application: application }).get();
     }
   }
 }

--- a/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
+++ b/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
@@ -8,7 +8,7 @@ export class ServiceAccountReader {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {
-      return API.path('auth').path('user').path('serviceAccounts').get();
+      return API.path('auth', 'user', 'serviceAccounts').get();
     }
   }
 
@@ -16,7 +16,7 @@ export class ServiceAccountReader {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {
-      return API.path('auth').path('user').path('serviceAccounts').query({ application: application }).get();
+      return API.path('auth', 'user', 'serviceAccounts').query({ application: application }).get();
     }
   }
 }

--- a/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
+++ b/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
@@ -1,6 +1,6 @@
 import { $q } from 'ngimport';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { SETTINGS } from 'core/config/settings';
 
 export class ServiceAccountReader {
@@ -8,7 +8,7 @@ export class ServiceAccountReader {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {
-      return API.path('auth', 'user', 'serviceAccounts').get();
+      return REST().path('auth', 'user', 'serviceAccounts').get();
     }
   }
 
@@ -16,7 +16,7 @@ export class ServiceAccountReader {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {
-      return API.path('auth', 'user', 'serviceAccounts').query({ application: application }).get();
+      return REST().path('auth', 'user', 'serviceAccounts').query({ application: application }).get();
     }
   }
 }

--- a/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
+++ b/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
@@ -1,5 +1,3 @@
-
-
 import { $q } from 'ngimport';
 
 import { API } from 'core/api/ApiService';
@@ -10,7 +8,7 @@ export class ServiceAccountReader {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {
-      return API.one('auth').one('user').one('serviceAccounts').get();
+      return API.path('auth').path('user').path('serviceAccounts').get();
     }
   }
 
@@ -18,7 +16,7 @@ export class ServiceAccountReader {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {
-      return API.one('auth').one('user').one('serviceAccounts').withParams({ application: application }).get();
+      return API.path('auth').path('user').path('serviceAccounts').query({ application: application }).get();
     }
   }
 }

--- a/app/scripts/modules/core/src/services/ServicesReader.ts
+++ b/app/scripts/modules/core/src/services/ServicesReader.ts
@@ -3,9 +3,7 @@ import { IService } from 'core/domain';
 
 export class ServicesReader {
   public static getServices(account: string, region: string): PromiseLike<IService[]> {
-    return API.path('servicebroker')
-      .path(account)
-      .path('services')
+    return API.path('servicebroker', account, 'services')
       .query({
         cloudProvider: 'cloudfoundry',
         region: region,

--- a/app/scripts/modules/core/src/services/ServicesReader.ts
+++ b/app/scripts/modules/core/src/services/ServicesReader.ts
@@ -1,9 +1,10 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { IService } from 'core/domain';
 
 export class ServicesReader {
   public static getServices(account: string, region: string): PromiseLike<IService[]> {
-    return API.path('servicebroker', account, 'services')
+    return REST()
+      .path('servicebroker', account, 'services')
       .query({
         cloudProvider: 'cloudfoundry',
         region: region,

--- a/app/scripts/modules/core/src/services/ServicesReader.ts
+++ b/app/scripts/modules/core/src/services/ServicesReader.ts
@@ -3,8 +3,8 @@ import { IService } from 'core/domain';
 
 export class ServicesReader {
   public static getServices(account: string, region: string): PromiseLike<IService[]> {
-    return REST()
-      .path('servicebroker', account, 'services')
+    return REST('/servicebroker')
+      .path(account, 'services')
       .query({
         cloudProvider: 'cloudfoundry',
         region: region,

--- a/app/scripts/modules/core/src/services/ServicesReader.ts
+++ b/app/scripts/modules/core/src/services/ServicesReader.ts
@@ -1,16 +1,15 @@
-
 import { API } from 'core/api/ApiService';
 import { IService } from 'core/domain';
 
 export class ServicesReader {
   public static getServices(account: string, region: string): PromiseLike<IService[]> {
-    return API.one('servicebroker')
-      .one(account)
-      .all('services')
-      .withParams({
+    return API.path('servicebroker')
+      .path(account)
+      .path('services')
+      .query({
         cloudProvider: 'cloudfoundry',
         region: region,
       })
-      .getList();
+      .get();
   }
 }

--- a/app/scripts/modules/core/src/slack/SlackReader.ts
+++ b/app/scripts/modules/core/src/slack/SlackReader.ts
@@ -12,8 +12,8 @@ export interface ISlackChannel {
 
 export class SlackReader {
   public static getChannels(): PromiseLike<ISlackChannel[]> {
-    return API.one('slack', 'channels')
-      .getList()
+    return API.path('slack', 'channels')
+      .get()
       .catch(() => [] as ISlackChannel[]);
   }
 }

--- a/app/scripts/modules/core/src/slack/SlackReader.ts
+++ b/app/scripts/modules/core/src/slack/SlackReader.ts
@@ -1,4 +1,4 @@
-import { API } from 'core';
+import { REST } from 'core';
 
 export interface ISlackChannel {
   id: string;
@@ -12,7 +12,8 @@ export interface ISlackChannel {
 
 export class SlackReader {
   public static getChannels(): PromiseLike<ISlackChannel[]> {
-    return API.path('slack', 'channels')
+    return REST()
+      .path('slack', 'channels')
       .get()
       .catch(() => [] as ISlackChannel[]);
   }

--- a/app/scripts/modules/core/src/slack/SlackReader.ts
+++ b/app/scripts/modules/core/src/slack/SlackReader.ts
@@ -12,8 +12,7 @@ export interface ISlackChannel {
 
 export class SlackReader {
   public static getChannels(): PromiseLike<ISlackChannel[]> {
-    return REST()
-      .path('slack', 'channels')
+    return REST('/slack/channels')
       .get()
       .catch(() => [] as ISlackChannel[]);
   }

--- a/app/scripts/modules/core/src/snapshot/SnapshotReader.ts
+++ b/app/scripts/modules/core/src/snapshot/SnapshotReader.ts
@@ -1,16 +1,14 @@
-
-
 import { API } from 'core/api';
 import { ISnapshot } from 'core/domain';
 
 export class SnapshotReader {
   public static getSnapshotHistory(application: string, account: string, params = {}): PromiseLike<ISnapshot[]> {
-    return API.one('applications')
-      .one(application)
-      .one('snapshots')
-      .one(account)
-      .one('history')
-      .withParams(params)
-      .getList();
+    return API.path('applications')
+      .path(application)
+      .path('snapshots')
+      .path(account)
+      .path('history')
+      .query(params)
+      .get();
   }
 }

--- a/app/scripts/modules/core/src/snapshot/SnapshotReader.ts
+++ b/app/scripts/modules/core/src/snapshot/SnapshotReader.ts
@@ -3,6 +3,6 @@ import { ISnapshot } from 'core/domain';
 
 export class SnapshotReader {
   public static getSnapshotHistory(application: string, account: string, params = {}): PromiseLike<ISnapshot[]> {
-    return REST().path('applications', application, 'snapshots', account, 'history').query(params).get();
+    return REST('/applications').path(application, 'snapshots', account, 'history').query(params).get();
   }
 }

--- a/app/scripts/modules/core/src/snapshot/SnapshotReader.ts
+++ b/app/scripts/modules/core/src/snapshot/SnapshotReader.ts
@@ -1,8 +1,8 @@
-import { API } from 'core/api';
+import { REST } from 'core/api';
 import { ISnapshot } from 'core/domain';
 
 export class SnapshotReader {
   public static getSnapshotHistory(application: string, account: string, params = {}): PromiseLike<ISnapshot[]> {
-    return API.path('applications', application, 'snapshots', account, 'history').query(params).get();
+    return REST().path('applications', application, 'snapshots', account, 'history').query(params).get();
   }
 }

--- a/app/scripts/modules/core/src/snapshot/SnapshotReader.ts
+++ b/app/scripts/modules/core/src/snapshot/SnapshotReader.ts
@@ -3,12 +3,6 @@ import { ISnapshot } from 'core/domain';
 
 export class SnapshotReader {
   public static getSnapshotHistory(application: string, account: string, params = {}): PromiseLike<ISnapshot[]> {
-    return API.path('applications')
-      .path(application)
-      .path('snapshots')
-      .path(account)
-      .path('history')
-      .query(params)
-      .get();
+    return API.path('applications', application, 'snapshots', account, 'history').query(params).get();
   }
 }

--- a/app/scripts/modules/core/src/storage/StorageAccountReader.ts
+++ b/app/scripts/modules/core/src/storage/StorageAccountReader.ts
@@ -1,9 +1,7 @@
-
-
 import { API } from 'core/api/ApiService';
 
 export class StorageAccountReader {
   public static getStorageAccounts(): PromiseLike<string[]> {
-    return API.one('storage').get();
+    return API.path('storage').get();
   }
 }

--- a/app/scripts/modules/core/src/storage/StorageAccountReader.ts
+++ b/app/scripts/modules/core/src/storage/StorageAccountReader.ts
@@ -1,7 +1,7 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 
 export class StorageAccountReader {
   public static getStorageAccounts(): PromiseLike<string[]> {
-    return API.path('storage').get();
+    return REST().path('storage').get();
   }
 }

--- a/app/scripts/modules/core/src/storage/StorageAccountReader.ts
+++ b/app/scripts/modules/core/src/storage/StorageAccountReader.ts
@@ -2,6 +2,6 @@ import { REST } from 'core/api/ApiService';
 
 export class StorageAccountReader {
   public static getStorageAccounts(): PromiseLike<string[]> {
-    return REST().path('storage').get();
+    return REST('/storage').get();
   }
 }

--- a/app/scripts/modules/core/src/subnet/subnet.read.service.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { ISubnet } from 'core/domain';
 
 export class SubnetReader {
@@ -8,7 +8,8 @@ export class SubnetReader {
     if (this.cache) {
       return this.cache;
     }
-    this.cache = API.path('subnets')
+    this.cache = REST()
+      .path('subnets')
       .get()
       .then((subnets: ISubnet[]) => {
         subnets.forEach((subnet: ISubnet) => {
@@ -24,7 +25,7 @@ export class SubnetReader {
   }
 
   public static listSubnetsByProvider(cloudProvider: string): PromiseLike<ISubnet[]> {
-    return API.path('subnets', cloudProvider).get();
+    return REST().path('subnets', cloudProvider).get();
   }
 
   public static getSubnetByIdAndProvider(subnetId: string, cloudProvider = 'aws'): PromiseLike<ISubnet> {

--- a/app/scripts/modules/core/src/subnet/subnet.read.service.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.ts
@@ -8,8 +8,7 @@ export class SubnetReader {
     if (this.cache) {
       return this.cache;
     }
-    this.cache = REST()
-      .path('subnets')
+    this.cache = REST('/subnets')
       .get()
       .then((subnets: ISubnet[]) => {
         subnets.forEach((subnet: ISubnet) => {
@@ -25,7 +24,7 @@ export class SubnetReader {
   }
 
   public static listSubnetsByProvider(cloudProvider: string): PromiseLike<ISubnet[]> {
-    return REST().path('subnets', cloudProvider).get();
+    return REST('/subnets').path(cloudProvider).get();
   }
 
   public static getSubnetByIdAndProvider(subnetId: string, cloudProvider = 'aws'): PromiseLike<ISubnet> {

--- a/app/scripts/modules/core/src/subnet/subnet.read.service.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.ts
@@ -1,4 +1,3 @@
-
 import { API } from 'core/api/ApiService';
 import { ISubnet } from 'core/domain';
 
@@ -9,8 +8,8 @@ export class SubnetReader {
     if (this.cache) {
       return this.cache;
     }
-    this.cache = API.one('subnets')
-      .getList()
+    this.cache = API.path('subnets')
+      .get()
       .then((subnets: ISubnet[]) => {
         subnets.forEach((subnet: ISubnet) => {
           subnet.label = subnet.purpose;
@@ -25,7 +24,7 @@ export class SubnetReader {
   }
 
   public static listSubnetsByProvider(cloudProvider: string): PromiseLike<ISubnet[]> {
-    return API.one('subnets', cloudProvider).getList();
+    return API.path('subnets', cloudProvider).get();
   }
 
   public static getSubnetByIdAndProvider(subnetId: string, cloudProvider = 'aws'): PromiseLike<ISubnet> {

--- a/app/scripts/modules/core/src/task/task.read.service.ts
+++ b/app/scripts/modules/core/src/task/task.read.service.ts
@@ -9,8 +9,8 @@ export class TaskReader {
   private static activeStatuses: string[] = ['RUNNING', 'SUSPENDED', 'NOT_STARTED'];
 
   public static getTasks(applicationName: string, statuses: string[] = []): PromiseLike<ITask[]> {
-    return REST()
-      .path('applications', applicationName, 'tasks')
+    return REST('/applications')
+      .path(applicationName, 'tasks')
       .query({ statuses: statuses.join(',') })
       .get()
       .then((tasks: ITask[]) => {
@@ -24,8 +24,8 @@ export class TaskReader {
   }
 
   public static getTask(taskId: string): PromiseLike<ITask> {
-    return REST()
-      .path('tasks', taskId)
+    return REST('/tasks')
+      .path(taskId)
       .get()
       .then((task: ITask) => {
         this.setTaskProperties(task);

--- a/app/scripts/modules/core/src/task/task.read.service.ts
+++ b/app/scripts/modules/core/src/task/task.read.service.ts
@@ -9,8 +9,7 @@ export class TaskReader {
   private static activeStatuses: string[] = ['RUNNING', 'SUSPENDED', 'NOT_STARTED'];
 
   public static getTasks(applicationName: string, statuses: string[] = []): PromiseLike<ITask[]> {
-    return API.path('applications', applicationName)
-      .path('tasks')
+    return API.path('applications', applicationName, 'tasks')
       .query({ statuses: statuses.join(',') })
       .get()
       .then((tasks: ITask[]) => {

--- a/app/scripts/modules/core/src/task/task.read.service.ts
+++ b/app/scripts/modules/core/src/task/task.read.service.ts
@@ -1,7 +1,7 @@
 import { $log, $q, $timeout } from 'ngimport';
 import { Subject } from 'rxjs';
 
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { OrchestratedItemTransformer } from 'core/orchestratedItem/orchestratedItem.transformer';
 import { ITask } from 'core/domain';
 
@@ -9,7 +9,8 @@ export class TaskReader {
   private static activeStatuses: string[] = ['RUNNING', 'SUSPENDED', 'NOT_STARTED'];
 
   public static getTasks(applicationName: string, statuses: string[] = []): PromiseLike<ITask[]> {
-    return API.path('applications', applicationName, 'tasks')
+    return REST()
+      .path('applications', applicationName, 'tasks')
       .query({ statuses: statuses.join(',') })
       .get()
       .then((tasks: ITask[]) => {
@@ -23,7 +24,8 @@ export class TaskReader {
   }
 
   public static getTask(taskId: string): PromiseLike<ITask> {
-    return API.path('tasks', taskId)
+    return REST()
+      .path('tasks', taskId)
       .get()
       .then((task: ITask) => {
         this.setTaskProperties(task);

--- a/app/scripts/modules/core/src/task/task.read.service.ts
+++ b/app/scripts/modules/core/src/task/task.read.service.ts
@@ -11,7 +11,8 @@ export class TaskReader {
   public static getTasks(applicationName: string, statuses: string[] = []): PromiseLike<ITask[]> {
     return API.path('applications', applicationName)
       .path('tasks')
-      .get({ statuses: statuses.join(',') })
+      .query({ statuses: statuses.join(',') })
+      .get()
       .then((tasks: ITask[]) => {
         tasks.forEach((task) => this.setTaskProperties(task));
         return tasks.filter((task) => !task.getValueFor('dryRun'));

--- a/app/scripts/modules/core/src/task/task.read.service.ts
+++ b/app/scripts/modules/core/src/task/task.read.service.ts
@@ -9,9 +9,9 @@ export class TaskReader {
   private static activeStatuses: string[] = ['RUNNING', 'SUSPENDED', 'NOT_STARTED'];
 
   public static getTasks(applicationName: string, statuses: string[] = []): PromiseLike<ITask[]> {
-    return API.one('applications', applicationName)
-      .all('tasks')
-      .getList({ statuses: statuses.join(',') })
+    return API.path('applications', applicationName)
+      .path('tasks')
+      .get({ statuses: statuses.join(',') })
       .then((tasks: ITask[]) => {
         tasks.forEach((task) => this.setTaskProperties(task));
         return tasks.filter((task) => !task.getValueFor('dryRun'));
@@ -23,7 +23,7 @@ export class TaskReader {
   }
 
   public static getTask(taskId: string): PromiseLike<ITask> {
-    return API.one('tasks', taskId)
+    return API.path('tasks', taskId)
       .get()
       .then((task: ITask) => {
         this.setTaskProperties(task);

--- a/app/scripts/modules/core/src/task/task.write.service.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.ts
@@ -1,4 +1,4 @@
-import { API } from 'core/api/ApiService';
+import { REST } from 'core/api/ApiService';
 import { ITask } from '../domain';
 import { TaskReader } from './task.read.service';
 import { ITaskCommand } from './taskExecutor';
@@ -10,11 +10,12 @@ export interface ITaskCreateResult {
 
 export class TaskWriter {
   public static postTaskCommand(taskCommand: ITaskCommand): PromiseLike<ITaskCreateResult> {
-    return API.path('tasks').post(taskCommand);
+    return REST().path('tasks').post(taskCommand);
   }
 
   public static cancelTask(taskId: string): PromiseLike<ITask> {
-    return API.path('tasks', taskId, 'cancel')
+    return REST()
+      .path('tasks', taskId, 'cancel')
       .put()
       .then(() =>
         TaskReader.getTask(taskId).then((task) =>

--- a/app/scripts/modules/core/src/task/task.write.service.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.ts
@@ -10,12 +10,12 @@ export interface ITaskCreateResult {
 
 export class TaskWriter {
   public static postTaskCommand(taskCommand: ITaskCommand): PromiseLike<ITaskCreateResult> {
-    return REST().path('tasks').post(taskCommand);
+    return REST('/tasks').post(taskCommand);
   }
 
   public static cancelTask(taskId: string): PromiseLike<ITask> {
-    return REST()
-      .path('tasks', taskId, 'cancel')
+    return REST('/tasks')
+      .path(taskId, 'cancel')
       .put()
       .then(() =>
         TaskReader.getTask(taskId).then((task) =>

--- a/app/scripts/modules/core/src/task/task.write.service.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.ts
@@ -14,8 +14,7 @@ export class TaskWriter {
   }
 
   public static cancelTask(taskId: string): PromiseLike<ITask> {
-    return API.path('tasks')
-      .path(taskId, 'cancel')
+    return API.path('tasks', taskId, 'cancel')
       .put()
       .then(() =>
         TaskReader.getTask(taskId).then((task) =>

--- a/app/scripts/modules/core/src/task/task.write.service.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.ts
@@ -10,12 +10,12 @@ export interface ITaskCreateResult {
 
 export class TaskWriter {
   public static postTaskCommand(taskCommand: ITaskCommand): PromiseLike<ITaskCreateResult> {
-    return API.all('tasks').post(taskCommand);
+    return API.path('tasks').post(taskCommand);
   }
 
   public static cancelTask(taskId: string): PromiseLike<ITask> {
-    return API.all('tasks')
-      .one(taskId, 'cancel')
+    return API.path('tasks')
+      .path(taskId, 'cancel')
       .put()
       .then(() =>
         TaskReader.getTask(taskId).then((task) =>

--- a/app/scripts/modules/dcos/image/image.reader.js
+++ b/app/scripts/modules/dcos/image/image.reader.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 import { module } from 'angular';
 
@@ -8,7 +8,8 @@ export const DCOS_IMAGE_IMAGE_READER = 'spinnaker.dcos.image.reader';
 export const name = DCOS_IMAGE_IMAGE_READER; // for backwards compatibility
 module(DCOS_IMAGE_IMAGE_READER, []).factory('dcosImageReader', function () {
   function findImages(params) {
-    return API.path('images', 'find')
+    return REST()
+      .path('images', 'find')
       .query(params)
       .get()
       .then(

--- a/app/scripts/modules/dcos/image/image.reader.js
+++ b/app/scripts/modules/dcos/image/image.reader.js
@@ -8,8 +8,7 @@ export const DCOS_IMAGE_IMAGE_READER = 'spinnaker.dcos.image.reader';
 export const name = DCOS_IMAGE_IMAGE_READER; // for backwards compatibility
 module(DCOS_IMAGE_IMAGE_READER, []).factory('dcosImageReader', function () {
   function findImages(params) {
-    return REST()
-      .path('images', 'find')
+    return REST('/images/find')
       .query(params)
       .get()
       .then(

--- a/app/scripts/modules/dcos/image/image.reader.js
+++ b/app/scripts/modules/dcos/image/image.reader.js
@@ -8,8 +8,8 @@ export const DCOS_IMAGE_IMAGE_READER = 'spinnaker.dcos.image.reader';
 export const name = DCOS_IMAGE_IMAGE_READER; // for backwards compatibility
 module(DCOS_IMAGE_IMAGE_READER, []).factory('dcosImageReader', function () {
   function findImages(params) {
-    return API.all('images', 'find')
-      .getList(params)
+    return API.path('images', 'find')
+      .get(params)
       .then(
         function (results) {
           return results;

--- a/app/scripts/modules/dcos/image/image.reader.js
+++ b/app/scripts/modules/dcos/image/image.reader.js
@@ -9,7 +9,8 @@ export const name = DCOS_IMAGE_IMAGE_READER; // for backwards compatibility
 module(DCOS_IMAGE_IMAGE_READER, []).factory('dcosImageReader', function () {
   function findImages(params) {
     return API.path('images', 'find')
-      .get(params)
+      .query(params)
+      .get()
       .then(
         function (results) {
           return results;

--- a/app/scripts/modules/docker/src/image/DockerImageReader.ts
+++ b/app/scripts/modules/docker/src/image/DockerImageReader.ts
@@ -21,7 +21,7 @@ export class DockerImageReader {
 
   public static findImages(params: IFindImageParams): PromiseLike<IDockerImage[]> {
     return RetryService.buildRetrySequence<IDockerImage[]>(
-      () => API.path('images', 'find').get(params),
+      () => API.path('images', 'find').query(params).get(),
       (results: IDockerImage[]) => results.length > 0,
       10,
       1000,
@@ -32,7 +32,7 @@ export class DockerImageReader {
 
   public static findTags(params: IFindTagsParams): PromiseLike<string[]> {
     return RetryService.buildRetrySequence<string[]>(
-      () => API.path('images', 'tags').get(params),
+      () => API.path('images', 'tags').query(params).get(),
       (results: string[]) => results.length > 0,
       10,
       1000,

--- a/app/scripts/modules/docker/src/image/DockerImageReader.ts
+++ b/app/scripts/modules/docker/src/image/DockerImageReader.ts
@@ -9,10 +9,7 @@ export interface IDockerImage extends IImage {
 
 export class DockerImageReader {
   public static getImage(imageName: string, region: string, credentials: string): PromiseLike<IDockerImage> {
-    return API.path('images')
-      .path(credentials)
-      .path(region)
-      .path(imageName)
+    return API.path('images', credentials, region, imageName)
       .query({ provider: 'docker' })
       .get()
       .then((results: IDockerImage[]) => (results && results.length ? results[0] : null))

--- a/app/scripts/modules/docker/src/image/DockerImageReader.ts
+++ b/app/scripts/modules/docker/src/image/DockerImageReader.ts
@@ -9,8 +9,8 @@ export interface IDockerImage extends IImage {
 
 export class DockerImageReader {
   public static getImage(imageName: string, region: string, credentials: string): PromiseLike<IDockerImage> {
-    return REST()
-      .path('images', credentials, region, imageName)
+    return REST('/images')
+      .path(credentials, region, imageName)
       .query({ provider: 'docker' })
       .get()
       .then((results: IDockerImage[]) => (results && results.length ? results[0] : null))
@@ -19,7 +19,7 @@ export class DockerImageReader {
 
   public static findImages(params: IFindImageParams): PromiseLike<IDockerImage[]> {
     return RetryService.buildRetrySequence<IDockerImage[]>(
-      () => REST().path('images', 'find').query(params).get(),
+      () => REST('/images/find').query(params).get(),
       (results: IDockerImage[]) => results.length > 0,
       10,
       1000,
@@ -30,7 +30,7 @@ export class DockerImageReader {
 
   public static findTags(params: IFindTagsParams): PromiseLike<string[]> {
     return RetryService.buildRetrySequence<string[]>(
-      () => REST().path('images', 'tags').query(params).get(),
+      () => REST('/images/tags').query(params).get(),
       (results: string[]) => results.length > 0,
       10,
       1000,

--- a/app/scripts/modules/docker/src/image/DockerImageReader.ts
+++ b/app/scripts/modules/docker/src/image/DockerImageReader.ts
@@ -1,4 +1,4 @@
-import { API, IFindImageParams, IFindTagsParams, IImage, RetryService } from '@spinnaker/core';
+import { REST, IFindImageParams, IFindTagsParams, IImage, RetryService } from '@spinnaker/core';
 
 export interface IDockerImage extends IImage {
   account: string;
@@ -9,7 +9,8 @@ export interface IDockerImage extends IImage {
 
 export class DockerImageReader {
   public static getImage(imageName: string, region: string, credentials: string): PromiseLike<IDockerImage> {
-    return API.path('images', credentials, region, imageName)
+    return REST()
+      .path('images', credentials, region, imageName)
       .query({ provider: 'docker' })
       .get()
       .then((results: IDockerImage[]) => (results && results.length ? results[0] : null))
@@ -18,7 +19,7 @@ export class DockerImageReader {
 
   public static findImages(params: IFindImageParams): PromiseLike<IDockerImage[]> {
     return RetryService.buildRetrySequence<IDockerImage[]>(
-      () => API.path('images', 'find').query(params).get(),
+      () => REST().path('images', 'find').query(params).get(),
       (results: IDockerImage[]) => results.length > 0,
       10,
       1000,
@@ -29,7 +30,7 @@ export class DockerImageReader {
 
   public static findTags(params: IFindTagsParams): PromiseLike<string[]> {
     return RetryService.buildRetrySequence<string[]>(
-      () => API.path('images', 'tags').query(params).get(),
+      () => REST().path('images', 'tags').query(params).get(),
       (results: string[]) => results.length > 0,
       10,
       1000,

--- a/app/scripts/modules/docker/src/image/DockerImageReader.ts
+++ b/app/scripts/modules/docker/src/image/DockerImageReader.ts
@@ -1,5 +1,3 @@
-
-
 import { API, IFindImageParams, IFindTagsParams, IImage, RetryService } from '@spinnaker/core';
 
 export interface IDockerImage extends IImage {
@@ -11,11 +9,11 @@ export interface IDockerImage extends IImage {
 
 export class DockerImageReader {
   public static getImage(imageName: string, region: string, credentials: string): PromiseLike<IDockerImage> {
-    return API.all('images')
-      .one(credentials)
-      .one(region)
-      .one(imageName)
-      .withParams({ provider: 'docker' })
+    return API.path('images')
+      .path(credentials)
+      .path(region)
+      .path(imageName)
+      .query({ provider: 'docker' })
       .get()
       .then((results: IDockerImage[]) => (results && results.length ? results[0] : null))
       .catch((): IDockerImage => null);
@@ -23,7 +21,7 @@ export class DockerImageReader {
 
   public static findImages(params: IFindImageParams): PromiseLike<IDockerImage[]> {
     return RetryService.buildRetrySequence<IDockerImage[]>(
-      () => API.all('images', 'find').getList(params),
+      () => API.path('images', 'find').get(params),
       (results: IDockerImage[]) => results.length > 0,
       10,
       1000,
@@ -34,7 +32,7 @@ export class DockerImageReader {
 
   public static findTags(params: IFindTagsParams): PromiseLike<string[]> {
     return RetryService.buildRetrySequence<string[]>(
-      () => API.all('images', 'tags').getList(params),
+      () => API.path('images', 'tags').get(params),
       (results: string[]) => results.length > 0,
       10,
       1000,

--- a/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
@@ -1,11 +1,11 @@
 import { module } from 'angular';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 import { IEcsClusterDescriptor } from './IEcsCluster';
 
 export class EcsClusterReader {
   public listClusters(): PromiseLike<IEcsClusterDescriptor[]> {
-    return API.path('ecs', 'ecsClusters').get();
+    return REST().path('ecs', 'ecsClusters').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
@@ -5,7 +5,7 @@ import { IEcsClusterDescriptor } from './IEcsCluster';
 
 export class EcsClusterReader {
   public listClusters(): PromiseLike<IEcsClusterDescriptor[]> {
-    return API.all('ecs').all('ecsClusters').getList();
+    return API.path('ecs').path('ecsClusters').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
@@ -5,7 +5,7 @@ import { IEcsClusterDescriptor } from './IEcsCluster';
 
 export class EcsClusterReader {
   public listClusters(): PromiseLike<IEcsClusterDescriptor[]> {
-    return API.path('ecs').path('ecsClusters').get();
+    return API.path('ecs', 'ecsClusters').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
@@ -5,7 +5,7 @@ import { IEcsClusterDescriptor } from './IEcsCluster';
 
 export class EcsClusterReader {
   public listClusters(): PromiseLike<IEcsClusterDescriptor[]> {
-    return REST().path('ecs', 'ecsClusters').get();
+    return REST('/ecs/ecsClusters').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/iamRoles/iamRole.read.service.ts
+++ b/app/scripts/modules/ecs/src/iamRoles/iamRole.read.service.ts
@@ -5,7 +5,7 @@ import { IRoleDescriptor } from './IRole';
 
 export class IamRoleReader {
   public listRoles(provider: string): PromiseLike<IRoleDescriptor[]> {
-    return API.path('roles').path(provider).get();
+    return API.path('roles', provider).get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/iamRoles/iamRole.read.service.ts
+++ b/app/scripts/modules/ecs/src/iamRoles/iamRole.read.service.ts
@@ -5,7 +5,7 @@ import { IRoleDescriptor } from './IRole';
 
 export class IamRoleReader {
   public listRoles(provider: string): PromiseLike<IRoleDescriptor[]> {
-    return API.all('roles').all(provider).getList();
+    return API.path('roles').path(provider).get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/iamRoles/iamRole.read.service.ts
+++ b/app/scripts/modules/ecs/src/iamRoles/iamRole.read.service.ts
@@ -1,11 +1,11 @@
 import { module } from 'angular';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 import { IRoleDescriptor } from './IRole';
 
 export class IamRoleReader {
   public listRoles(provider: string): PromiseLike<IRoleDescriptor[]> {
-    return API.path('roles', provider).get();
+    return REST().path('roles', provider).get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/iamRoles/iamRole.read.service.ts
+++ b/app/scripts/modules/ecs/src/iamRoles/iamRole.read.service.ts
@@ -5,7 +5,7 @@ import { IRoleDescriptor } from './IRole';
 
 export class IamRoleReader {
   public listRoles(provider: string): PromiseLike<IRoleDescriptor[]> {
-    return REST().path('roles', provider).get();
+    return REST('/roles').path(provider).get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/metricAlarm/metricAlarm.read.service.ts
+++ b/app/scripts/modules/ecs/src/metricAlarm/metricAlarm.read.service.ts
@@ -5,7 +5,7 @@ import { IMetricAlarmDescriptor } from './MetricAlarm';
 
 export class MetricAlarmReader {
   public listMetricAlarms(): PromiseLike<IMetricAlarmDescriptor[]> {
-    return API.path('ecs').path('cloudMetrics').path('alarms').get();
+    return API.path('ecs', 'cloudMetrics', 'alarms').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/metricAlarm/metricAlarm.read.service.ts
+++ b/app/scripts/modules/ecs/src/metricAlarm/metricAlarm.read.service.ts
@@ -5,7 +5,7 @@ import { IMetricAlarmDescriptor } from './MetricAlarm';
 
 export class MetricAlarmReader {
   public listMetricAlarms(): PromiseLike<IMetricAlarmDescriptor[]> {
-    return REST().path('ecs', 'cloudMetrics', 'alarms').get();
+    return REST('/ecs/cloudMetrics/alarms').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/metricAlarm/metricAlarm.read.service.ts
+++ b/app/scripts/modules/ecs/src/metricAlarm/metricAlarm.read.service.ts
@@ -5,7 +5,7 @@ import { IMetricAlarmDescriptor } from './MetricAlarm';
 
 export class MetricAlarmReader {
   public listMetricAlarms(): PromiseLike<IMetricAlarmDescriptor[]> {
-    return API.all('ecs').all('cloudMetrics').all('alarms').getList();
+    return API.path('ecs').path('cloudMetrics').path('alarms').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/metricAlarm/metricAlarm.read.service.ts
+++ b/app/scripts/modules/ecs/src/metricAlarm/metricAlarm.read.service.ts
@@ -1,11 +1,11 @@
 import { module } from 'angular';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 import { IMetricAlarmDescriptor } from './MetricAlarm';
 
 export class MetricAlarmReader {
   public listMetricAlarms(): PromiseLike<IMetricAlarmDescriptor[]> {
-    return API.path('ecs', 'cloudMetrics', 'alarms').get();
+    return REST().path('ecs', 'cloudMetrics', 'alarms').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/secrets/secret.read.service.ts
+++ b/app/scripts/modules/ecs/src/secrets/secret.read.service.ts
@@ -1,11 +1,11 @@
 import { module } from 'angular';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 import { ISecretDescriptor } from './ISecret';
 
 export class SecretReader {
   public listSecrets(): PromiseLike<ISecretDescriptor[]> {
-    return API.path('ecs', 'secrets').get();
+    return REST().path('ecs', 'secrets').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/secrets/secret.read.service.ts
+++ b/app/scripts/modules/ecs/src/secrets/secret.read.service.ts
@@ -5,7 +5,7 @@ import { ISecretDescriptor } from './ISecret';
 
 export class SecretReader {
   public listSecrets(): PromiseLike<ISecretDescriptor[]> {
-    return API.all('ecs').all('secrets').getList();
+    return API.path('ecs').path('secrets').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/secrets/secret.read.service.ts
+++ b/app/scripts/modules/ecs/src/secrets/secret.read.service.ts
@@ -5,7 +5,7 @@ import { ISecretDescriptor } from './ISecret';
 
 export class SecretReader {
   public listSecrets(): PromiseLike<ISecretDescriptor[]> {
-    return API.path('ecs').path('secrets').get();
+    return API.path('ecs', 'secrets').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/secrets/secret.read.service.ts
+++ b/app/scripts/modules/ecs/src/secrets/secret.read.service.ts
@@ -5,7 +5,7 @@ import { ISecretDescriptor } from './ISecret';
 
 export class SecretReader {
   public listSecrets(): PromiseLike<ISecretDescriptor[]> {
-    return REST().path('ecs', 'secrets').get();
+    return REST('/ecs/secrets').get();
   }
 }
 

--- a/app/scripts/modules/ecs/src/serverGroup/events/serverGroupEventsReader.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/events/serverGroupEventsReader.service.ts
@@ -1,4 +1,3 @@
-
 import { $log } from 'ngimport';
 
 import { API, IServerGroup } from '@spinnaker/core';
@@ -12,17 +11,17 @@ export interface IEventDescription {
 
 export class ServerGroupEventsReader {
   public static getEvents(serverGroup: IServerGroup): PromiseLike<IEventDescription[]> {
-    return API.one('applications')
-      .one(serverGroup.app)
-      .one('serverGroups')
-      .all(serverGroup.account)
-      .one(serverGroup.name)
-      .all('events')
-      .withParams({
+    return API.path('applications')
+      .path(serverGroup.app)
+      .path('serverGroups')
+      .path(serverGroup.account)
+      .path(serverGroup.name)
+      .path('events')
+      .query({
         region: serverGroup.region,
         provider: serverGroup.cloudProvider,
       })
-      .getList()
+      .get()
       .catch((error: any): any[] => {
         $log.error(error, 'error retrieving events');
         return [];

--- a/app/scripts/modules/ecs/src/serverGroup/events/serverGroupEventsReader.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/events/serverGroupEventsReader.service.ts
@@ -11,12 +11,7 @@ export interface IEventDescription {
 
 export class ServerGroupEventsReader {
   public static getEvents(serverGroup: IServerGroup): PromiseLike<IEventDescription[]> {
-    return API.path('applications')
-      .path(serverGroup.app)
-      .path('serverGroups')
-      .path(serverGroup.account)
-      .path(serverGroup.name)
-      .path('events')
+    return API.path('applications', serverGroup.app, 'serverGroups', serverGroup.account, serverGroup.name, 'events')
       .query({
         region: serverGroup.region,
         provider: serverGroup.cloudProvider,

--- a/app/scripts/modules/ecs/src/serverGroup/events/serverGroupEventsReader.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/events/serverGroupEventsReader.service.ts
@@ -11,8 +11,8 @@ export interface IEventDescription {
 
 export class ServerGroupEventsReader {
   public static getEvents(serverGroup: IServerGroup): PromiseLike<IEventDescription[]> {
-    return REST()
-      .path('applications', serverGroup.app, 'serverGroups', serverGroup.account, serverGroup.name, 'events')
+    return REST('/applications')
+      .path(serverGroup.app, 'serverGroups', serverGroup.account, serverGroup.name, 'events')
       .query({
         region: serverGroup.region,
         provider: serverGroup.cloudProvider,

--- a/app/scripts/modules/ecs/src/serverGroup/events/serverGroupEventsReader.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/events/serverGroupEventsReader.service.ts
@@ -1,6 +1,6 @@
 import { $log } from 'ngimport';
 
-import { API, IServerGroup } from '@spinnaker/core';
+import { REST, IServerGroup } from '@spinnaker/core';
 
 export interface IEventDescription {
   createdAt: number;
@@ -11,7 +11,8 @@ export interface IEventDescription {
 
 export class ServerGroupEventsReader {
   public static getEvents(serverGroup: IServerGroup): PromiseLike<IEventDescription[]> {
-    return API.path('applications', serverGroup.app, 'serverGroups', serverGroup.account, serverGroup.name, 'events')
+    return REST()
+      .path('applications', serverGroup.app, 'serverGroups', serverGroup.account, serverGroup.name, 'events')
       .query({
         region: serverGroup.region,
         provider: serverGroup.cloudProvider,

--- a/app/scripts/modules/ecs/src/serviceDiscovery/serviceDiscovery.read.service.ts
+++ b/app/scripts/modules/ecs/src/serviceDiscovery/serviceDiscovery.read.service.ts
@@ -3,6 +3,6 @@ import { IServiceDiscoveryRegistryDescriptor } from './IServiceDiscovery';
 
 export class ServiceDiscoveryReader {
   public static listServiceDiscoveryRegistries(): PromiseLike<IServiceDiscoveryRegistryDescriptor[]> {
-    return REST().path('ecs', 'serviceDiscoveryRegistries').get();
+    return REST('/ecs/serviceDiscoveryRegistries').get();
   }
 }

--- a/app/scripts/modules/ecs/src/serviceDiscovery/serviceDiscovery.read.service.ts
+++ b/app/scripts/modules/ecs/src/serviceDiscovery/serviceDiscovery.read.service.ts
@@ -1,9 +1,8 @@
-
 import { API } from '@spinnaker/core';
 import { IServiceDiscoveryRegistryDescriptor } from './IServiceDiscovery';
 
 export class ServiceDiscoveryReader {
   public static listServiceDiscoveryRegistries(): PromiseLike<IServiceDiscoveryRegistryDescriptor[]> {
-    return API.all('ecs').all('serviceDiscoveryRegistries').getList();
+    return API.path('ecs').path('serviceDiscoveryRegistries').get();
   }
 }

--- a/app/scripts/modules/ecs/src/serviceDiscovery/serviceDiscovery.read.service.ts
+++ b/app/scripts/modules/ecs/src/serviceDiscovery/serviceDiscovery.read.service.ts
@@ -1,8 +1,8 @@
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 import { IServiceDiscoveryRegistryDescriptor } from './IServiceDiscovery';
 
 export class ServiceDiscoveryReader {
   public static listServiceDiscoveryRegistries(): PromiseLike<IServiceDiscoveryRegistryDescriptor[]> {
-    return API.path('ecs', 'serviceDiscoveryRegistries').get();
+    return REST().path('ecs', 'serviceDiscoveryRegistries').get();
   }
 }

--- a/app/scripts/modules/ecs/src/serviceDiscovery/serviceDiscovery.read.service.ts
+++ b/app/scripts/modules/ecs/src/serviceDiscovery/serviceDiscovery.read.service.ts
@@ -3,6 +3,6 @@ import { IServiceDiscoveryRegistryDescriptor } from './IServiceDiscovery';
 
 export class ServiceDiscoveryReader {
   public static listServiceDiscoveryRegistries(): PromiseLike<IServiceDiscoveryRegistryDescriptor[]> {
-    return API.path('ecs').path('serviceDiscoveryRegistries').get();
+    return API.path('ecs', 'serviceDiscoveryRegistries').get();
   }
 }

--- a/app/scripts/modules/google/src/backendService/backendService.reader.js
+++ b/app/scripts/modules/google/src/backendService/backendService.reader.js
@@ -17,8 +17,7 @@ module(GOOGLE_BACKENDSERVICE_BACKENDSERVICE_READER, []).factory('gceBackendServi
         return [];
       });
     } else {
-      return REST()
-        .path('search')
+      return REST('/search')
         .useCache(InfrastructureCaches.get('backendServices'))
         .query({ q: '', type: 'backendServices', allowShortQuery: 'true' })
         .get();

--- a/app/scripts/modules/google/src/backendService/backendService.reader.js
+++ b/app/scripts/modules/google/src/backendService/backendService.reader.js
@@ -17,9 +17,9 @@ module(GOOGLE_BACKENDSERVICE_BACKENDSERVICE_READER, []).factory('gceBackendServi
         return [];
       });
     } else {
-      return API.all('search')
+      return API.path('search')
         .useCache(InfrastructureCaches.get('backendServices'))
-        .getList({ q: '', type: 'backendServices', allowShortQuery: 'true' });
+        .get({ q: '', type: 'backendServices', allowShortQuery: 'true' });
     }
   }
 

--- a/app/scripts/modules/google/src/backendService/backendService.reader.js
+++ b/app/scripts/modules/google/src/backendService/backendService.reader.js
@@ -2,7 +2,7 @@
 
 import { module } from 'angular';
 
-import { API, InfrastructureCaches } from '@spinnaker/core';
+import { REST, InfrastructureCaches } from '@spinnaker/core';
 
 export const GOOGLE_BACKENDSERVICE_BACKENDSERVICE_READER = 'spinnaker.deck.gce.backendService.reader.service';
 export const name = GOOGLE_BACKENDSERVICE_BACKENDSERVICE_READER; // for backwards compatibility
@@ -17,7 +17,8 @@ module(GOOGLE_BACKENDSERVICE_BACKENDSERVICE_READER, []).factory('gceBackendServi
         return [];
       });
     } else {
-      return API.path('search')
+      return REST()
+        .path('search')
         .useCache(InfrastructureCaches.get('backendServices'))
         .query({ q: '', type: 'backendServices', allowShortQuery: 'true' })
         .get();

--- a/app/scripts/modules/google/src/backendService/backendService.reader.js
+++ b/app/scripts/modules/google/src/backendService/backendService.reader.js
@@ -19,7 +19,8 @@ module(GOOGLE_BACKENDSERVICE_BACKENDSERVICE_READER, []).factory('gceBackendServi
     } else {
       return API.path('search')
         .useCache(InfrastructureCaches.get('backendServices'))
-        .get({ q: '', type: 'backendServices', allowShortQuery: 'true' });
+        .query({ q: '', type: 'backendServices', allowShortQuery: 'true' })
+        .get();
     }
   }
 

--- a/app/scripts/modules/google/src/image/image.reader.ts
+++ b/app/scripts/modules/google/src/image/image.reader.ts
@@ -1,4 +1,4 @@
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 export interface IGceImage {
   imageName: string;
@@ -6,7 +6,8 @@ export interface IGceImage {
 
 export class GceImageReader {
   public static findImages(params: { account?: string; provider?: string; q?: string }): PromiseLike<IGceImage[]> {
-    return API.path('images', 'find')
+    return REST()
+      .path('images', 'find')
       .query(params)
       .get()
       .catch(() => [] as IGceImage[]);

--- a/app/scripts/modules/google/src/image/image.reader.ts
+++ b/app/scripts/modules/google/src/image/image.reader.ts
@@ -6,8 +6,8 @@ export interface IGceImage {
 
 export class GceImageReader {
   public static findImages(params: { account?: string; provider?: string; q?: string }): PromiseLike<IGceImage[]> {
-    return API.one('images', 'find')
-      .withParams(params)
+    return API.path('images', 'find')
+      .query(params)
       .get()
       .catch(() => [] as IGceImage[]);
   }

--- a/app/scripts/modules/google/src/image/image.reader.ts
+++ b/app/scripts/modules/google/src/image/image.reader.ts
@@ -6,8 +6,7 @@ export interface IGceImage {
 
 export class GceImageReader {
   public static findImages(params: { account?: string; provider?: string; q?: string }): PromiseLike<IGceImage[]> {
-    return REST()
-      .path('images', 'find')
+    return REST('/images/find')
       .query(params)
       .get()
       .catch(() => [] as IGceImage[]);

--- a/app/scripts/modules/oracle/src/image/image.reader.js
+++ b/app/scripts/modules/oracle/src/image/image.reader.js
@@ -17,10 +17,7 @@ module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function () {
   }
 
   function getImage(imageId, region, credentials) {
-    return API.path('images')
-      .path(credentials)
-      .path(region)
-      .path(imageId)
+    return API.path('images', credentials, region, imageId)
       .query({ provider: 'oracle' })
       .get()
       .then(

--- a/app/scripts/modules/oracle/src/image/image.reader.js
+++ b/app/scripts/modules/oracle/src/image/image.reader.js
@@ -2,13 +2,14 @@
 
 import { module } from 'angular';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 export const ORACLE_IMAGE_IMAGE_READER = 'spinnaker.oracle.image.reader';
 export const name = ORACLE_IMAGE_IMAGE_READER; // for backwards compatibility
 module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function () {
   function findImages(params) {
-    return API.path('images', 'find')
+    return REST()
+      .path('images', 'find')
       .query(params)
       .get()
       .catch(function () {
@@ -17,7 +18,8 @@ module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function () {
   }
 
   function getImage(imageId, region, credentials) {
-    return API.path('images', credentials, region, imageId)
+    return REST()
+      .path('images', credentials, region, imageId)
       .query({ provider: 'oracle' })
       .get()
       .then(

--- a/app/scripts/modules/oracle/src/image/image.reader.js
+++ b/app/scripts/modules/oracle/src/image/image.reader.js
@@ -8,8 +8,7 @@ export const ORACLE_IMAGE_IMAGE_READER = 'spinnaker.oracle.image.reader';
 export const name = ORACLE_IMAGE_IMAGE_READER; // for backwards compatibility
 module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function () {
   function findImages(params) {
-    return REST()
-      .path('images', 'find')
+    return REST('/images/find')
       .query(params)
       .get()
       .catch(function () {
@@ -18,8 +17,8 @@ module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function () {
   }
 
   function getImage(imageId, region, credentials) {
-    return REST()
-      .path('images', credentials, region, imageId)
+    return REST('/images')
+      .path(credentials, region, imageId)
       .query({ provider: 'oracle' })
       .get()
       .then(

--- a/app/scripts/modules/oracle/src/image/image.reader.js
+++ b/app/scripts/modules/oracle/src/image/image.reader.js
@@ -8,8 +8,8 @@ export const ORACLE_IMAGE_IMAGE_READER = 'spinnaker.oracle.image.reader';
 export const name = ORACLE_IMAGE_IMAGE_READER; // for backwards compatibility
 module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function () {
   function findImages(params) {
-    return API.one('images', 'find')
-      .withParams(params)
+    return API.path('images', 'find')
+      .query(params)
       .get()
       .catch(function () {
         return [];
@@ -17,11 +17,11 @@ module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function () {
   }
 
   function getImage(imageId, region, credentials) {
-    return API.one('images')
-      .one(credentials)
-      .one(region)
-      .one(imageId)
-      .withParams({ provider: 'oracle' })
+    return API.path('images')
+      .path(credentials)
+      .path(region)
+      .path(imageId)
+      .query({ provider: 'oracle' })
       .get()
       .then(
         function (results) {

--- a/app/scripts/modules/tencentcloud/src/image/image.reader.ts
+++ b/app/scripts/modules/tencentcloud/src/image/image.reader.ts
@@ -36,16 +36,15 @@ export class TencentcloudImageReader {
       return $q.when([{ message: 'Please enter at least 3 characters...', disabled: true }]) as any;
     }
 
-    return REST()
-      .path('images', 'find')
+    return REST('/images/find')
       .query({ ...params, provider: 'tencentcloud' })
       .get()
       .catch(() => [] as ITencentcloudImage[]);
   }
 
   public getImage(name: string, region: string, credentials: string): PromiseLike<ITencentcloudImage> {
-    return REST()
-      .path('images', credentials, region, name)
+    return REST('/images')
+      .path(credentials, region, name)
       .query({ provider: 'tencentcloud' })
       .get()
       .then((results: any[]) => (results && results.length ? results[0] : null))

--- a/app/scripts/modules/tencentcloud/src/image/image.reader.ts
+++ b/app/scripts/modules/tencentcloud/src/image/image.reader.ts
@@ -43,10 +43,7 @@ export class TencentcloudImageReader {
   }
 
   public getImage(name: string, region: string, credentials: string): PromiseLike<ITencentcloudImage> {
-    return API.path('images')
-      .path(credentials)
-      .path(region)
-      .path(name)
+    return API.path('images', credentials, region, name)
       .query({ provider: 'tencentcloud' })
       .get()
       .then((results: any[]) => (results && results.length ? results[0] : null))

--- a/app/scripts/modules/tencentcloud/src/image/image.reader.ts
+++ b/app/scripts/modules/tencentcloud/src/image/image.reader.ts
@@ -1,4 +1,3 @@
-
 import { $q } from 'ngimport';
 
 import { API } from '@spinnaker/core';
@@ -37,18 +36,18 @@ export class TencentcloudImageReader {
       return $q.when([{ message: 'Please enter at least 3 characters...', disabled: true }]) as any;
     }
 
-    return API.one('images', 'find')
-      .withParams({ ...params, provider: 'tencentcloud' })
+    return API.path('images', 'find')
+      .query({ ...params, provider: 'tencentcloud' })
       .get()
       .catch(() => [] as ITencentcloudImage[]);
   }
 
   public getImage(name: string, region: string, credentials: string): PromiseLike<ITencentcloudImage> {
-    return API.one('images')
-      .one(credentials)
-      .one(region)
-      .one(name)
-      .withParams({ provider: 'tencentcloud' })
+    return API.path('images')
+      .path(credentials)
+      .path(region)
+      .path(name)
+      .query({ provider: 'tencentcloud' })
       .get()
       .then((results: any[]) => (results && results.length ? results[0] : null))
       .catch(() => null as ITencentcloudImage);

--- a/app/scripts/modules/tencentcloud/src/image/image.reader.ts
+++ b/app/scripts/modules/tencentcloud/src/image/image.reader.ts
@@ -1,6 +1,6 @@
 import { $q } from 'ngimport';
 
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 export interface ITencentcloudSnapshot {
   diskSize: string;
   diskType: string;
@@ -36,14 +36,16 @@ export class TencentcloudImageReader {
       return $q.when([{ message: 'Please enter at least 3 characters...', disabled: true }]) as any;
     }
 
-    return API.path('images', 'find')
+    return REST()
+      .path('images', 'find')
       .query({ ...params, provider: 'tencentcloud' })
       .get()
       .catch(() => [] as ITencentcloudImage[]);
   }
 
   public getImage(name: string, region: string, credentials: string): PromiseLike<ITencentcloudImage> {
-    return API.path('images', credentials, region, name)
+    return REST()
+      .path('images', credentials, region, name)
       .query({ provider: 'tencentcloud' })
       .get()
       .then((results: any[]) => (results && results.length ? results[0] : null))

--- a/app/scripts/modules/tencentcloud/src/keyPairs/KeyPairsReader.ts
+++ b/app/scripts/modules/tencentcloud/src/keyPairs/KeyPairsReader.ts
@@ -1,14 +1,12 @@
-
-
 import { API } from '@spinnaker/core';
 
 import { IKeyPair } from 'tencentcloud/domain';
 
 export class KeyPairsReader {
   public static listKeyPairs(): PromiseLike<IKeyPair[]> {
-    return API.all('keyPairs')
+    return API.path('keyPairs')
       .useCache()
-      .getList()
+      .get()
       .then((keyPairs: IKeyPair[]) => keyPairs.sort((a, b) => a.keyName.localeCompare(b.keyName)));
   }
 }

--- a/app/scripts/modules/tencentcloud/src/keyPairs/KeyPairsReader.ts
+++ b/app/scripts/modules/tencentcloud/src/keyPairs/KeyPairsReader.ts
@@ -4,8 +4,7 @@ import { IKeyPair } from 'tencentcloud/domain';
 
 export class KeyPairsReader {
   public static listKeyPairs(): PromiseLike<IKeyPair[]> {
-    return REST()
-      .path('keyPairs')
+    return REST('/keyPairs')
       .useCache()
       .get()
       .then((keyPairs: IKeyPair[]) => keyPairs.sort((a, b) => a.keyName.localeCompare(b.keyName)));

--- a/app/scripts/modules/tencentcloud/src/keyPairs/KeyPairsReader.ts
+++ b/app/scripts/modules/tencentcloud/src/keyPairs/KeyPairsReader.ts
@@ -1,10 +1,11 @@
-import { API } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
 
 import { IKeyPair } from 'tencentcloud/domain';
 
 export class KeyPairsReader {
   public static listKeyPairs(): PromiseLike<IKeyPair[]> {
-    return API.path('keyPairs')
+    return REST()
+      .path('keyPairs')
       .useCache()
       .get()
       .then((keyPairs: IKeyPair[]) => keyPairs.sort((a, b) => a.keyName.localeCompare(b.keyName)));

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.10.4",
     "@mdx-js/loader": "^1.6.18",
-    "@spinnaker/eslint-plugin": "1.0.8",
+    "@spinnaker/eslint-plugin": "1.0.10",
     "@spinnaker/mocks": "1.0.7",
     "@storybook/addon-console": "^1.2.2",
     "@storybook/addon-essentials": "^6.0.21",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/eslint-plugin",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "eslint-plugin.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,12 +2514,12 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@spinnaker/eslint-plugin@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@spinnaker/eslint-plugin/-/eslint-plugin-1.0.8.tgz#ae71ac210ae3bfdbb18119ffbf4caed94b745478"
-  integrity sha512-a1XvyHyMBwo9sPji1FnCHJcy38SrBdhCdZoffqBxzTYJmUH9wjy5e+j5rpXjk1jWxDNCWxpnxt2kfpPe2Rso7w==
+"@spinnaker/eslint-plugin@1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@spinnaker/eslint-plugin/-/eslint-plugin-1.0.10.tgz#f79b94716d84fe1656e71e0f92e6f42d80943644"
+  integrity sha512-9EUlp8003G6a4smxnsa3lnuvyV90EHJo3xnSkFOCGgMr/UuckKMtHTafjWF3oBNkbyYL2zb7PHcUJOmJEX9Y6A==
   dependencies:
-    lodash "^4.17.15"
+    lodash "^4.17.20"
 
 "@spinnaker/kayenta@^0.0.107":
   version "0.0.107"
@@ -12673,7 +12673,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1:
+lodash@^4.0.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
This applies the ESLint migration rules from #8761, migrating call sites to the new `REST` api introduced in #8760 

1) Rename methods `one`/`all`/`withParams`/`getList` to `path`/`query`/`get`
2) Migrate from `.data(obj).post()` to `.post(obj)
3) Migrate from `.get(queryParams)` to `.query(queryParams).get()`
4) Migrate from `.path('foo').path(id).path('bar')` to `.path('foo', id, 'bar')`
5) Migrate from `API.path('foo')` to `REST().path('foo')`
6) Migrate from `REST().path('foo', 'bar').get()` to `REST('/foo/bar').get()`