### PR TITLE
fix: use 'import type {} from package' to fix the webpack warnings for missing interface imports

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
@@ -6,7 +6,7 @@ import { Debounce, Throttle } from 'lodash-decorators';
 import { clone, find, flatten, forOwn, groupBy, max, maxBy, sortBy, sum, sumBy, uniq } from 'lodash';
 import { Subscription } from 'rxjs';
 
-import { IExecution, IPipeline } from 'core/domain';
+import type { IExecution, IPipeline } from 'core/domain';
 import { IPipelineValidationResults } from '../validation/PipelineConfigValidator';
 import { UUIDGenerator } from 'core/utils/uuid.service';
 import { PipelineConfigValidator } from '../validation/PipelineConfigValidator';

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -12,7 +12,7 @@ import { StageExecutionDetails } from '../../details/StageExecutionDetails';
 import { ExecutionStatus } from '../../status/ExecutionStatus';
 import { ParametersAndArtifacts } from '../../status/ParametersAndArtifacts';
 import { ExecutionCancellationReason } from '../../status/ExecutionCancellationReason';
-import { IExecution, IRestartDetails, IPipeline } from 'core/domain';
+import type { IExecution, IRestartDetails, IPipeline } from 'core/domain';
 import { IExecutionViewState, IPipelineGraphNode } from '../../config/graph/pipelineGraph.service';
 import { OrchestratedItemRunningTime } from './OrchestratedItemRunningTime';
 import { SETTINGS } from 'core/config/settings';


### PR DESCRIPTION
Fixes these warnings:

```
export 'IPipeline' was not found in 'core/domain'
```
