### PR TITLE
chore(core): Allow cloud provider logos in registry

### DIFF
--- a/app/scripts/modules/core/src/cloudProvider/CloudProviderLogo.tsx
+++ b/app/scripts/modules/core/src/cloudProvider/CloudProviderLogo.tsx
@@ -14,6 +14,7 @@ export interface ICloudProviderLogoProps {
 
 export interface ICloudProviderLogoState {
   tooltip?: string;
+  logo: React.ComponentType<React.SVGProps<HTMLOrSVGElement>>;
 }
 
 export class CloudProviderLogo extends React.Component<ICloudProviderLogoProps, ICloudProviderLogoState> {
@@ -26,9 +27,12 @@ export class CloudProviderLogo extends React.Component<ICloudProviderLogoProps, 
     if (props.showTooltip) {
       return {
         tooltip: CloudProviderRegistry.getValue(this.props.provider, 'name') || this.props.provider,
+        logo: CloudProviderRegistry.getValue(this.props.provider, 'cloudProviderLogo'),
       };
     }
-    return {};
+    return {
+      logo: CloudProviderRegistry.getValue(this.props.provider, 'cloudProviderLogo'),
+    };
   }
 
   public componentWillReceiveProps(nextProps: ICloudProviderLogoProps): void {
@@ -38,19 +42,20 @@ export class CloudProviderLogo extends React.Component<ICloudProviderLogoProps, 
   }
 
   public render(): React.ReactElement<CloudProviderLogo> {
-    const logo = (
-      <span className="cloud-provider-logo">
-        <span
-          className={`icon icon-${this.props.provider}`}
-          style={{ height: this.props.height, width: this.props.width }}
-        />
-      </span>
+    const RegistryLogo = this.state.logo;
+    const ProviderLogo = RegistryLogo ? (
+      <RegistryLogo height={this.props.height} width={this.props.width} />
+    ) : (
+      <span
+        className={`icon icon-${this.props.provider}`}
+        style={{ height: this.props.height, width: this.props.width }}
+      />
     );
 
     if (this.state.tooltip) {
-      return <Tooltip value={this.state.tooltip}>{logo}</Tooltip>;
-    } else {
-      return logo;
+      return <Tooltip value={this.state.tooltip}>{ProviderLogo}</Tooltip>;
     }
+
+    return <span className="cloud-provider-logo">{ProviderLogo}</span>;
   }
 }

--- a/app/scripts/modules/core/src/cloudProvider/CloudProviderLogo.tsx
+++ b/app/scripts/modules/core/src/cloudProvider/CloudProviderLogo.tsx
@@ -17,45 +17,25 @@ export interface ICloudProviderLogoState {
   logo: React.ComponentType<React.SVGProps<HTMLOrSVGElement>>;
 }
 
-export class CloudProviderLogo extends React.Component<ICloudProviderLogoProps, ICloudProviderLogoState> {
-  constructor(props: ICloudProviderLogoProps) {
-    super(props);
-    this.state = this.getState(props);
-  }
+export const CloudProviderLogo = ({ height, provider, showTooltip, width }: ICloudProviderLogoProps) => {
+  const [tooltip, setTooltip] = React.useState<string>(undefined);
+  const RegistryLogo = CloudProviderRegistry.getValue(provider, 'cloudProviderLogo');
 
-  private getState(props: ICloudProviderLogoProps): ICloudProviderLogoState {
-    if (props.showTooltip) {
-      return {
-        tooltip: CloudProviderRegistry.getValue(this.props.provider, 'name') || this.props.provider,
-        logo: CloudProviderRegistry.getValue(this.props.provider, 'cloudProviderLogo'),
-      };
+  React.useEffect(() => {
+    if (showTooltip) {
+      setTooltip(CloudProviderRegistry.getValue(provider, 'name') || provider);
     }
-    return {
-      logo: CloudProviderRegistry.getValue(this.props.provider, 'cloudProviderLogo'),
-    };
+  }, [showTooltip]);
+
+  const ProviderLogo = RegistryLogo ? (
+    <RegistryLogo height={height} width={width} />
+  ) : (
+    <span className={`icon icon-${provider}`} style={{ height, width }} />
+  );
+
+  if (tooltip) {
+    return <Tooltip value={tooltip}>{ProviderLogo}</Tooltip>;
   }
 
-  public componentWillReceiveProps(nextProps: ICloudProviderLogoProps): void {
-    if (nextProps.showTooltip !== this.props.showTooltip) {
-      this.setState(this.getState(nextProps));
-    }
-  }
-
-  public render(): React.ReactElement<CloudProviderLogo> {
-    const RegistryLogo = this.state.logo;
-    const ProviderLogo = RegistryLogo ? (
-      <RegistryLogo height={this.props.height} width={this.props.width} />
-    ) : (
-      <span
-        className={`icon icon-${this.props.provider}`}
-        style={{ height: this.props.height, width: this.props.width }}
-      />
-    );
-
-    if (this.state.tooltip) {
-      return <Tooltip value={this.state.tooltip}>{ProviderLogo}</Tooltip>;
-    }
-
-    return <span className="cloud-provider-logo">{ProviderLogo}</span>;
-  }
-}
+  return <span className="cloud-provider-logo">{ProviderLogo}</span>;
+};

--- a/app/scripts/modules/core/src/cloudProvider/cloudProviderLogo.less
+++ b/app/scripts/modules/core/src/cloudProvider/cloudProviderLogo.less
@@ -9,12 +9,19 @@
     mask-size: cover;
     background-color: var(--color-success);
   }
+  svg {
+    fill: var(--color-success);
+  }
 }
 
 .disabled {
   .cloud-provider-logo {
     .icon {
       background-color: var(--color-dovegray);
+    }
+
+    svg {
+      fill: var(--color-success);
     }
   }
 }


### PR DESCRIPTION
An `svg` used in for cloud provider logos can now be configured while registering the cloud provider via `cloudProviderLogo`. The current implementation uses css to put an image mask over a span. For plugin-based cloud providers, the plugin will load the svg when it registers the plugin on initilization. 
