### PR TITLE
fix(core): Redirecting non-permalinks to permalinks

### DIFF
--- a/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -152,8 +152,7 @@ export class SingleExecutionDetails extends React.Component<
     const { app } = this.props;
     const { execution, pipelineConfig, sortFilter, stateNotFound } = this.state;
 
-    const defaultExecutionParams = { application: app.name, executionId: execution ? execution.id : '' };
-    const executionParams = ReactInjector.$state.params.executionParams || defaultExecutionParams;
+    const executionParams = { application: app.name, pipeline: execution && execution.name };
 
     return (
       <div style={{ width: '100%', paddingTop: 0 }}>
@@ -164,13 +163,15 @@ export class SingleExecutionDetails extends React.Component<
                 <div className="flex-container-h baseline">
                   <h3>
                     <Tooltip value="Back to Executions">
-                      <UISref to="^.executions.execution" params={executionParams}>
+                      <UISref to="^.executions" params={executionParams}>
                         <a className="btn btn-configure">
                           <span className="glyphicon glyphicon glyphicon-circle-arrow-left" />
                         </a>
                       </UISref>
                     </Tooltip>
-                    {execution.name}
+                    <UISref to="^.executions" params={executionParams}>
+                      <a>{execution.name}</a>
+                    </UISref>
                   </h3>
 
                   <div className="form-group checkbox flex-pull-right">

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -203,7 +203,21 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
         if ($state.params.executionId) {
           const executions: IExecution[] = app.executions.data;
           if (executions.every((e) => e.id !== $state.params.executionId)) {
-            $state.go('.^');
+            const detailsState = $state.current.name.replace('executions.execution', 'executionDetails.execution');
+            const capturedParams = {
+              executionId: $state.params.executionId,
+              stage: $state.params.stage,
+              step: $state.params.step,
+              details: $state.params.details,
+            };
+            $state.go('.^', undefined, { location: 'replace' }).then(() => {
+              const { executionService } = ReactInjector;
+              if (capturedParams.executionId) {
+                executionService.getExecution(capturedParams.executionId).then(() => {
+                  $state.go(detailsState, capturedParams);
+                });
+              }
+            });
           }
         }
       },


### PR DESCRIPTION
...but only when they're not found in the `.executions` route.

This addresses a major annoyance in sharing links to executions that are not the most recent (i.e. `Show [2] executions per pipeline`).

### Current behavior
Instead of just navigating up (existing behavior) and dropping the executionId from the route:
1. Lands on `#/applications/myawesomeapp/executions/0425LQQ2020FHQWGHADS`
2. Execution not found in already fetched n most recent executions per pipeline
3. Transition up to parent state (executions): `#/applications/myawesomeapp/executions`

### Proposed behavior
We will instead check if the execution exists at all and if so, forward to the SingleExecutionDetails route:
1. Lands on `#/applications/myawesomeapp/executions/0425LQQ2020FHQWGHADS`
2. Execution not found in already fetched n most recent executions per pipeline
3. Capture execution ID and params
4. Transition up to parent state `#/applications/myawesomeapp/executions` with `location: 'replace'`
5. Check if execution exists and if so, transition again to the SingleExecutionDetails: `#/applications/myawesomeapp/executions/details/0425LQQ2020FHQWGHADS`

### Caveats
Anything that navigates back to the aged out execution `#/applications/myawesomeapp/executions/0425LQQ2020FHQWGHADS` would trigger the forwarding logic again, making it difficult for users to navigate back up to the Executions page, as they would perpetually get forwarded back to the SingleExecutionDetails for that execution.

For this reason, the following changes were also made:
1. Step 4 uses `location: 'replace'` to replace the aged out execution on the history stack. This way, navigating back (browser's back button) would land on `#/applications/myawesomeapp/executions` instead and not get re-forwarded
2. The back icon in the SingleExecutionDetails now transitions up to the parent state `#/applications/myawesomeapp/executions` instead of `#/applications/myawesomeapp/executions/0425LQQ2020FHQWGHADS`, again to prevent getting re-forwarded. For convenience, this also filters down to the pipeline name: `#/applications/myawesomeapp/executions?pipeline=pied+piper`

### Controversial
Change 2 does result in a slight loss in functionality: the ability to
1. Open a permalink in a fresh tab
2. Click the back icon to navigate up to see all executions **with the linked execution selected**

This still works when navigating from an execution to its permalink and back (achieved by using the browser's back button), so the functionality is only lost when opening into a new tab.

Being able to open older executions without having to manually add `/details/` feels like a worthwhile tradeoff, though we could use some extra flags/params to bring that functionality back if we feel strong enough about it.