### PR TITLE
feat(core/managed): add pre-deployment events for builds

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -108,9 +108,9 @@ export interface IManagedArtifactVersion {
   lifecycleSteps?: Array<{
     // likely more scopes + types later, but hard-coding to avoid premature abstraction for now
     scope: 'PRE_DEPLOYMENT';
-    type: 'BAKE';
+    type: 'BUILD' | 'BAKE';
     id: string;
-    status: 'NOT_STARTED' | 'RUNNING' | 'SUCCEEDED' | 'FAILED';
+    status: 'NOT_STARTED' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'ABORTED' | 'UNKNOWN';
     startedAt?: string;
     completedAt?: string;
     link?: string;

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -244,7 +244,9 @@ export const ArtifactDetail = ({
   const isPinnedEverywhere = environments.every(({ pinned }) => pinned);
   const isBadEverywhere = environments.every(({ state }) => state === 'vetoed');
   const createdAtTimestamp = useMemo(() => createdAt && DateTime.fromISO(createdAt), [createdAt]);
-  const preDeploymentSteps = lifecycleSteps?.filter(({ scope }) => scope === 'PRE_DEPLOYMENT');
+
+  // These steps come in with chronological ordering, but we need reverse-chronological orddering for display
+  const preDeploymentSteps = lifecycleSteps?.filter(({ scope }) => scope === 'PRE_DEPLOYMENT').reverse();
 
   return (
     <>
@@ -350,7 +352,7 @@ export const ArtifactDetail = ({
               name={environmentName}
               resources={resourcesByEnvironment[environmentName]}
             >
-              <div className="sp-margin-l-right">
+              <div>
                 <EnvironmentCards
                   application={application}
                   environment={environment}
@@ -389,7 +391,7 @@ export const ArtifactDetail = ({
         })}
         {preDeploymentSteps && preDeploymentSteps.length > 0 && (
           <PreDeploymentRow>
-            {lifecycleSteps.map((step) => (
+            {preDeploymentSteps.map((step) => (
               <PreDeploymentStepCard key={step.id} step={step} application={application} reference={reference} />
             ))}
           </PreDeploymentRow>

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -167,13 +167,19 @@ function getArtifactStatuses({ environments, lifecycleSteps }: IManagedArtifactV
   // NOTE: The order in which entries are added to `statuses` is important. The highest priority
   // item must be inserted first.
 
-  const bakeStep = lifecycleSteps?.find(
+  const preDeploymentSteps = lifecycleSteps?.filter(
     ({ scope, type, status }) =>
-      scope === 'PRE_DEPLOYMENT' && type === 'BAKE' && ['RUNNING', 'FAILED'].includes(status),
+      scope === 'PRE_DEPLOYMENT' && ['BUILD', 'BAKE'].includes(type) && ['RUNNING', 'FAILED'].includes(status),
   );
 
-  if (bakeStep) {
-    statuses.push({ iconName: 'bake', appearance: bakeStep.status === 'RUNNING' ? 'progress' : 'error' });
+  if (preDeploymentSteps?.length > 0) {
+    // These steps come in with chronological ordering, but we need reverse-chronological orddering for display
+    preDeploymentSteps.reverse().forEach(({ type, status }) => {
+      statuses.push({
+        iconName: type === 'BUILD' ? 'build' : 'bake',
+        appearance: status === 'RUNNING' ? 'progress' : 'error',
+      });
+    });
   }
 
   const pendingConstraintIcons = new Set<IconNames>();

--- a/app/scripts/modules/core/src/managed/VersionStateCard.tsx
+++ b/app/scripts/modules/core/src/managed/VersionStateCard.tsx
@@ -138,14 +138,17 @@ export const VersionStateCard = memo(
         description={cardAppearanceByState[state].description?.(cardMetadata)}
         actions={
           compareLink && (
-            <Button
+            <a
+              className="nostyle"
+              href={compareLink}
+              target="_blank"
+              rel="noopener noreferrer"
               onClick={() => {
-                window.open(compareLink, '_blank', 'noopener noreferrer');
                 logClick('See changes clicked');
               }}
             >
-              See changes
-            </Button>
+              <Button>See changes</Button>
+            </a>
           )
         }
       />


### PR DESCRIPTION
We recently added support for ['pre-deployment' events](https://github.com/spinnaker/deck/pull/8750), starting with baking. We're now ready to add the same for builds. A couple notable bits that have evolved since the last PR:

- In order to handle the cases that can show up in the build context there's a new status: `ABORTED`. Unfortunately our internal build system (Jenkins) doesn't seem to differentiate between builds that entered this status because of a timeout (bad/error) or because a user manually canceled it (fine/not an error), so we have to be somewhat hand-wavey about this status and our use of colors. For now I've made the decision to show it the same way we show successful builds (neutral color, no badge in the sidebar) because I have a hunch the manual cancellation use case is way more common than timeouts, but either way we're going to be trading something off (i.e. if we treated it as an error we'd be raising the alarm about intentionally canceled builds)
- I added the `UNKNOWN` status for when we can't determine current state, which I've made a warning color (no badge in the sidebar). Not really sure about this and we have zero customer feedback right now so I'm trying not to overthink it


<details>

<summary>Version sidebar</summary>

<img width="352" alt="Screen Shot 2020-12-03 at 10 05 34 AM" src="https://user-images.githubusercontent.com/1850998/101102337-c2c7f300-357d-11eb-8192-d40226b2cc29.png">
<img width="347" alt="Screen Shot 2020-12-03 at 10 09 58 AM" src="https://user-images.githubusercontent.com/1850998/101102384-c5c2e380-357d-11eb-879b-aef8537f43dc.png">


</details>


<details>

<summary>Version details</summary>

<img width="921" alt="Screen Shot 2020-12-03 at 10 07 52 AM" src="https://user-images.githubusercontent.com/1850998/101108694-fa3c9c80-3589-11eb-8fdd-b9db63e7b094.png">
<img width="910" alt="Screen Shot 2020-12-03 at 10 05 19 AM" src="https://user-images.githubusercontent.com/1850998/101108706-00327d80-358a-11eb-9f08-1eeaa78182dd.png">
<img width="927" alt="Screen Shot 2020-12-03 at 10 09 22 AM" src="https://user-images.githubusercontent.com/1850998/101108730-07f22200-358a-11eb-896d-a5f98ca695f9.png">
<img width="917" alt="Screen Shot 2020-12-03 at 10 10 39 AM" src="https://user-images.githubusercontent.com/1850998/101108750-0fb1c680-358a-11eb-8444-30b49777b770.png">
<img width="908" alt="Screen Shot 2020-12-03 at 10 20 51 AM" src="https://user-images.githubusercontent.com/1850998/101108758-14767a80-358a-11eb-9cd0-832b4441a9fe.png">
<img width="914" alt="Screen Shot 2020-12-03 at 10 12 41 AM" src="https://user-images.githubusercontent.com/1850998/101108764-180a0180-358a-11eb-84b3-1f7b3522bb6d.png">
<img width="1145" alt="Screen Shot 2020-12-03 at 9 13 11 AM" src="https://user-images.githubusercontent.com/1850998/101108811-340da300-358a-11eb-8b4f-be9af22869a9.png">



</details>