### PR TITLE
Revert "feat(bake): add UI element for helmChartFilePath to bake mani…

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -283,9 +283,6 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.bake.manifest.overrideExpressionEvaluation':
     '<p>Explicitly evaluate SpEL expressions in overrides just prior to manifest baking. Can be paired with the "Skip SpEL evaluation" option in the Deploy Manifest stage when baking a third-party manifest artifact with expressions not meant for Spinnaker to evaluate as SpEL.</p>',
   'pipeline.config.bake.manifest.templateRenderer': '<p>This is the engine used for rendering your manifest.</p>',
-  'pipeline.config.bake.manifest.helm.chartFilePath': `
-    <p>This is the relative path to the Chart.yaml file within your Git repo.</p>
-    <p>e.g.: <b>helm/my-chart/Chart.yaml</b></p>`,
   'pipeline.config.bake.manifest.helm.rawOverrides':
     'Use <i>--set</i> instead of <i>--set-string</i> when injecting override values. Values injected using <i>--set</i> will be converted to primitive types by Helm.',
   'pipeline.config.bake.manifest.kustomize.filePath': `

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
@@ -6,7 +6,6 @@ import { MapEditor } from 'core/forms';
 import { IArtifact, IExpectedArtifact } from 'core/domain';
 import { excludeAllTypesExcept, ArtifactTypePatterns, StageArtifactSelectorDelegate } from 'core/artifact';
 import { IFormikStageConfigInjectedProps } from '../../FormikStageConfig';
-import { TYPE } from '../../../triggers/artifacts/gitrepo/GitRepoArtifactEditor';
 
 export class BakeHelmConfigForm extends React.Component<IFormikStageConfigInjectedProps> {
   private static readonly excludedArtifactTypes = excludeAllTypesExcept(
@@ -138,16 +137,6 @@ export class BakeHelmConfigForm extends React.Component<IFormikStageConfigInject
           pipeline={this.props.pipeline}
           stage={stage}
         />
-        {this.getInputArtifact(stage, 0).artifact.type == TYPE && (
-          <StageConfigField label=" File" helpKey="pipeline.config.bake.manifest.helm.chartFilePath">
-            <TextInput
-              onChange={(e: React.ChangeEvent<any>) => {
-                this.props.formik.setFieldValue('helmChartFilePath', e.target.value);
-              }}
-              value={stage.helmChartFilePath}
-            />
-          </StageConfigField>
-        )}
         <h4>Overrides</h4>
         {stage.inputArtifacts && stage.inputArtifacts.length > 1 && (
           <div className="row form-group">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
@@ -7,7 +7,7 @@ import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 import { CheckboxInput } from 'core/presentation';
 
-export const TYPE = 'git/repo';
+const TYPE = 'git/repo';
 
 interface IGitRepoArtifactEditorState {
   includesSubPath: boolean;


### PR DESCRIPTION
…fest stage, when using a git/repo artifact for the helm chart (#8751)"

This reverts commit 38b31387459b548d8b44caeee24bbcd251eeedc5.

The logic here is missing a null check, and inputArtifacts have an account property, but
not typically a type, so it takes more work to determine if the selected template artifact
(i.e. the helm chart) is associated with an account that support git/repo artifacts.

The above commit produced the following errors in the javascript console:
```
react-dom.production.min.js:209 TypeError: Cannot read property 'type' of undefined
    at BakeHelmConfigForm_BakeHelmConfigForm.render (BakeHelmConfigForm.tsx:141)
    at gi (react-dom.production.min.js:182)
    at fi (react-dom.production.min.js:181)
    at Rj (react-dom.production.min.js:263)
    at Qj (react-dom.production.min.js:246)
    at Kj (react-dom.production.min.js:246)
    at yj (react-dom.production.min.js:239)
    at react-dom.production.min.js:123
    at exports.unstable_runWithPriority (scheduler.production.min.js:19)
    at cg (react-dom.production.min.js:122)
```

and a Bake (Manifest) Configuration UI like this:
![image](https://user-images.githubusercontent.com/1521148/101534712-69304180-394c-11eb-9750-61928dbf5a9d.png)
