### PR TITLE
Avoid raw "$http" usage

### DIFF
--- a/app/scripts/modules/amazon/src/image/image.reader.spec.js
+++ b/app/scripts/modules/amazon/src/image/image.reader.spec.js
@@ -5,19 +5,19 @@ import { API } from '@spinnaker/core';
 import { AwsImageReader } from './image.reader';
 
 describe('Service: aws Image Reader', function () {
-  var service, $http, scope;
+  var service, $httpBackend, scope;
 
   beforeEach(
-    window.inject(function ($httpBackend, $rootScope) {
+    window.inject(function (_$httpBackend_, $rootScope) {
       service = new AwsImageReader();
-      $http = $httpBackend;
+      $httpBackend = _$httpBackend_;
       scope = $rootScope.$new();
     }),
   );
 
   afterEach(function () {
-    $http.verifyNoOutstandingRequest();
-    $http.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+    $httpBackend.verifyNoOutstandingExpectation();
   });
 
   describe('findImages', function () {
@@ -31,13 +31,13 @@ describe('Service: aws Image Reader', function () {
     it('queries gate when 3 characters are supplied', function () {
       var result = null;
 
-      $http.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
 
       service.findImages({ provider: 'aws', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
@@ -48,7 +48,7 @@ describe('Service: aws Image Reader', function () {
 
       query = 'abcd';
 
-      $http.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
 
       var promise = service.findImages({ provider: 'aws', q: query, region: region });
 
@@ -56,7 +56,7 @@ describe('Service: aws Image Reader', function () {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
@@ -81,13 +81,13 @@ describe('Service: aws Image Reader', function () {
       query = 'abc';
       var result = null;
 
-      $http.when('GET', buildQueryString()).respond(404, {});
+      $httpBackend.when('GET', buildQueryString()).respond(404, {});
 
       service.findImages({ provider: 'aws', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(0);
     });
@@ -105,25 +105,25 @@ describe('Service: aws Image Reader', function () {
     it('returns null if server returns 404 or an empty list', function () {
       var result = 'not null';
 
-      $http.when('GET', buildQueryString()).respond(404, {});
+      $httpBackend.when('GET', buildQueryString()).respond(404, {});
 
       service.getImage(imageName, region, credentials).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result).toBe(null);
 
       result = 'not null';
 
-      $http.when('GET', buildQueryString()).respond(200, []);
+      $httpBackend.when('GET', buildQueryString()).respond(200, []);
 
       service.getImage(imageName, region, credentials).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result).toBe(null);
     });

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
@@ -10,9 +10,8 @@ import { AWSProviderSettings } from 'amazon/aws.settings';
 export const AMAZON_INSTANCE_AWSINSTANCETYPE_SERVICE = 'spinnaker.amazon.instanceType.service';
 export const name = AMAZON_INSTANCE_AWSINSTANCETYPE_SERVICE; // for backwards compatibility
 module(AMAZON_INSTANCE_AWSINSTANCETYPE_SERVICE, []).factory('awsInstanceTypeService', [
-  '$http',
   '$q',
-  function ($http, $q) {
+  function ($q) {
     const m5 = {
       type: 'm5',
       description:

--- a/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
+++ b/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
@@ -5,11 +5,11 @@ import { API } from '@spinnaker/core';
 import { VpcReader } from '../vpc/VpcReader';
 
 describe('VpcReader', function () {
-  var $http, $scope;
+  var $httpBackend, $scope;
 
   beforeEach(
-    window.inject(function ($httpBackend, $rootScope) {
-      $http = $httpBackend;
+    window.inject(function (_$httpBackend_, $rootScope) {
+      $httpBackend = _$httpBackend_;
       $scope = $rootScope.$new();
     }),
   );
@@ -19,7 +19,7 @@ describe('VpcReader', function () {
   });
 
   beforeEach(function () {
-    $http.whenGET(API.baseUrl + '/networks/aws').respond(200, [
+    $httpBackend.whenGET(API.baseUrl + '/networks/aws').respond(200, [
       { name: 'vpc1', id: 'vpc-1', deprecated: true },
       { name: 'vpc2', id: 'vpc-2', deprecated: false },
       { name: 'vpc3', id: 'vpc-3' },
@@ -33,7 +33,7 @@ describe('VpcReader', function () {
       result = vpcs;
     });
 
-    $http.flush();
+    $httpBackend.flush();
     $scope.$digest();
 
     expect(result[0].label).toBe('vpc1 (deprecated)');
@@ -51,7 +51,7 @@ describe('VpcReader', function () {
       result = name;
     });
 
-    $http.flush();
+    $httpBackend.flush();
     $scope.$digest();
 
     expect(result).toBe('vpc1');

--- a/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
@@ -7,10 +7,10 @@ import { mockDeployStage, mockPipeline } from '@spinnaker/mocks';
 import { ConfigFileArtifactList } from './ConfigFileArtifactList';
 
 describe('<ConfigFileArtifactList/>', () => {
-  let $http: ng.IHttpBackendService;
+  let $httpBackend: ng.IHttpBackendService;
   beforeEach(
-    mock.inject(function ($httpBackend: ng.IHttpBackendService) {
-      $http = $httpBackend;
+    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
+      $httpBackend = _$httpBackend_;
     }),
   );
 
@@ -34,7 +34,7 @@ describe('<ConfigFileArtifactList/>', () => {
         types: ['http'],
       },
     ];
-    $http.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
+    $httpBackend.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
 
     const configArtifacts = [
       {
@@ -62,7 +62,7 @@ describe('<ConfigFileArtifactList/>', () => {
       />,
     );
     expect(wrapper.find(StageArtifactSelector).length).toBe(2);
-    $http.flush();
+    $httpBackend.flush();
   });
 
   it('renders 1 children of StageArtifactSelector when 1 expectedArtifacts are passed in', () => {
@@ -72,7 +72,7 @@ describe('<ConfigFileArtifactList/>', () => {
         types: ['http'],
       },
     ];
-    $http.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
+    $httpBackend.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
 
     // artifact intentionally left null indicating an expected artifact
     const configArtifacts = [
@@ -91,6 +91,6 @@ describe('<ConfigFileArtifactList/>', () => {
       />,
     );
     expect(wrapper.find(StageArtifactSelector).length).toBe(1);
-    $http.flush();
+    $httpBackend.flush();
   });
 });

--- a/app/scripts/modules/azure/src/image/image.reader.spec.js
+++ b/app/scripts/modules/azure/src/image/image.reader.spec.js
@@ -3,20 +3,20 @@
 import { API } from '@spinnaker/core';
 
 describe('Service: Azure Image Reader', function () {
-  var service, $http;
+  var service, $httpBackend;
 
   beforeEach(window.module(require('./image.reader').name));
 
   beforeEach(
-    window.inject(function (azureImageReader, $httpBackend) {
+    window.inject(function (azureImageReader, _$httpBackend_) {
       service = azureImageReader;
-      $http = $httpBackend;
+      $httpBackend = _$httpBackend_;
     }),
   );
 
   afterEach(function () {
-    $http.verifyNoOutstandingRequest();
-    $http.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+    $httpBackend.verifyNoOutstandingExpectation();
   });
 
   describe('findImages', function () {
@@ -30,13 +30,13 @@ describe('Service: Azure Image Reader', function () {
     it('queries gate when 3 characters are supplied', function () {
       var result = null;
 
-      $http.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
 
       service.findImages({ provider: 'azure', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
@@ -47,7 +47,7 @@ describe('Service: Azure Image Reader', function () {
 
       query = 'abcd';
 
-      $http.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
 
       var promise = service.findImages({ provider: 'azure', q: query, region: region });
 
@@ -55,7 +55,7 @@ describe('Service: Azure Image Reader', function () {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
@@ -65,13 +65,13 @@ describe('Service: Azure Image Reader', function () {
       query = 'abc';
       var result = null;
 
-      $http.when('GET', buildQueryString()).respond(404, {});
+      $httpBackend.when('GET', buildQueryString()).respond(404, {});
 
       service.findImages({ provider: 'azure', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(0);
     });
@@ -89,25 +89,25 @@ describe('Service: Azure Image Reader', function () {
     it('returns null if server returns 404 or an empty list', function () {
       var result = 'not null';
 
-      $http.when('GET', buildQueryString()).respond(404, {});
+      $httpBackend.when('GET', buildQueryString()).respond(404, {});
 
       service.getImage(imageName, region, credentials).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result).toBe(null);
 
       result = 'not null';
 
-      $http.when('GET', buildQueryString()).respond(200, []);
+      $httpBackend.when('GET', buildQueryString()).respond(200, []);
 
       service.getImage(imageName, region, credentials).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result).toBe(null);
     });

--- a/app/scripts/modules/azure/src/instance/azureInstanceType.service.js
+++ b/app/scripts/modules/azure/src/instance/azureInstanceType.service.js
@@ -6,9 +6,8 @@ import _ from 'lodash';
 export const AZURE_INSTANCE_AZUREINSTANCETYPE_SERVICE = 'spinnaker.azure.instanceType.service';
 export const name = AZURE_INSTANCE_AZUREINSTANCETYPE_SERVICE; // for backwards compatibility
 module(AZURE_INSTANCE_AZUREINSTANCETYPE_SERVICE, []).factory('azureInstanceTypeService', [
-  '$http',
   '$q',
-  function ($http, $q) {
+  function ($q) {
     const B = {
       type: 'B-series',
       description:

--- a/app/scripts/modules/azure/src/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/src/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -3,7 +3,7 @@
 import { API, ApplicationModelBuilder } from '@spinnaker/core';
 
 describe('Controller: azureCreateLoadBalancerCtrl', function () {
-  var $http;
+  var $httpBackend;
 
   // load the controller's module
   beforeEach(window.module(require('./createLoadBalancer.controller').name));
@@ -29,9 +29,9 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
   );
 
   beforeEach(
-    window.inject(function ($httpBackend) {
+    window.inject(function (_$httpBackend_) {
       // Set up the mock http service responses
-      $http = $httpBackend;
+      $httpBackend = _$httpBackend_;
     }),
   );
 
@@ -48,9 +48,9 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
   });
 
   it('makes the expected REST calls for data for a new loadbalancer', function () {
-    $http.when('GET', API.baseUrl + '/networks').respond([]);
-    $http.when('GET', API.baseUrl + '/securityGroups').respond({});
-    $http.when('GET', API.baseUrl + '/credentials?expand=true').respond([]);
-    $http.when('GET', API.baseUrl + '/subnets').respond([]);
+    $httpBackend.when('GET', API.baseUrl + '/networks').respond([]);
+    $httpBackend.when('GET', API.baseUrl + '/securityGroups').respond({});
+    $httpBackend.when('GET', API.baseUrl + '/credentials?expand=true').respond([]);
+    $httpBackend.when('GET', API.baseUrl + '/subnets').respond([]);
   });
 });

--- a/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -3,7 +3,7 @@
 import { AccountService, API, SECURITY_GROUP_READER } from '@spinnaker/core';
 
 describe('Controller: Azure.CreateSecurityGroup', function () {
-  var $http;
+  var $httpBackend;
 
   beforeEach(window.module(SECURITY_GROUP_READER, require('./CreateSecurityGroupCtrl').name));
 
@@ -70,14 +70,14 @@ describe('Controller: Azure.CreateSecurityGroup', function () {
     );
 
     beforeEach(
-      window.inject(function ($httpBackend) {
+      window.inject(function (_$httpBackend_) {
         // Set up the mock http service responses
-        $http = $httpBackend;
+        $httpBackend = _$httpBackend_;
       }),
     );
 
     it('initializes with no firewalls available for ingress permissions', function () {
-      $http.when('GET', API.baseUrl + '/networks').respond([]);
+      $httpBackend.when('GET', API.baseUrl + '/networks').respond([]);
       this.initializeCtrl();
       expect(this.$scope.securityGroup.securityRules.length).toBe(0);
     });

--- a/app/scripts/modules/canary/canary/actions/endCanary.controller.js
+++ b/app/scripts/modules/canary/canary/actions/endCanary.controller.js
@@ -2,17 +2,16 @@
 
 import { module } from 'angular';
 
-import { SETTINGS } from '@spinnaker/core';
+import { API } from '@spinnaker/core';
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 
 export const CANARY_CANARY_ACTIONS_ENDCANARY_CONTROLLER = 'spinnaker.canary.actions.override.result.controller';
 export const name = CANARY_CANARY_ACTIONS_ENDCANARY_CONTROLLER; // for backwards compatibility
 module(CANARY_CANARY_ACTIONS_ENDCANARY_CONTROLLER, [UIROUTER_ANGULARJS]).controller('EndCanaryCtrl', [
   '$scope',
-  '$http',
   '$uibModalInstance',
   'canaryId',
-  function ($scope, $http, $uibModalInstance, canaryId) {
+  function ($scope, $uibModalInstance, canaryId) {
     $scope.command = {
       reason: null,
       result: 'SUCCESS',
@@ -22,9 +21,8 @@ module(CANARY_CANARY_ACTIONS_ENDCANARY_CONTROLLER, [UIROUTER_ANGULARJS]).control
 
     this.endCanary = function () {
       $scope.state = 'submitting';
-      const targetUrl = [SETTINGS.gateUrl, 'canaries', canaryId, 'end'].join('/');
-      $http
-        .put(targetUrl, $scope.command)
+      API.one('canaries', canaryId, 'end')
+        .put($scope.command)
         .then(function onSuccess() {
           $scope.state = 'success';
         })

--- a/app/scripts/modules/canary/canary/actions/generateScore.controller.js
+++ b/app/scripts/modules/canary/canary/actions/generateScore.controller.js
@@ -2,17 +2,16 @@
 
 import { module } from 'angular';
 
-import { SETTINGS } from '@spinnaker/core';
+import { API, SETTINGS } from '@spinnaker/core';
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 
 export const CANARY_CANARY_ACTIONS_GENERATESCORE_CONTROLLER = 'spinnaker.canary.actions.generate.score.controller';
 export const name = CANARY_CANARY_ACTIONS_GENERATESCORE_CONTROLLER; // for backwards compatibility
 module(CANARY_CANARY_ACTIONS_GENERATESCORE_CONTROLLER, [UIROUTER_ANGULARJS]).controller('GenerateScoreCtrl', [
   '$scope',
-  '$http',
   '$uibModalInstance',
   'canaryId',
-  function ($scope, $http, $uibModalInstance, canaryId) {
+  function ($scope, $uibModalInstance, canaryId) {
     $scope.command = {
       duration: null,
       durationUnit: 'h',
@@ -22,9 +21,8 @@ module(CANARY_CANARY_ACTIONS_GENERATESCORE_CONTROLLER, [UIROUTER_ANGULARJS]).con
 
     this.generateCanaryScore = function () {
       $scope.state = 'submitting';
-      const targetUrl = [SETTINGS.gateUrl, 'canaries', canaryId, 'generateCanaryResult'].join('/');
-      $http
-        .post(targetUrl, $scope.command)
+      API.one('canaries', canaryId, 'generateCanaryResult')
+        .post($scope.command)
         .then(function onSuccess() {
           $scope.state = 'success';
         })

--- a/app/scripts/modules/canary/canary/canaryExecutionSummary.controller.js
+++ b/app/scripts/modules/canary/canary/canaryExecutionSummary.controller.js
@@ -15,9 +15,8 @@ module(CANARY_CANARY_CANARYEXECUTIONSUMMARY_CONTROLLER, [
   CANARY_CANARY_ACTIONS_ENDCANARY_CONTROLLER,
 ]).controller('CanaryExecutionSummaryCtrl', [
   '$scope',
-  '$http',
   '$uibModal',
-  function ($scope, $http, $uibModal) {
+  function ($scope, $uibModal) {
     this.generateCanaryScore = function () {
       $uibModal.open({
         templateUrl: require('./actions/generateScore.modal.html'),

--- a/app/scripts/modules/core/src/account/AccountService.spec.ts
+++ b/app/scripts/modules/core/src/account/AccountService.spec.ts
@@ -8,11 +8,11 @@ import { AccountService, IAccount } from './AccountService';
 import { CloudProviderRegistry } from '../cloudProvider';
 
 describe('Service: AccountService', () => {
-  let $http: ng.IHttpBackendService;
+  let $httpBackend: ng.IHttpBackendService;
 
   beforeEach(
-    mock.inject(function ($httpBackend: ng.IHttpBackendService) {
-      $http = $httpBackend;
+    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
+      $httpBackend = _$httpBackend_;
     }),
   );
   beforeEach(() => AccountService.initialize());
@@ -20,7 +20,7 @@ describe('Service: AccountService', () => {
   afterEach(SETTINGS.resetToOriginal);
 
   it('should filter the list of accounts by provider when supplied', (done) => {
-    $http.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(200, [
+    $httpBackend.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(200, [
       { name: 'test', type: 'aws' },
       { name: 'prod', type: 'aws' },
       { name: 'prod', type: 'gce' },
@@ -32,13 +32,13 @@ describe('Service: AccountService', () => {
       expect(accounts.map((account: IAccount) => account.name)).toEqual(['test', 'prod']);
       done();
     });
-    $http.flush();
+    $httpBackend.flush();
     setTimeout(() => $rootScope.$digest());
   });
 
   describe('getAllAccountDetailsForProvider', () => {
     it('should return details for each account', (done) => {
-      $http.expectGET(API.baseUrl + '/credentials?expand=true').respond(200, [
+      $httpBackend.expectGET(API.baseUrl + '/credentials?expand=true').respond(200, [
         { name: 'test', type: 'aws' },
         { name: 'prod', type: 'aws' },
       ]);
@@ -49,18 +49,18 @@ describe('Service: AccountService', () => {
         expect(details[1].name).toBe('prod');
         done();
       });
-      $http.flush();
+      $httpBackend.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
     it('should fall back to an empty array if an exception occurs when listing accounts', (done) => {
-      $http.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(429, null);
+      $httpBackend.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(429, null);
 
       AccountService.getAllAccountDetailsForProvider('aws').then((details: any[]) => {
         expect(details).toEqual([]);
         done();
       });
-      $http.flush();
+      $httpBackend.flush();
       setTimeout(() => $rootScope.$digest());
     });
   });
@@ -69,7 +69,7 @@ describe('Service: AccountService', () => {
     let registeredProviders: string[];
     beforeEach(() => {
       registeredProviders = ['aws', 'gce', 'cf'];
-      $http
+      $httpBackend
         .whenGET(`${API.baseUrl}/credentials?expand=true`)
         .respond(200, [{ type: 'aws' }, { type: 'gce' }, { type: 'cf' }]);
       spyOn(CloudProviderRegistry, 'listRegisteredProviders').and.returnValue(registeredProviders);
@@ -80,7 +80,7 @@ describe('Service: AccountService', () => {
         expect(result).toEqual(['aws', 'cf', 'gce']);
         done();
       });
-      $http.flush();
+      $httpBackend.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
@@ -90,7 +90,7 @@ describe('Service: AccountService', () => {
         expect(result).toEqual(['aws', 'gce']);
         done();
       });
-      $http.flush();
+      $httpBackend.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
@@ -101,7 +101,7 @@ describe('Service: AccountService', () => {
         expect(result).toEqual(['cf', 'gce']);
         done();
       });
-      $http.flush();
+      $httpBackend.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
@@ -112,7 +112,7 @@ describe('Service: AccountService', () => {
         expect(result).toEqual(['cf', 'gce']);
         done();
       });
-      $http.flush();
+      $httpBackend.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
@@ -123,7 +123,7 @@ describe('Service: AccountService', () => {
         expect(result).toEqual([]);
         done();
       });
-      $http.flush();
+      $httpBackend.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
@@ -134,7 +134,7 @@ describe('Service: AccountService', () => {
         expect(result).toEqual(['aws', 'cf', 'gce']);
         done();
       });
-      $http.flush();
+      $httpBackend.flush();
       setTimeout(() => $rootScope.$digest());
     });
   });

--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -29,6 +29,8 @@ export interface IRequestBuilder {
   post<T = any, P = any>(data?: P): PromiseLike<T>;
   /** issues a PUT request */
   put<T = any, P = any>(data?: P): PromiseLike<T>;
+  /** issues a PATCH request */
+  patch<T = any, P = any>(data?: P): PromiseLike<T>;
   /** issues a DELETE request */
   delete<T = any>(): PromiseLike<T>;
 }
@@ -82,6 +84,7 @@ export interface IHttpClientImplementation {
   get<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
   post<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
   put<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
+  patch<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
   delete<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
 }
 
@@ -104,8 +107,12 @@ class AngularJSHttpClient implements IHttpClientImplementation {
   get = <T = any>(requestConfig: IRequestBuilderConfig) => this.request<T>('GET', requestConfig);
   post = <T = any>(requestConfig: IRequestBuilderConfig) => this.request<T>('POST', requestConfig);
   put = <T = any>(requestConfig: IRequestBuilderConfig) => this.request<T>('PUT', requestConfig);
+  patch = <T = any>(requestConfig: IRequestBuilderConfig) => this.request<T>('PATCH', requestConfig);
 
-  private request<T>(method: 'GET' | 'POST' | 'PUT' | 'DELETE', requestConfig: IRequestBuilderConfig): PromiseLike<T> {
+  private request<T>(
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    requestConfig: IRequestBuilderConfig,
+  ): PromiseLike<T> {
     return $http<T>({ ...requestConfig, method }).then((response) => {
       const contentType = response.headers('content-type');
 
@@ -186,6 +193,13 @@ export class RequestBuilder implements IRequestBuilder {
     const data = putData ?? this.config.data;
     const url = joinPaths(this.baseUrl, this.config.url);
     return this.httpClient.put<T>({ ...this.config, url, data });
+  }
+
+  patch<T>(putData?: any) {
+    // Check this.config.data for backwards compat
+    const data = putData ?? this.config.data;
+    const url = joinPaths(this.baseUrl, this.config.url);
+    return this.httpClient.patch<T>({ ...this.config, url, data });
   }
 
   // queryParams argument for backwards compat

--- a/app/scripts/modules/core/src/authentication/AuthenticationInitializer.spec.ts
+++ b/app/scripts/modules/core/src/authentication/AuthenticationInitializer.spec.ts
@@ -20,13 +20,13 @@ describe('authenticationProvider: application startup', function () {
   });
   afterAll(() => (AuthenticationInitializer.loginRedirect = loginRedirect));
 
-  let $timeout: ng.ITimeoutService, $http: ng.IHttpBackendService, $rootScope: IDeckRootScope;
+  let $timeout: ng.ITimeoutService, $httpBackend: ng.IHttpBackendService, $rootScope: IDeckRootScope;
 
   beforeEach(
     mock.inject(
       (_$timeout_: ng.ITimeoutService, _$httpBackend_: ng.IHttpBackendService, _$rootScope_: IDeckRootScope) => {
         $timeout = _$timeout_;
-        $http = _$httpBackend_;
+        $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
       },
     ),
@@ -36,9 +36,9 @@ describe('authenticationProvider: application startup', function () {
 
   describe('authenticateUser', () => {
     it('requests authentication from gate, then sets authentication name field', function () {
-      $http.whenGET(SETTINGS.authEndpoint).respond(200, { username: 'joe!' });
+      $httpBackend.whenGET(SETTINGS.authEndpoint).respond(200, { username: 'joe!' });
       $timeout.flush();
-      $http.flush();
+      $httpBackend.flush();
 
       expect($rootScope.authenticating).toBe(false);
       expect(AuthenticationService.getAuthenticatedUser().name).toBe('joe!');
@@ -46,9 +46,9 @@ describe('authenticationProvider: application startup', function () {
     });
 
     it('requests authentication from gate, then opens modal and redirects on 401', function () {
-      $http.whenGET(SETTINGS.authEndpoint).respond(401, null, { 'X-AUTH-REDIRECT-URL': '/authUp' });
+      $httpBackend.whenGET(SETTINGS.authEndpoint).respond(401, null, { 'X-AUTH-REDIRECT-URL': '/authUp' });
       $rootScope.$digest();
-      $http.flush();
+      $httpBackend.flush();
 
       expect($rootScope.authenticating).toBe(true);
       expect(AuthenticationService.getAuthenticatedUser().name).toBe('[anonymous]');

--- a/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
@@ -17,7 +17,7 @@ describe('Service: Cluster', function () {
   beforeEach(mock.module(CLUSTER_SERVICE, REACT_MODULE));
 
   let clusterService: ClusterService;
-  let $http: IHttpBackendService;
+  let $httpBackend: IHttpBackendService;
   let application: Application;
 
   function buildTask(config: { status: string; variables: { [key: string]: any } }) {
@@ -30,8 +30,8 @@ describe('Service: Cluster', function () {
   }
 
   beforeEach(
-    mock.inject(($httpBackend: IHttpBackendService, _clusterService_: ClusterService) => {
-      $http = $httpBackend;
+    mock.inject((_$httpBackend_: IHttpBackendService, _clusterService_: ClusterService) => {
+      $httpBackend = _$httpBackend_;
       clusterService = _clusterService_;
 
       application = ApplicationModelBuilder.createApplicationForTests(
@@ -55,22 +55,22 @@ describe('Service: Cluster', function () {
   describe('lazy cluster fetching', () => {
     it('switches to lazy cluster fetching if there are more than the on demand threshold for clusters', () => {
       const clusters = Array(SETTINGS.onDemandClusterThreshold + 1);
-      $http.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
-      $http.expectGET(API.baseUrl + '/applications/app/serverGroups?clusters=').respond(200, []);
+      $httpBackend.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
+      $httpBackend.expectGET(API.baseUrl + '/applications/app/serverGroups?clusters=').respond(200, []);
       let serverGroups: IServerGroup[] = null;
       clusterService.loadServerGroups(application).then((result: IServerGroup[]) => (serverGroups = result));
-      $http.flush();
+      $httpBackend.flush();
       expect(application.serverGroups.fetchOnDemand).toBe(true);
       expect(serverGroups).toEqual([]);
     });
 
     it('does boring regular fetching when there are less than the on demand threshold for clusters', () => {
       const clusters = Array(SETTINGS.onDemandClusterThreshold);
-      $http.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
-      $http.expectGET(API.baseUrl + '/applications/app/serverGroups').respond(200, []);
+      $httpBackend.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
+      $httpBackend.expectGET(API.baseUrl + '/applications/app/serverGroups').respond(200, []);
       let serverGroups: IServerGroup[] = null;
       clusterService.loadServerGroups(application).then((result: IServerGroup[]) => (serverGroups = result));
-      $http.flush();
+      $httpBackend.flush();
       expect(application.serverGroups.fetchOnDemand).toBe(false);
       expect(serverGroups).toEqual([]);
     });
@@ -79,11 +79,11 @@ describe('Service: Cluster', function () {
       spyOn(ClusterState.filterModel.asFilterModel, 'applyParamsToUrl').and.callFake(() => {});
       const clusters = Array(250);
       ClusterState.filterModel.asFilterModel.sortFilter.clusters = { 'test:myapp': true };
-      $http.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
-      $http.expectGET(API.baseUrl + '/applications/app/serverGroups').respond(200, []);
+      $httpBackend.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
+      $httpBackend.expectGET(API.baseUrl + '/applications/app/serverGroups').respond(200, []);
       let serverGroups: IServerGroup[] = null;
       clusterService.loadServerGroups(application).then((result: IServerGroup[]) => (serverGroups = result));
-      $http.flush();
+      $httpBackend.flush();
       expect(application.serverGroups.fetchOnDemand).toBe(false);
       expect(ClusterState.filterModel.asFilterModel.sortFilter.filter).toEqual('clusters:myapp');
       expect(ClusterState.filterModel.asFilterModel.sortFilter.account.test).toBe(true);

--- a/app/scripts/modules/core/src/function/function.read.service.spec.ts
+++ b/app/scripts/modules/core/src/function/function.read.service.spec.ts
@@ -3,7 +3,7 @@ import { mock } from 'angular';
 import { IFunctionTransformer } from 'core/function/function.transformer';
 
 describe('FunctionReadService', () => {
-  let $http: ng.IHttpBackendService;
+  let $httpBackend: ng.IHttpBackendService;
   const functionTransformerMock: IFunctionTransformer = {
     normalizeFunction: (data): IFunctionSourceData => {
       return data;
@@ -14,8 +14,8 @@ describe('FunctionReadService', () => {
   };
 
   beforeEach(
-    mock.inject(function ($httpBackend: ng.IHttpBackendService) {
-      $http = $httpBackend;
+    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
+      $httpBackend = _$httpBackend_;
     }),
   );
 
@@ -23,7 +23,7 @@ describe('FunctionReadService', () => {
     it(`should set cloudprovider if not set`, (done) => {
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      $http.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
+      $httpBackend.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
         {
           name: 'account1',
           provider: 'aws',
@@ -55,13 +55,13 @@ describe('FunctionReadService', () => {
         done();
       });
 
-      $http.flush();
+      $httpBackend.flush();
     });
 
     it(`should not set cloudprovider if provided`, (done) => {
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      $http.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
+      $httpBackend.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
         {
           name: 'account1',
           cloudProvider: 'fluffyCloud',
@@ -95,7 +95,7 @@ describe('FunctionReadService', () => {
         done();
       });
 
-      $http.flush();
+      $httpBackend.flush();
     });
   });
 
@@ -103,7 +103,7 @@ describe('FunctionReadService', () => {
     it(`should set cloudprovider if not set`, (done) => {
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      $http.whenGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
+      $httpBackend.whenGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
         expect(params).toEqual({
           provider: 'aws',
           account: 'acct1',
@@ -147,13 +147,13 @@ describe('FunctionReadService', () => {
         done();
       });
 
-      $http.flush();
+      $httpBackend.flush();
     });
 
     it(`should not set cloudprovider if provided`, (done) => {
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      $http.whenGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
+      $httpBackend.whenGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
         expect(params).toEqual({
           provider: 'aws',
           account: 'acct1',
@@ -199,7 +199,7 @@ describe('FunctionReadService', () => {
         done();
       });
 
-      $http.flush();
+      $httpBackend.flush();
     });
   });
 });

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
@@ -5,23 +5,23 @@ import { API } from 'core/api/ApiService';
 import { IPagerDutyService, PagerDutyReader } from './pagerDuty.read.service';
 
 describe('PagerDutyReader', () => {
-  let $http: IHttpBackendService;
+  let $httpBackend: IHttpBackendService;
 
   beforeEach(mock.module());
   beforeEach(
     mock.inject((_$httpBackend_: IHttpBackendService) => {
-      $http = _$httpBackend_;
+      $httpBackend = _$httpBackend_;
     }),
   );
 
   afterEach(function () {
-    $http.verifyNoOutstandingExpectation();
-    $http.verifyNoOutstandingRequest();
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
   });
 
   it('should return an empty array when configured to do so and invoked', () => {
     const services: IPagerDutyService[] = [];
-    $http.whenGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
+    $httpBackend.whenGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
 
     let executed = false;
     PagerDutyReader.listServices().subscribe((pagerDutyServices: IPagerDutyService[]) => {
@@ -30,7 +30,7 @@ describe('PagerDutyReader', () => {
       executed = true; // can't use done() function b/c $digest is already in progress
     });
 
-    $http.flush();
+    $httpBackend.flush();
     expect(executed).toBeTruthy();
   });
 
@@ -53,7 +53,7 @@ describe('PagerDutyReader', () => {
         status: 'active',
       },
     ];
-    $http.whenGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
+    $httpBackend.whenGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
 
     let executed = false;
     PagerDutyReader.listServices().subscribe((pagerDutyServices: IPagerDutyService[]) => {
@@ -62,7 +62,7 @@ describe('PagerDutyReader', () => {
       executed = true; // can't use done() function b/c $digest is already in progress
     });
 
-    $http.flush();
+    $httpBackend.flush();
     expect(executed).toBeTruthy();
   });
 });

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.spec.ts
@@ -6,7 +6,7 @@ import { IPipeline } from 'core/domain/IPipeline';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 
 describe('PipelineConfigService', () => {
-  let $http: ng.IHttpBackendService, $scope: ng.IScope;
+  let $httpBackend: ng.IHttpBackendService, $scope: ng.IScope;
 
   const buildStage = (base: any): IStage => {
     const stageDefaults: IStage = {
@@ -46,8 +46,8 @@ describe('PipelineConfigService', () => {
   };
 
   beforeEach(
-    mock.inject(($httpBackend: ng.IHttpBackendService, $rootScope: ng.IRootScopeService) => {
-      $http = $httpBackend;
+    mock.inject((_$httpBackend_: ng.IHttpBackendService, $rootScope: ng.IRootScopeService) => {
+      $httpBackend = _$httpBackend_;
       $scope = $rootScope.$new();
     }),
   );
@@ -62,7 +62,7 @@ describe('PipelineConfigService', () => {
         ],
       });
 
-      $http
+      $httpBackend
         .expectPOST(API.baseUrl + '/pipelines', (requestString: string) => {
           const request = JSON.parse(requestString) as IPipeline;
           return (
@@ -76,8 +76,8 @@ describe('PipelineConfigService', () => {
 
       PipelineConfigService.savePipeline(pipeline);
       $scope.$digest();
-      $http.flush();
-      $http.verifyNoOutstandingRequest();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingRequest();
     });
   });
 
@@ -85,12 +85,12 @@ describe('PipelineConfigService', () => {
     it('escapes special characters in pipeline name', () => {
       const pipeline: IPipeline = buildPipeline({});
 
-      $http.expectDELETE(API.baseUrl + '/pipelines/foo/bar%5Bbaz%5D').respond(200, '');
+      $httpBackend.expectDELETE(API.baseUrl + '/pipelines/foo/bar%5Bbaz%5D').respond(200, '');
 
       PipelineConfigService.deletePipeline('foo', pipeline, 'bar[baz]');
 
       $scope.$digest();
-      $http.flush();
+      $httpBackend.flush();
     });
   });
 
@@ -103,13 +103,13 @@ describe('PipelineConfigService', () => {
         buildPipeline({ id: 'c', name: 'first', application: 'app', index: 0, stages: [] }),
         buildPipeline({ id: 'd', name: 'third', application: 'app', index: 2, stages: [] }),
       ];
-      $http.expectGET(API.baseUrl + '/applications/app/pipelineConfigs').respond(200, fromServer);
+      $httpBackend.expectGET(API.baseUrl + '/applications/app/pipelineConfigs').respond(200, fromServer);
 
       PipelineConfigService.getPipelinesForApplication('app').then((pipelines: IPipeline[]) => {
         result = pipelines;
       });
       $scope.$digest();
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.map((r) => r.name)).toEqual(['first', 'second', 'third', 'last']);
     });
@@ -123,8 +123,8 @@ describe('PipelineConfigService', () => {
       ];
 
       const posted: any[] = [];
-      $http.expectGET(API.baseUrl + '/applications/app/pipelineConfigs').respond(200, fromServer);
-      $http
+      $httpBackend.expectGET(API.baseUrl + '/applications/app/pipelineConfigs').respond(200, fromServer);
+      $httpBackend
         .whenPOST(API.baseUrl + '/pipelines', (data: string) => {
           const json: any = JSON.parse(data);
           posted.push({ index: json.index, name: json.name });
@@ -134,7 +134,7 @@ describe('PipelineConfigService', () => {
 
       PipelineConfigService.getPipelinesForApplication('app');
       $scope.$digest();
-      $http.flush();
+      $httpBackend.flush();
 
       expect(posted).toEqual([
         { name: 'first', index: 0 },

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
@@ -7,7 +7,7 @@ import { ExecutionService } from 'core/pipeline/service/execution.service';
 describe('Service: manualJudgment', () => {
   let $scope: IScope,
     service: ManualJudgmentService,
-    $http: IHttpBackendService,
+    $httpBackend: IHttpBackendService,
     $q: IQService,
     executionService: ExecutionService;
 
@@ -18,13 +18,13 @@ describe('Service: manualJudgment', () => {
       (
         $rootScope: IRootScopeService,
         manualJudgmentService: ManualJudgmentService,
-        $httpBackend: IHttpBackendService,
+        _$httpBackend_: IHttpBackendService,
         _$q_: IQService,
         _executionService_: ExecutionService,
       ) => {
         $scope = $rootScope.$new();
         service = manualJudgmentService;
-        $http = $httpBackend;
+        $httpBackend = _$httpBackend_;
         $q = _$q_;
         executionService = _executionService_;
       },
@@ -43,13 +43,13 @@ describe('Service: manualJudgment', () => {
       const deferred: IDeferred<boolean> = $q.defer();
       let succeeded = false;
 
-      $http.expectPATCH(requestUrl).respond(200, '');
+      $httpBackend.expectPATCH(requestUrl).respond(200, '');
       spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
       spyOn(executionService, 'updateExecution').and.stub();
 
       service.provideJudgment(null, execution, stage, 'continue').then(() => (succeeded = true));
 
-      $http.flush();
+      $httpBackend.flush();
       expect(succeeded).toBe(false);
 
       // waitForExecutionMatches...
@@ -64,7 +64,7 @@ describe('Service: manualJudgment', () => {
       let succeeded = false,
         failed = false;
 
-      $http.expectPATCH(requestUrl).respond(200, '');
+      $httpBackend.expectPATCH(requestUrl).respond(200, '');
       spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
 
       service.provideJudgment(null, execution, stage, 'continue').then(
@@ -72,7 +72,7 @@ describe('Service: manualJudgment', () => {
         () => (failed = true),
       );
 
-      $http.flush();
+      $httpBackend.flush();
       expect(succeeded).toBe(false);
       expect(failed).toBe(false);
 
@@ -88,14 +88,14 @@ describe('Service: manualJudgment', () => {
       let succeeded = false,
         failed = false;
 
-      $http.expectPATCH(requestUrl).respond(503, '');
+      $httpBackend.expectPATCH(requestUrl).respond(503, '');
 
       service.provideJudgment(null, execution, stage, 'continue').then(
         () => (succeeded = true),
         () => (failed = true),
       );
 
-      $http.flush();
+      $httpBackend.flush();
       expect(succeeded).toBe(false);
       expect(failed).toBe(true);
     });

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -1,4 +1,5 @@
 import { IHttpBackendService, IQProvider, IQService, ITimeoutService, mock, noop } from 'angular';
+import { REACT_MODULE } from 'core/reactShims';
 
 import { EXECUTION_SERVICE, ExecutionService } from './execution.service';
 import { IExecution } from 'core/domain';
@@ -12,7 +13,7 @@ describe('Service: executionService', () => {
   let timeout: ITimeoutService;
   let $q: IQService;
 
-  beforeEach(mock.module(EXECUTION_SERVICE, 'ui.router'));
+  beforeEach(mock.module(REACT_MODULE, EXECUTION_SERVICE, 'ui.router'));
 
   // https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$q
   beforeEach(

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -258,7 +258,6 @@ export class ExecutionService {
       .withParams({ force, reason })
       .put()
       .then(() => this.waitUntilPipelineIsCancelled(application, executionId))
-      .then(() => application.executions.refresh())
       .catch((exception) => {
         throw exception && exception.data ? exception.message : null;
       });

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -1,4 +1,4 @@
-import { IHttpService, IQService, ITimeoutService, module } from 'angular';
+import { IQService, ITimeoutService, module } from 'angular';
 import { get, identity, pickBy } from 'lodash';
 import { StateService } from '@uirouter/core';
 
@@ -36,12 +36,7 @@ export class ExecutionService {
     '$$hashKey',
   ];
 
-  constructor(
-    private $http: IHttpService,
-    private $q: IQService,
-    private $state: StateService,
-    private $timeout: ITimeoutService,
-  ) {}
+  constructor(private $q: IQService, private $state: StateService, private $timeout: ITimeoutService) {}
 
   public getRunningExecutions(applicationName: string): PromiseLike<IExecution[]> {
     return this.getFilteredExecutions(applicationName, this.activeStatuses, this.runningLimit, null, true);
@@ -259,80 +254,56 @@ export class ExecutionService {
     force?: boolean,
     reason?: string,
   ): PromiseLike<any> {
-    const deferred = this.$q.defer();
-    this.$http({
-      method: 'PUT',
-      url: [SETTINGS.gateUrl, 'pipelines', executionId, 'cancel'].join('/'),
-      params: {
-        force,
-        reason,
-      },
-    }).then(
-      () => this.waitUntilPipelineIsCancelled(application, executionId).then(deferred.resolve),
-      (exception) => deferred.reject(exception && exception.data ? exception.message : null),
-    );
-    return deferred.promise;
+    return API.one('pipelines', executionId, 'cancel')
+      .withParams({ force, reason })
+      .put()
+      .then(() => this.waitUntilPipelineIsCancelled(application, executionId))
+      .then(() => application.executions.refresh())
+      .catch((exception) => {
+        throw exception && exception.data ? exception.message : null;
+      });
   }
 
   public pauseExecution(application: Application, executionId: string): PromiseLike<any> {
-    const deferred = this.$q.defer();
-    const matcher = (execution: IExecution) => {
-      return execution.status === 'PAUSED';
-    };
-
-    this.$http({
-      method: 'PUT',
-      url: [SETTINGS.gateUrl, 'pipelines', executionId, 'pause'].join('/'),
-    }).then(
-      () =>
-        this.waitUntilExecutionMatches(executionId, matcher)
-          .then(() => application.executions.refresh())
-          .then(deferred.resolve),
-      (exception) => deferred.reject(exception && exception.data ? exception.message : null),
-    );
-    return deferred.promise;
+    return API.one('pipelines', executionId, 'pause')
+      .put()
+      .then(() => this.waitUntilExecutionMatches(executionId, (execution) => execution.status === 'PAUSED'))
+      .then(() => application.executions.refresh())
+      .catch((exception) => {
+        throw exception && exception.data ? exception.message : null;
+      });
   }
 
   public resumeExecution(application: Application, executionId: string): PromiseLike<any> {
-    const deferred = this.$q.defer();
-    const matcher = (execution: IExecution) => {
-      return execution.status === 'RUNNING';
-    };
-
-    this.$http({
-      method: 'PUT',
-      url: [SETTINGS.gateUrl, 'pipelines', executionId, 'resume'].join('/'),
-    }).then(
-      () =>
-        this.waitUntilExecutionMatches(executionId, matcher)
-          .then(() => application.executions.refresh())
-          .then(deferred.resolve),
-      (exception) => deferred.reject(exception && exception.data ? exception.message : null),
-    );
-    return deferred.promise;
+    return API.one('pipelines', executionId, 'resume')
+      .put()
+      .then(() => this.waitUntilExecutionMatches(executionId, (execution) => execution.status === 'RUNNING'))
+      .then(() => application.executions.refresh())
+      .catch((exception) => {
+        throw exception && exception.data ? exception.message : null;
+      });
   }
 
   public deleteExecution(application: Application, executionId: string): PromiseLike<any> {
-    const deferred = this.$q.defer();
-    this.$http({
-      method: 'DELETE',
-      url: [SETTINGS.gateUrl, 'pipelines', executionId].join('/'),
-    }).then(
-      () => this.waitUntilPipelineIsDeleted(application, executionId).then(deferred.resolve),
-      (exception) => deferred.reject(exception && exception.data ? exception.data.message : null),
-    );
-    return deferred.promise;
+    const promiseLike = API.one('pipelines', executionId)
+      .delete()
+      .then(() => this.waitUntilPipelineIsDeleted(application, executionId))
+      .then(() => application.executions.refresh())
+      .catch((exception) => {
+        throw exception && exception.data ? exception.message : null;
+      });
+    return promiseLike;
   }
 
   public waitUntilExecutionMatches(
     executionId: string,
-    closure: (execution: IExecution) => boolean,
+    matchPredicate: (execution: IExecution) => boolean,
   ): PromiseLike<IExecution> {
     return this.getExecution(executionId).then((execution) => {
-      if (closure(execution)) {
+      if (matchPredicate(execution)) {
         return execution;
       }
-      return this.$timeout(() => this.waitUntilExecutionMatches(executionId, closure), 1000);
+      return this.$timeout(() => this.waitUntilExecutionMatches(executionId, matchPredicate), 1000);
     });
   }
 
@@ -547,14 +518,7 @@ export class ExecutionService {
   }
 
   public patchExecution(executionId: string, stageId: string, data: any): PromiseLike<any> {
-    const targetUrl = [SETTINGS.gateUrl, 'pipelines', executionId, 'stages', stageId].join('/');
-    const request = {
-      method: 'PATCH',
-      url: targetUrl,
-      data,
-      timeout: (SETTINGS.pollSchedule || 30000) * 2 + 5000,
-    };
-    return this.$http(request).then((resp) => resp.data);
+    return API.one('pipelines', executionId, 'stages', stageId).patch(data);
   }
 
   private stringifyExecution(execution: IExecution): string {
@@ -570,12 +534,10 @@ export class ExecutionService {
 
 export const EXECUTION_SERVICE = 'spinnaker.core.pipeline.executions.service';
 module(EXECUTION_SERVICE, [UIROUTER_ANGULARJS]).factory('executionService', [
-  '$http',
   '$q',
   '$state',
   '$timeout',
-  ($http: IHttpService, $q: IQService, $state: StateService, $timeout: ITimeoutService) =>
-    new ExecutionService($http, $q, $state, $timeout),
+  ($q: IQService, $state: StateService, $timeout: ITimeoutService) => new ExecutionService($q, $state, $timeout),
 ]);
 
 DebugWindow.addInjectable('executionService');

--- a/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
@@ -5,17 +5,17 @@ import { SubnetReader } from 'core/subnet/subnet.read.service';
 import { ISubnet } from 'core/domain';
 
 describe('SubnetReader', function () {
-  let $http: IHttpBackendService, $scope: IScope;
+  let $httpBackend: IHttpBackendService, $scope: IScope;
 
   beforeEach(
-    mock.inject(function ($httpBackend: IHttpBackendService, $rootScope: IRootScopeService) {
-      $http = $httpBackend;
+    mock.inject(function (_$httpBackend_: IHttpBackendService, $rootScope: IRootScopeService) {
+      $httpBackend = _$httpBackend_;
       $scope = $rootScope.$new();
     }),
   );
 
   it('adds label to subnet, including (deprecated) if deprecated field is true', function () {
-    $http
+    $httpBackend
       .whenGET(API.baseUrl + '/subnets')
       .respond(200, [
         { purpose: 'internal', deprecated: true },
@@ -29,7 +29,7 @@ describe('SubnetReader', function () {
       result = subnets;
     });
 
-    $http.flush();
+    $httpBackend.flush();
     $scope.$digest();
 
     expect(result[0].label).toBe('internal (deprecated)');

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
@@ -10,12 +10,12 @@ import { OrchestratedItemTransformer } from 'core/orchestratedItem/orchestratedI
 import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 
 describe('TaskMonitor', () => {
-  let $scope: ng.IScope, $http: ng.IHttpBackendService;
+  let $scope: ng.IScope, $httpBackend: ng.IHttpBackendService;
 
   beforeEach(
-    mock.inject(($rootScope: ng.IRootScopeService, $httpBackend: ng.IHttpBackendService) => {
+    mock.inject(($rootScope: ng.IRootScopeService, _$httpBackend_: ng.IHttpBackendService) => {
       $scope = $rootScope.$new();
-      $http = $httpBackend;
+      $httpBackend = _$httpBackend_;
     }),
   );
 
@@ -45,15 +45,15 @@ describe('TaskMonitor', () => {
 
       $timeout.flush(); // still running first time
 
-      $http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
+      $httpBackend.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
       $timeout.flush();
-      $http.flush();
+      $httpBackend.flush();
       expect(monitor.task.isCompleted).toBe(false);
       expect((monitor.application.getDataSource('runningTasks').refresh as Spy).calls.count()).toBe(1);
 
-      $http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
+      $httpBackend.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
       $timeout.flush(); // complete second time
-      $http.flush();
+      $httpBackend.flush();
 
       expect(completeCalled).toBe(true);
       expect(monitor.task.isCompleted).toBe(true);
@@ -109,14 +109,14 @@ describe('TaskMonitor', () => {
 
       $timeout.flush(); // still running first time
 
-      $http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
+      $httpBackend.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
       $timeout.flush();
-      $http.flush();
+      $httpBackend.flush();
       expect(monitor.task.isCompleted).toBe(false);
 
-      $http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'TERMINAL' });
+      $httpBackend.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'TERMINAL' });
       $timeout.flush(); // complete second time
-      $http.flush();
+      $httpBackend.flush();
 
       expect(monitor.submitting).toBe(false);
       expect(monitor.error).toBe(true);

--- a/app/scripts/modules/core/src/widgets/spelText/SpelText.tsx
+++ b/app/scripts/modules/core/src/widgets/spelText/SpelText.tsx
@@ -5,7 +5,7 @@ import './spel.less';
 
 import classNames from 'classnames';
 import $ from 'jquery';
-import { $q, $http, $timeout } from 'ngimport';
+import { $q, $timeout } from 'ngimport';
 import { SpelAutocompleteService } from './SpelAutocompleteService';
 import { ExecutionService } from '../../pipeline/service/execution.service';
 import { StateService } from '@uirouter/core';
@@ -37,10 +37,7 @@ export class SpelText extends React.Component<ISpelTextProps, ISpelTextState> {
   constructor(props: ISpelTextProps) {
     super(props);
     this.state = { textcompleteConfig: [] };
-    this.autocompleteService = new SpelAutocompleteService(
-      $q,
-      new ExecutionService($http, $q, {} as StateService, $timeout),
-    );
+    this.autocompleteService = new SpelAutocompleteService($q, new ExecutionService($q, {} as StateService, $timeout));
     Observable.fromPromise(this.autocompleteService.addPipelineInfo(this.props.pipeline))
       .takeUntil(this.destroy$)
       .subscribe((textcompleteConfig) => {

--- a/app/scripts/modules/dcos/image/image.reader.spec.js
+++ b/app/scripts/modules/dcos/image/image.reader.spec.js
@@ -3,20 +3,20 @@
 import { API } from '@spinnaker/core';
 
 describe('Service: DCOS Image Reader', function () {
-  var service, $http;
+  var service, $httpBackend;
 
   beforeEach(window.module(require('./image.reader').name));
 
   beforeEach(
-    window.inject(function (dcosImageReader, $httpBackend) {
+    window.inject(function (dcosImageReader, _$httpBackend_) {
       service = dcosImageReader;
-      $http = $httpBackend;
+      $httpBackend = _$httpBackend_;
     }),
   );
 
   afterEach(function () {
-    $http.verifyNoOutstandingRequest();
-    $http.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+    $httpBackend.verifyNoOutstandingExpectation();
   });
 
   describe('findImages', function () {
@@ -30,13 +30,13 @@ describe('Service: DCOS Image Reader', function () {
     it('queries gate when 3 characters are supplied', function () {
       var result = null;
 
-      $http.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
 
       service.findImages({ provider: 'dcos', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
@@ -47,7 +47,7 @@ describe('Service: DCOS Image Reader', function () {
 
       query = 'abcd';
 
-      $http.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
 
       var promise = service.findImages({ provider: 'dcos', q: query, region: region });
 
@@ -55,7 +55,7 @@ describe('Service: DCOS Image Reader', function () {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
@@ -65,13 +65,13 @@ describe('Service: DCOS Image Reader', function () {
       query = 'abc';
       var result = null;
 
-      $http.when('GET', buildQueryString()).respond(404, {});
+      $httpBackend.when('GET', buildQueryString()).respond(404, {});
 
       service.findImages({ provider: 'dcos', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $http.flush();
+      $httpBackend.flush();
 
       expect(result.length).toBe(0);
     });

--- a/app/scripts/modules/google/src/instance/gceInstanceType.service.js
+++ b/app/scripts/modules/google/src/instance/gceInstanceType.service.js
@@ -10,10 +10,9 @@ import { GCE_INSTANCE_TYPE_DISK_DEFAULTS } from './gceInstanceTypeDisks';
 export const GOOGLE_INSTANCE_GCEINSTANCETYPE_SERVICE = 'spinnaker.gce.instanceType.service';
 export const name = GOOGLE_INSTANCE_GCEINSTANCETYPE_SERVICE; // for backwards compatibility
 module(GOOGLE_INSTANCE_GCEINSTANCETYPE_SERVICE, []).factory('gceInstanceTypeService', [
-  '$http',
   '$q',
   '$log',
-  function ($http, $q, $log) {
+  function ($q, $log) {
     const cachedResult = null;
 
     const n1standard = {

--- a/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -12,7 +12,7 @@ import {
 import { OracleProviderSettings } from 'oracle/oracle.settings';
 
 describe('Controller: oracleCreateLoadBalancerCtrl', function () {
-  let $http: ng.IHttpBackendService;
+  let $httpBackend: ng.IHttpBackendService;
   let controller: OracleLoadBalancerController;
   const loadBalancer: IOracleLoadBalancer = null;
   let $scope: IScope;
@@ -49,9 +49,9 @@ describe('Controller: oracleCreateLoadBalancerCtrl', function () {
   );
 
   beforeEach(
-    mock.inject(function ($httpBackend: ng.IHttpBackendService) {
+    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
       // Set up the mock http service responses
-      $http = $httpBackend;
+      $httpBackend = _$httpBackend_;
     }),
   );
 
@@ -182,10 +182,10 @@ describe('Controller: oracleCreateLoadBalancerCtrl', function () {
   });
 
   it('makes the expected REST calls for data for a new loadbalancer', function () {
-    $http.expect('GET', API.baseUrl + '/networks/oracle').respond([]);
-    $http.expect('GET', API.baseUrl + '/subnets/oracle').respond([]);
-    $http.flush();
-    $http.verifyNoOutstandingExpectation();
-    $http.verifyNoOutstandingRequest();
+    $httpBackend.expect('GET', API.baseUrl + '/networks/oracle').respond([]);
+    $httpBackend.expect('GET', API.baseUrl + '/subnets/oracle').respond([]);
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
   });
 });


### PR DESCRIPTION
While migrating tests away from `$httpBackend` I noticed that there is still some direct usage of `$http`.  Where possible, I migrated these to `API`.

I also migrated `$http.expectGET()` calls to `$httpBackend.expectGET` to enable an upcoming migration of tests from`$httpBackend` to `MockHttpClient`

This PR is organized into 3 separate commits for easier reading