### PR TITLE
fix(ecs): rename capacityProviderStrategies to capacityProviderStrategy

### DIFF
--- a/app/scripts/modules/ecs/src/ecs.help.ts
+++ b/app/scripts/modules/ecs/src/ecs.help.ts
@@ -75,7 +75,7 @@ const helpContents: { [key: string]: string } = {
     '<p>The container name value, already specified in the task definition, to be used for your service discovery service.</p>',
   'ecs.computeOptions':
     '<p>Specify either a <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html" target="_blank">launch type</a> (default) or <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html" target="_blank">capacity providers</a> for running your ECS service.</p>',
-  'ecs.capacityProviderStrategies':
+  'ecs.capacityProviderStrategy':
     '<p>A capacity provider strategy gives you control over how your tasks use one or more capacity providers. See <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html#capacity-providers-concepts" target="_blank">AWS documentation</a> for more details. </p>',
   'ecs.capacityProviderName': '<p>The short name of the capacity provider.</p>',
   'ecs.capacityProviderBase':

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
@@ -245,13 +245,13 @@ module(ECS_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_ECS_CONTROLLER, [
     // TODO: Migrate horizontalScaling component to react and move this logic there
     $scope.capacityProviderState = {
       useCapacityProviders:
-        $scope.command.capacityProviderStrategies && $scope.command.capacityProviderStrategies.length > 0,
+        $scope.command.capacityProviderStrategy && $scope.command.capacityProviderStrategy.length > 0,
       updateComputeOption: function (chosenOption) {
         if (chosenOption == 'launchType') {
-          $scope.command.capacityProviderStrategies = [];
+          $scope.command.capacityProviderStrategy = [];
         } else if (chosenOption == 'capacityProviders') {
           $scope.command.launchType = '';
-          $scope.command.capacityProviderStrategies = $scope.command.capacityProviderStrategies || [];
+          $scope.command.capacityProviderStrategy = $scope.command.capacityProviderStrategy || [];
         }
       },
     };

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
@@ -34,8 +34,8 @@
 
   <div class="form-group" ng-if="$ctrl.capacityProviderState.useCapacityProviders">
     <div class="sm-label-left">
-      <b>Capacity Provider Strategies</b>
-      <help-field key="ecs.capacityProviderStrategies"></help-field>
+      <b>Capacity Provider Strategy</b>
+      <help-field key="ecs.capacityProviderStrategy"></help-field>
     </div>
     <div>
       <table class="table table-condensed packed tags">
@@ -45,7 +45,7 @@
           <th style="width: 25%">Weight <help-field key="ecs.capacityProviderWeight"></help-field></th>
         </thead>
         <tbody>
-          <tr ng-repeat="cp in $ctrl.command.capacityProviderStrategies">
+          <tr ng-repeat="cp in $ctrl.command.capacityProviderStrategy">
             <td>
               <input
                 type="text"
@@ -72,7 +72,7 @@
             </td>
             <td>
               <div class="form-control-static">
-                <a class="btn-link sm-label" ng-click="$ctrl.command.capacityProviderStrategies.splice($index, 1)">
+                <a class="btn-link sm-label" ng-click="$ctrl.command.capacityProviderStrategy.splice($index, 1)">
                   <span class="glyphicon glyphicon-trash"></span>
                   <span class="sr-only">Remove</span>
                 </a>
@@ -85,7 +85,7 @@
             <td colspan="3">
               <button
                 class="btn btn-block btn-sm add-new"
-                ng-click="$ctrl.command.capacityProviderStrategies.push({})"
+                ng-click="$ctrl.command.capacityProviderStrategy.push({})"
                 data-test-id="ServerGroup.addCapacityProvider"
               >
                 <span class="glyphicon glyphicon-plus-sign"></span>


### PR DESCRIPTION
Rename capacityProviderStrategies to capacityProviderStrategy to align with [CreateService api](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html#ECS-CreateService-request-capacityProviderStrategy). As this is a new feature for 1.24, this will not be backwards incompatible if patched.

* requires https://github.com/spinnaker/clouddriver/pull/5154

### Testing

* UI screenshot
![image](https://user-images.githubusercontent.com/34254888/101937900-53fb2300-3b97-11eb-98aa-71d6d76cf368.png)

* update JSON for stage
![image](https://user-images.githubusercontent.com/34254888/101937840-3ded6280-3b97-11eb-8813-b8d9953f913b.png)

* deployment success
![image](https://user-images.githubusercontent.com/34254888/101937763-21e9c100-3b97-11eb-9ff4-55e067b12fd1.png)
