### PR TITLE
fix(core/managed): temporarily hide build pre-deployment events

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -34,6 +34,12 @@ import { isResourceKindSupported } from './resources/resourceRegistry';
 
 import './ArtifactDetail.less';
 
+const SUPPORTED_PRE_DEPLOYMENT_TYPES = [
+  // KLUDGE WARNING: disabling build events temporarily while we get the API in shape
+  // 'BUILD',
+  'BAKE',
+];
+
 function shouldDisplayResource(reference: string, resource: IManagedResourceSummary) {
   return isResourceKindSupported(resource.kind) && reference === resource.artifact?.reference;
 }
@@ -246,7 +252,9 @@ export const ArtifactDetail = ({
   const createdAtTimestamp = useMemo(() => createdAt && DateTime.fromISO(createdAt), [createdAt]);
 
   // These steps come in with chronological ordering, but we need reverse-chronological orddering for display
-  const preDeploymentSteps = lifecycleSteps?.filter(({ scope }) => scope === 'PRE_DEPLOYMENT').reverse();
+  const preDeploymentSteps = lifecycleSteps
+    ?.filter(({ scope, type }) => scope === 'PRE_DEPLOYMENT' && SUPPORTED_PRE_DEPLOYMENT_TYPES.includes(type))
+    .reverse();
 
   return (
     <>

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -169,7 +169,13 @@ function getArtifactStatuses({ environments, lifecycleSteps }: IManagedArtifactV
 
   const preDeploymentSteps = lifecycleSteps?.filter(
     ({ scope, type, status }) =>
-      scope === 'PRE_DEPLOYMENT' && ['BUILD', 'BAKE'].includes(type) && ['RUNNING', 'FAILED'].includes(status),
+      scope === 'PRE_DEPLOYMENT' &&
+      [
+        // KLUDGE WARNING: disabling build events temporarily while we get the API in shape
+        // 'BUILD',
+        'BAKE',
+      ].includes(type) &&
+      ['RUNNING', 'FAILED'].includes(status),
   );
 
   if (preDeploymentSteps?.length > 0) {

--- a/app/scripts/modules/core/src/managed/PreDeploymentStepCard.tsx
+++ b/app/scripts/modules/core/src/managed/PreDeploymentStepCard.tsx
@@ -9,8 +9,6 @@ import { Application } from '../application';
 import { StatusCard } from './StatusCard';
 import { Button } from './Button';
 
-const SUPPORTED_TYPES = ['BUILD', 'BAKE'];
-
 const cardAppearanceByStatus = {
   NOT_STARTED: 'future',
   RUNNING: 'info',
@@ -92,10 +90,6 @@ export interface PreDeploymentStepCardProps {
 
 export const PreDeploymentStepCard = memo(({ step, application, reference }: PreDeploymentStepCardProps) => {
   const { type, status, startedAt, completedAt, link } = step;
-
-  if (!SUPPORTED_TYPES.includes(type)) {
-    return null;
-  }
 
   const { iconName, title } = cardConfigurationByType[type];
 


### PR DESCRIPTION
The API data for build events introduced via #8768 has proved to be a bit wonky in the first iteration, and is going to take a little more implementation time on the Keel side to resolve. Events get stuck in the `RUNNING` status — which looks pretty sketchy/untrustworthy in the Environments UI — so I'm going to temporarily disable them here until we're confident the data will look right.