### PR TITLE
chore(package): core@0.0.536 ecs@0.0.272

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.535",
+  "version": "0.0.536",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.271",
+  "version": "0.0.272",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## core@0.0.536

8a8698145e64a5644045c2e622f214189663b105 fix(core/managed): temporarily hide build pre-deployment events (#8776)
7a723c980fabb5265dbb66251c1ae4c62b2ea01b Revert "feat(bake): add UI element for helmChartFilePath to bake manifest stage, when using a git/repo artifact for the helm chart (#8751)" (#8773)
54097588e543bc62981f35bd19d811be93b0f64b fix(core): Redirecting aged out executions to permalink (#8770)
38b31387459b548d8b44caeee24bbcd251eeedc5 feat(bake): add UI element for helmChartFilePath to bake manifest stage, when using a git/repo artifact for the helm chart (#8751)

## ecs@0.0.272

1e49b1c5171284ddd88b5d0cade785c22c5ea869 feat(ecs): Add basic capacity provider UI (#8767)

PR created via `modules/publish.js`