### PR TITLE
fix(core/pipeline): Fix linking to pipeline execution

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/monitorPipeline/MonitorPipelineStageExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/monitorPipeline/MonitorPipelineStageExecutionDetails.tsx
@@ -47,7 +47,7 @@ export function MonitorPipelineStageExecutionDetails(props: IExecutionDetailsSec
           {statuses.map((status) => {
             return (
               <div key={status.executionId}>
-                <span className={'label label-default label-' + status.status.toLowerCase()}>{status.status}</span>
+                <span className={'label label-default label-' + status.status.toLowerCase()}>{status.status}</span>{' '}
                 <UISref
                   key={status.executionId}
                   to="home.applications.application.pipelines.executionDetails.execution"
@@ -58,9 +58,7 @@ export function MonitorPipelineStageExecutionDetails(props: IExecutionDetailsSec
                   }}
                   options={{ inherit: false, reload: 'home.applications.application.pipelines.executionDetails' }}
                 >
-                  <span>
-                    &nbsp;<a target="_self">{status.executionId}</a>
-                  </span>
+                  <a>{status.executionId}</a>
                 </UISref>{' '}
                 ({status.application})
                 {status.failureMessage && <StageFailureMessage stage={stage} message={status.failureMessage} />}


### PR DESCRIPTION
Wrapping the link with a `span` tag results in the following html and breaks the link.

![image](https://user-images.githubusercontent.com/357832/101708192-9dd1f500-3a41-11eb-8acf-595b2daf747e.png)
