### PR TITLE
feat(ecs): Add basic capacity provider UI 

### DIFF
--- a/app/scripts/modules/ecs/src/ecs.help.ts
+++ b/app/scripts/modules/ecs/src/ecs.help.ts
@@ -73,6 +73,15 @@ const helpContents: { [key: string]: string } = {
     '<p>The port to be used for your service discovery service. Required only for services using bridge or host network mode, and for services using awsvpc network mode and a type SRV DNS record',
   'ecs.serviceDiscoveryContainerName':
     '<p>The container name value, already specified in the task definition, to be used for your service discovery service.</p>',
+  'ecs.computeOptions':
+    '<p>Specify either a <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html" target="_blank">launch type</a> (default) or <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html" target="_blank">capacity providers</a> for running your ECS service.</p>',
+  'ecs.capacityProviderStrategies':
+    '<p>A capacity provider strategy gives you control over how your tasks use one or more capacity providers. See <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html#capacity-providers-concepts" target="_blank">AWS documentation</a> for more details. </p>',
+  'ecs.capacityProviderName': '<p>The short name of the capacity provider.</p>',
+  'ecs.capacityProviderBase':
+    '<p>Designates how many tasks, at a minimum, to run on the specified capacity provider. Only one capacity provider in a capacity provider strategy can have a <em>base</em> defined.</p>',
+  'ecs.capacityProviderWeight':
+    '<p>Designates the relative percentage of the total number of tasks launched that should use the specified capacity provider.</p>',
 };
 
 Object.keys(helpContents).forEach((key) => HelpContentsRegistry.register(key, helpContents[key]));

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
@@ -241,5 +241,19 @@ module(ECS_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_ECS_CONTROLLER, [
     $scope.configureCommand = function (query) {
       return ecsServerGroupConfigurationService.configureCommand($scope.command, query);
     };
+
+    // TODO: Migrate horizontalScaling component to react and move this logic there
+    $scope.capacityProviderState = {
+      useCapacityProviders:
+        $scope.command.capacityProviderStrategies && $scope.command.capacityProviderStrategies.length > 0,
+      updateComputeOption: function (chosenOption) {
+        if (chosenOption == 'launchType') {
+          $scope.command.capacityProviderStrategies = [];
+        } else if (chosenOption == 'capacityProviders') {
+          $scope.command.launchType = '';
+          $scope.command.capacityProviderStrategies = $scope.command.capacityProviderStrategies || [];
+        }
+      },
+    };
   },
 ]);

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
@@ -1,5 +1,104 @@
 <div class="container-fluid form-horizontal">
   <div class="form-group">
+    <div class="col-md-4 sm-label-right">
+      <b>Compute options</b>
+      <help-field key="ecs.computeOptions"></help-field>
+    </div>
+    <div class="col-md-2 radio">
+      <label>
+        <input
+          data-test-id="ServerGroup.computeOptionsLaunchType"
+          type="radio"
+          ng-model="$ctrl.capacityProviderState.useCapacityProviders"
+          ng-value="false"
+          ng-click="$ctrl.capacityProviderState.updateComputeOption('launchType')"
+          id="computeOptionsLaunchType"
+        />
+        Launch type
+      </label>
+    </div>
+    <div class="col-md-1 radio">
+      <label>
+        <input
+          data-test-id="ServerGroup.computeOptionsCapacityProviders"
+          type="radio"
+          ng-model="$ctrl.capacityProviderState.useCapacityProviders"
+          ng-value="true"
+          ng-click="$ctrl.capacityProviderState.updateComputeOption('capacityProviders')"
+          id="computeOptionsCapacityProviders"
+        />
+        Capacity Providers
+      </label>
+    </div>
+  </div>
+
+  <div class="form-group" ng-if="$ctrl.capacityProviderState.useCapacityProviders">
+    <div class="sm-label-left">
+      <b>Capacity Provider Strategies</b>
+      <help-field key="ecs.capacityProviderStrategies"></help-field>
+    </div>
+    <div>
+      <table class="table table-condensed packed tags">
+        <thead>
+          <th style="width: 50%">Provider name <help-field key="ecs.capacityProviderName"></help-field></th>
+          <th style="width: 25%">Base <help-field key="ecs.capacityProviderBase"></help-field></th>
+          <th style="width: 25%">Weight <help-field key="ecs.capacityProviderWeight"></help-field></th>
+        </thead>
+        <tbody>
+          <tr ng-repeat="cp in $ctrl.command.capacityProviderStrategies">
+            <td>
+              <input
+                type="text"
+                data-test-id="capacityProvider.name.{{ $index }}"
+                class="form-control input-sm no-spel"
+                ng-model="cp.capacityProvider"
+              />
+            </td>
+            <td>
+              <input
+                type="text"
+                data-test-id="capacityProvider.base.{{ $index }}"
+                class="form-control input-sm no-spel"
+                ng-model="cp.base"
+              />
+            </td>
+            <td>
+              <input
+                type="text"
+                data-test-id="capacityProvider.weight.{{ $index }}"
+                class="form-control input-sm no-spel"
+                ng-model="cp.weight"
+              />
+            </td>
+            <td>
+              <div class="form-control-static">
+                <a class="btn-link sm-label" ng-click="$ctrl.command.capacityProviderStrategies.splice($index, 1)">
+                  <span class="glyphicon glyphicon-trash"></span>
+                  <span class="sr-only">Remove</span>
+                </a>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="3">
+              <button
+                class="btn btn-block btn-sm add-new"
+                ng-click="$ctrl.command.capacityProviderStrategies.push({})"
+                data-test-id="ServerGroup.addCapacityProvider"
+              >
+                <span class="glyphicon glyphicon-plus-sign"></span>
+                Add New Capacity Provider
+              </button>
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+
+  <div class="form-group" ng-if="!$ctrl.capacityProviderState.useCapacityProviders" style="padding-top: 10px">
     <div class="col-md-5 sm-label-right">
       Launch Type
       <help-field key="ecs.launchtype"></help-field>
