### PR TITLE
feat(manual judgment/deck): Added ability to add roles to manual judgment stage

### DIFF
--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -37,6 +37,17 @@ export class ApplicationReader {
       });
   }
 
+  public static getApplicationPermissions(applicationName: string): PromiseLike < any > {
+      return API.one('applications', applicationName)
+          .withParams({
+              expand: false,
+          })
+          .get()
+          .then((application: Application) => {
+              return application.attributes.permissions;
+          });
+  }
+
   public static getApplication(name: string, expand = true): PromiseLike<Application> {
     return API.one('applications', name)
       .withParams({ expand: expand })

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -356,6 +356,8 @@ const helpContents: { [key: string]: string } = {
       </p>`,
   'pipeline.config.trigger.runAsUser':
     "The current user must have access to the specified service account, and the service account must have access to the current application. Otherwise, you'll receive an 'Access is denied' error.",
+  'pipeline.config.trigger.authorizedUser':
+      "The current user must have the permission to approve the manual judgment stage. Otherwise, you'll not be able continue to the next pipeline stage.",
   'pipeline.config.script.repoUrl':
     '<p>Path to the repo hosting the scripts in Stash. (e.g. <samp>CDL/mimir-scripts</samp>). Leave empty to use the default.</p>',
   'pipeline.config.script.repoBranch':

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.html
@@ -64,6 +64,33 @@
           </ui-select-choices>
         </ui-select>
       </stage-config-field>
+      <render-if-feature feature="fiatEnabled">
+        <stage-config-field
+          label="Authorized Groups"
+          help-key="pipeline.config.trigger.authorizedUser"
+          ng-if="stage.type === 'manualJudgment'"
+          style="margin-bottom: 10px"
+        >
+          <ui-select
+            ng-model="stage.selectedStageRoles"
+            multiple
+            class="form-control input-sm"
+            on-select="updateAvailableStageRoles()"
+            on-remove="updateAvailableStageRoles()"
+          >
+            <ui-select-match>{{$item.name}}</ui-select-match>
+            <ui-select-choices
+              repeat="option.roleId as option in options.stageRoles | anyFieldFilter: {name: $select.search}"
+              ui-disable-choice="!option.available"
+            >
+              <span
+                ng-if="!stage.selectedStageRoles.includes(option.roleId)"
+                ng-bind-html="option.name | highlight: $select.search"
+              ></span>
+            </ui-select-choices>
+          </ui-select>
+        </stage-config-field>
+      </render-if-feature>
     </div>
     <div class="col-md-2 text-right">
       <button

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -18,6 +18,7 @@ import { ReactModal } from 'core/presentation';
 import { PRODUCES_ARTIFACTS_REACT } from './producesArtifacts/ProducesArtifacts';
 import { OVERRRIDE_FAILURE } from './overrideFailure/overrideFailure.module';
 import { OVERRIDE_TIMEOUT_COMPONENT } from './overrideTimeout/overrideTimeout.module';
+import { ApplicationReader } from 'core/application/service/ApplicationReader';
 import { CORE_PIPELINE_CONFIG_STAGES_OPTIONALSTAGE_OPTIONALSTAGE_DIRECTIVE } from './optionalStage/optionalStage.directive';
 import { CORE_PIPELINE_CONFIG_STAGES_FAILONFAILEDEXPRESSIONS_FAILONFAILEDEXPRESSIONS_DIRECTIVE } from './failOnFailedExpressions/failOnFailedExpressions.directive';
 import { CORE_PIPELINE_CONFIG_STAGES_COMMON_STAGECONFIGFIELD_STAGECONFIGFIELD_DIRECTIVE } from './common/stageConfigField/stageConfigField.directive';
@@ -59,10 +60,12 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
     '$templateCache',
     function ($scope, $element, $compile, $controller, $templateCache) {
       let lastStageScope, reactComponentMounted;
-
+      let appPermissions = {};
+      let appRoles = [];
       $scope.options = {
         stageTypes: [],
         selectedStageType: null,
+        stageRoles: [],
       };
 
       AccountService.applicationAccounts($scope.application).then((accounts) => {
@@ -130,6 +133,31 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
             });
           }
         });
+      };
+
+      $scope.getApplicationPermissions = function() {
+          ApplicationReader.getApplicationPermissions($scope.application.name).then(result => {
+              appPermissions = result;
+              if (appPermissions) {
+                  const readArray = appPermissions.READ || [];
+                  const writeArray = appPermissions.WRITE || [];
+                  const executeArray = appPermissions.EXECUTE || [];
+                  appRoles = _.union(readArray, writeArray, executeArray);
+                  appRoles = Array.from(new Set(appRoles));
+                  $scope.updateAvailableStageRoles();
+              }
+          });
+      };
+
+      $scope.updateAvailableStageRoles = function() {
+          $scope.options.stageRoles = appRoles.map(function(value, index) {
+              return {
+                  name: value,
+                  roleId: value,
+                  id: index,
+                  available: true,
+              };
+          });
       };
 
       this.editStageJson = () => {
@@ -301,6 +329,7 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
         });
       };
 
+      $scope.getApplicationPermissions();
       $scope.$on('pipeline-reverted', this.selectStage);
       $scope.$on('pipeline-json-edited', this.selectStage);
       $scope.$watch('stage.type', this.selectStage);


### PR DESCRIPTION
This is part of: spinnaker/spinnaker#4792.

Enhanced stage.html to
Get the roles of the application. Display the roles of the application as a list, only if the stage is Manual Judgment.

Enhanced stage.module.js to
Fetch the permissions of the application from the gate application url. populate the list with only the roles of the application with no duplicates.

Enhanced ApplicationReader.ts to
Fetch the permissions of the application from the gate application url.

Enhanced ManualJudgmentApproval.tsx to
Fetch the roles of the application, stage and the user during the execution. Iterate through each of the user role to check if the role exists in the stage and application. If the role exists in the stage roles added in the manual judgment stage, then we check for role permissions added in the application. If the stage role has 'READ', then we disable the continue button If the stage role has 'WRITE,EXECUTE,CREATE', then we enable the continue button.

Enhanced help.contents.ts file
The current user must have the permission to approve the manual judgment stage. Otherwise, you'll not be able continue to the next pipeline stage.