### PR TITLE
fix(core/managed): re-enable build events

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -34,11 +34,7 @@ import { isResourceKindSupported } from './resources/resourceRegistry';
 
 import './ArtifactDetail.less';
 
-const SUPPORTED_PRE_DEPLOYMENT_TYPES = [
-  // KLUDGE WARNING: disabling build events temporarily while we get the API in shape
-  // 'BUILD',
-  'BAKE',
-];
+const SUPPORTED_PRE_DEPLOYMENT_TYPES = ['BUILD', 'BAKE'];
 
 function shouldDisplayResource(reference: string, resource: IManagedResourceSummary) {
   return isResourceKindSupported(resource.kind) && reference === resource.artifact?.reference;

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -169,13 +169,7 @@ function getArtifactStatuses({ environments, lifecycleSteps }: IManagedArtifactV
 
   const preDeploymentSteps = lifecycleSteps?.filter(
     ({ scope, type, status }) =>
-      scope === 'PRE_DEPLOYMENT' &&
-      [
-        // KLUDGE WARNING: disabling build events temporarily while we get the API in shape
-        // 'BUILD',
-        'BAKE',
-      ].includes(type) &&
-      ['RUNNING', 'FAILED'].includes(status),
+      scope === 'PRE_DEPLOYMENT' && ['BUILD', 'BAKE'].includes(type) && ['RUNNING', 'FAILED'].includes(status),
   );
 
   if (preDeploymentSteps?.length > 0) {


### PR DESCRIPTION
as described in https://github.com/spinnaker/deck/pull/8776, we temporarily disabled build pre-deployment steps in the UI to handle a data issue. We're now ready to flip the switch back on.