@@ -13,6 +112,8 @@
       </ui-select>
     </div>
   </div>
+
+  <hr />
 
   <div class="form-group">
     <div class="col-md-5 sm-label-right">

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.js
@@ -11,6 +11,7 @@ module(ECS_SERVERGROUP_CONFIGURE_WIZARD_HORIZONTALSCALING_HORIZONTALSCALING_COMP
     bindings: {
       command: '=',
       application: '=',
+      capacityProviderState: '=',
     },
     templateUrl: require('./horizontalScaling.component.html'),
   },

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.html
@@ -4,6 +4,7 @@
       <ecs-server-group-horizontal-scaling
         command="command"
         application="application"
+        capacity-provider-state="capacityProviderState"
       ></ecs-server-group-horizontal-scaling>
     </div>
   </div>

--- a/test/functional/cypress/integration/ecs/server_group.spec.js
+++ b/test/functional/cypress/integration/ecs/server_group.spec.js
@@ -153,4 +153,31 @@ describe('amazon ecs: ECSApp Server Group', () => {
     cy.get('[data-test-id="ServerGroupWizard.submitButton"]').click();
     cy.get('[data-test-id="Pipeline.revertChanges"]').click();
   });
+
+  it('edit an existing server group to use capacity providers', () => {
+    cy.visit('#/applications/ecsapp/executions');
+
+    cy.get('a:contains("Configure")').click();
+    cy.get('a:contains("Deploy")').click();
+    cy.get('.glyphicon-edit').click();
+
+    cy.get('[data-test-id="ServerGroup.stack"]').clear().type('edit');
+    cy.get('[data-test-id="ServerGroup.details"]').clear().type('computeOptions');
+
+    cy.get('[data-test-id="ServerGroup.computeOptionsCapacityProviders"]').click();
+    cy.get('[data-test-id="ServerGroup.addCapacityProvider"]').click();
+    cy.get('[data-test-id="capacityProvider.name.0"]').type('FARGATE');
+    cy.get('[data-test-id="capacityProvider.base.0"]').type(1);
+    cy.get('[data-test-id="capacityProvider.weight.0"]').type(2);
+
+    cy.get('[data-test-id="ServerGroupWizard.submitButton"]').click();
+    cy.get('.glyphicon-edit').click();
+
+    cy.get('[data-test-id="capacityProvider.name.0"]').should('have.value', 'FARGATE');
+    cy.get('[data-test-id="capacityProvider.base.0"]').should('have.value', '1');
+    cy.get('[data-test-id="capacityProvider.weight.0"]').should('have.value', '2');
+
+    cy.get('[data-test-id="ServerGroupWizard.submitButton"]').click();
+    cy.get('[data-test-id="Pipeline.revertChanges"]').click();
+  });
 });


### PR DESCRIPTION
Basic UI changes to support https://github.com/spinnaker/spinnaker/issues/5400

* NOTE: Does not (yet) look up capacity providers per cluster and provide them as a drop down. This work is anticipated as a near term enhancement.

* Related PR: https://github.com/spinnaker/clouddriver/pull/5123

## Testing

### UI

* With launch type (default)
![image](https://user-images.githubusercontent.com/34254888/101106022-f148cc80-3583-11eb-9510-c90ceaebacc3.png)

* With capacity provider strategies
![image](https://user-images.githubusercontent.com/34254888/101106060-150c1280-3584-11eb-9868-a1fcdd5fad70.png)



### Deployment:
* Successful deployment w/ https://github.com/spinnaker/clouddriver/pull/5123 : 

![image](https://user-images.githubusercontent.com/34254888/101196468-9d86c380-3615-11eb-9b0a-10db45573246.png)

![image](https://user-images.githubusercontent.com/34254888/101196626-d7f06080-3615-11eb-906f-db47d694f678.png)

