### PR TITLE
chore(package): core@0.0.537 ecs@0.0.273 google@0.0.29

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.536",
+  "version": "0.0.537",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.272",
+  "version": "0.0.273",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/google",
   "license": "Apache-2.0",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## core@0.0.537

06aca3a951b32c0ae6bad4aac3a760824b46202f fix(core/managed): re-enable build events (#8786)
728939d7957997b4756467123415024a18d4395b chore(core): Allow cloud provider logos in registry (#8782)
38568a3f9c94af42e71fda0dd6229f458a71b443 feat(manual judgment/deck): Added ability to add roles to manual judgment stage (#8779)
aa201bba182ff009676913ac40422d057eb9f647 fix(core/pipeline): Fix linking to pipeline execution (#8778)
a53e32cfcd045bfbabf9b5a46c46ead352f585ee feat(bake): add UI element for helmChartFilePath to bake manifest stage, when using a git/repo artifact for the helm chart (#8774)

## ecs@0.0.273

43e2f120b67a1446249a5b22faaf49c0afbb3658 fix(ecs): rename capacityProviderStrategies to capacityProviderStrategy

## google@0.0.29

1446faca4d7e6d24079722c8dd56f51c35f4d010 feat(targetShape): remove the ALPHA conditional on the targetShape (#8787)

PR created via `modules/publish.js`