### PR TITLE
feat(eslint-plugin): Add a new rule to migrate from $httpBackend to MockHttpClient

### DIFF
--- a/packages/eslint-plugin/base.config.js
+++ b/packages/eslint-plugin/base.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '@spinnaker/import-from-npm-not-alias': 2,
     '@spinnaker/import-from-npm-not-relative': 2,
     '@spinnaker/import-relative-within-subpackage': 2,
+    '@spinnaker/migrate-to-mock-http-client': 2,
     '@spinnaker/ng-no-component-class': 2,
     '@spinnaker/ng-no-module-export': 2,
     '@spinnaker/ng-no-require-angularjs': 2,

--- a/packages/eslint-plugin/eslint-plugin.js
+++ b/packages/eslint-plugin/eslint-plugin.js
@@ -7,6 +7,7 @@ module.exports = {
     'import-from-npm-not-alias': require('./rules/import-from-npm-not-alias'),
     'import-from-npm-not-relative': require('./rules/import-from-npm-not-relative'),
     'import-relative-within-subpackage': require('./rules/import-relative-within-subpackage'),
+    'migrate-to-mock-http-client': require('./rules/migrate-to-mock-http-client'),
     'ng-no-component-class': require('./rules/ng-no-component-class'),
     'ng-no-module-export': require('./rules/ng-no-module-export'),
     'ng-no-require-angularjs': require('./rules/ng-no-require-angularjs'),

--- a/packages/eslint-plugin/rules/migrate-to-mock-http-client.js
+++ b/packages/eslint-plugin/rules/migrate-to-mock-http-client.js
@@ -1,0 +1,128 @@
+'use strict';
+// @ts-check
+
+/**
+ * Import AST Types from 'estree'
+ * @typedef {import('estree').CallExpression} CallExpression
+ * @typedef {import('estree').ImportSpecifier} ImportSpecifier
+ */
+
+const _ = require('lodash/fp');
+
+const { getProgram } = require('../utils/utils');
+
+/** @type {RuleModule} */
+module.exports = {
+  create(context) {
+    const text = (node) => context.getSourceCode().getText(node);
+
+    return {
+      /** @param node {CallExpression} */
+      CallExpression(node) {
+        /** it(() => {}) */
+        const isItBlock = node.callee.type === 'Identifier' && node.callee.name === 'it';
+
+        if (isItBlock) {
+          const itBlockText = text(node);
+          const testFunction = node.arguments[1];
+
+          const doesFunctionIncludeHttpBackend = !!testFunction && itBlockText.includes('$httpBackend');
+
+          if (doesFunctionIncludeHttpBackend) {
+            const isFirstArgAFunction = ['FunctionExpression', 'ArrowFunctionExpression'].includes(testFunction.type);
+
+            if (isFirstArgAFunction) {
+              // Fix 1: make the test 'async'
+              if (testFunction.async !== true) {
+                return context.report({
+                  node,
+                  message: 'Migrate to MockHttpClient (step 1): make test function async',
+                  fix: (fixer) => fixer.insertTextBefore(testFunction, 'async '),
+                });
+              }
+
+              // Fix 2: Add a 'http' variable
+              if (
+                testFunction.body.type === 'BlockStatement' &&
+                !text(testFunction.body.body[0]).includes('mockHttpClient')
+              ) {
+                const program = getProgram(node);
+                const allImports = program.body.filter((item) => item.type === 'ImportDeclaration');
+                /** @type {Array<ImportSpecifier>} */
+                const importSpecifiers = allImports
+                  .map((decl) => decl.specifiers)
+                  .reduce((acc, x) => acc.concat(x), []);
+
+                const mockHttpClientImmport = importSpecifiers.find((specifier) => {
+                  return specifier.imported && specifier.imported.name === 'mockHttpClient';
+                });
+
+                return context.report({
+                  node,
+                  message: 'Migrate to MockHttpClient (step 2): Create a MockHttpClient named "http"',
+                  fix: (fixer) => {
+                    const insertHttp = fixer.insertTextBefore(
+                      testFunction.body.body[0],
+                      'const http = mockHttpClient();\n',
+                    );
+
+                    let insertImport = fixer.insertTextBeforeRange(
+                      [0, 0],
+                      `import { mockHttpClient } from 'core/api/mock/jasmine';\n`,
+                    );
+
+                    // Put after 'use strict'
+                    const sourcecode = text(program);
+                    const [preamble] = /^['"]use strict['"];?/.exec(sourcecode) || [];
+                    if (preamble) {
+                      const insertPos = preamble.length;
+                      insertImport = fixer.insertTextAfterRange(
+                        [insertPos, insertPos],
+                        `\nimport { mockHttpClient } from 'core/api/mock/jasmine';`,
+                      );
+                    }
+
+                    if (mockHttpClientImmport) {
+                      return insertHttp;
+                    } else {
+                      return [insertHttp, insertImport];
+                    }
+                  },
+                });
+              }
+
+              // Fix 3:
+              // - replace "$httpBackend.when('GET'" with "$httpBackend.expectGET("
+              // - replace "$httpBackend.whenGET" with "$httpBackend.expectGET"
+              // - replace "$httpBackend" with "http"
+              return context.report({
+                node,
+                message: 'Migrate to MockHttpClient (step 3): replace $httpBackend with http',
+                fix: (fixer) => {
+                  const newItBlockText = itBlockText
+                    .replace(/(this\.)?\$httpBackend\.when(GET|POST|PUT|PATCH|DELETE)/g, '$httpBackend.expect$2')
+                    .replace(
+                      /(this\.)?\$httpBackend\.when\(['"](GET|POST|PUT|PATCH|DELETE)['"], /g,
+                      '$httpBackend.expect$2(',
+                    )
+                    .replace(/(this\.)?\$httpBackend/g, 'http')
+                    .replace(/http.flush/g, 'await http.flush')
+                    .replace(/await await /g, 'await ');
+
+                  return fixer.replaceText(node, newItBlockText);
+                },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+  meta: {
+    fixable: 'code',
+    type: 'problem',
+    docs: {
+      description: 'Do not import API',
+    },
+  },
+};

--- a/packages/eslint-plugin/test/migrate-to-mock-http-client.spec.js
+++ b/packages/eslint-plugin/test/migrate-to-mock-http-client.spec.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const ruleTester = require('../utils/ruleTester');
+const rule = require('../rules/migrate-to-mock-http-client');
+
+ruleTester.run('migrate-to-mock-http-client', rule, {
+  valid: [
+    {
+      code: 'it(() => { const http = mockHttpClient(); })',
+    },
+  ],
+  invalid: [
+    {
+      code: `it('does things', () => { $httpBackend.flush() })`,
+      output: `it('does things', async () => { $httpBackend.flush() })`,
+      errors: ['Migrate to MockHttpClient (step 1): make test function async'],
+    },
+
+    // Step 1 make async
+    {
+      code: `
+describe('foo bar', () => {
+  it('does things', () => {
+    $httpBackend.flush()
+  })
+})`,
+      output: `
+describe('foo bar', () => {
+  it('does things', async () => {
+    $httpBackend.flush()
+  })
+})`,
+      errors: ['Migrate to MockHttpClient (step 1): make test function async'],
+    },
+
+    // Step 2 create mock
+    {
+      code: `
+describe('foo bar', () => {
+  it('does things', async () => {
+    $httpBackend.flush()
+  })
+})`,
+      output: `import { mockHttpClient } from 'core/api/mock/jasmine';
+
+describe('foo bar', () => {
+  it('does things', async () => {
+    const http = mockHttpClient();
+$httpBackend.flush()
+  })
+})`,
+      errors: ['Migrate to MockHttpClient (step 2): Create a MockHttpClient named "http"'],
+    },
+
+    // Step 3 change variables
+    {
+      code: `
+import { mockHttpClient } from 'core/api/mock/jasmine';
+describe('foo bar', () => {
+  it('does things', async () => {
+    const http = mockHttpClient();
+    $httpBackend.expectGET('/foo/bar').respond(200, { bar: 15 });
+    service.fetchBars();
+    $httpBackend.flush()
+  })
+})`,
+      output: `
+import { mockHttpClient } from 'core/api/mock/jasmine';
+describe('foo bar', () => {
+  it('does things', async () => {
+    const http = mockHttpClient();
+    http.expectGET('/foo/bar').respond(200, { bar: 15 });
+    service.fetchBars();
+    await http.flush()
+  })
+})`,
+      errors: ['Migrate to MockHttpClient (step 3): replace $httpBackend with http'],
+    },
+  ],
+});


### PR DESCRIPTION
This migrates to the mock HTTP client introduced in #8775

### from

```ts
describe('service', () => {
  it('fetches a foo', () => {
    $httpBackend.expectGET('/rest/foo').respond(200, { fooData: [] });
    const fooPromise = service.fetchFoo();
    $httpBackend.flush();
});
```

### to

```ts
import { mockHttpClient } from 'core/api/mock/jasmine';

describe('service', () => {
  it('fetches a foo', async () => {
    const http = mockHttpClient();
    http.expectGET('/rest/foo').respond(200, { fooData: [] });
    const fooPromise = service.fetchFoo();
    await http.flush();
});
```

This migration isn't expected to work out of the box in all cases.  Manual rewrite of some tests will be necessary.