### PR TITLE
Migrate tests to MockHttpClient

### DIFF
--- a/app/scripts/modules/amazon/src/image/image.reader.spec.js
+++ b/app/scripts/modules/amazon/src/image/image.reader.spec.js
@@ -6,20 +6,14 @@ import { API } from '@spinnaker/core';
 import { AwsImageReader } from './image.reader';
 
 describe('Service: aws Image Reader', function () {
-  var service, $httpBackend, scope;
+  var service, scope;
 
   beforeEach(
-    window.inject(function (_$httpBackend_, $rootScope) {
+    window.inject(function ($rootScope) {
       service = new AwsImageReader();
-      $httpBackend = _$httpBackend_;
       scope = $rootScope.$new();
     }),
   );
-
-  afterEach(function () {
-    $httpBackend.verifyNoOutstandingRequest();
-    $httpBackend.verifyNoOutstandingExpectation();
-  });
 
   describe('findImages', function () {
     var query = 'abc',

--- a/app/scripts/modules/amazon/src/image/image.reader.spec.js
+++ b/app/scripts/modules/amazon/src/image/image.reader.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 
 import { API } from '@spinnaker/core';
 
@@ -28,27 +29,29 @@ describe('Service: aws Image Reader', function () {
       return API.baseUrl + '/images/find?provider=aws&q=' + query + '&region=' + region;
     }
 
-    it('queries gate when 3 characters are supplied', function () {
+    it('queries gate when 3 characters are supplied', async function () {
+      const http = mockHttpClient();
       var result = null;
 
-      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      http.expectGET(buildQueryString()).respond(200, [{ success: true }]);
 
       service.findImages({ provider: 'aws', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
     });
 
-    it('queries gate when more than 3 characters are supplied', function () {
+    it('queries gate when more than 3 characters are supplied', async function () {
+      const http = mockHttpClient();
       var result = null;
 
       query = 'abcd';
 
-      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      http.expectGET(buildQueryString()).respond(200, [{ success: true }]);
 
       var promise = service.findImages({ provider: 'aws', q: query, region: region });
 
@@ -56,7 +59,7 @@ describe('Service: aws Image Reader', function () {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
@@ -77,17 +80,18 @@ describe('Service: aws Image Reader', function () {
       expect(result[0].message).toBe('Please enter at least 3 characters...');
     });
 
-    it('returns an empty array when server errors', function () {
+    it('returns an empty array when server errors', async function () {
+      const http = mockHttpClient();
       query = 'abc';
       var result = null;
 
-      $httpBackend.when('GET', buildQueryString()).respond(404, {});
+      http.expectGET(buildQueryString()).respond(404, {});
 
       service.findImages({ provider: 'aws', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(0);
     });
@@ -102,28 +106,29 @@ describe('Service: aws Image Reader', function () {
       return [API.baseUrl, 'images', credentials, region, imageName].join('/') + '?provider=aws';
     }
 
-    it('returns null if server returns 404 or an empty list', function () {
+    it('returns null if server returns 404 or an empty list', async function () {
+      const http = mockHttpClient();
       var result = 'not null';
 
-      $httpBackend.when('GET', buildQueryString()).respond(404, {});
+      http.expectGET(buildQueryString()).respond(404, {});
 
       service.getImage(imageName, region, credentials).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result).toBe(null);
 
       result = 'not null';
 
-      $httpBackend.when('GET', buildQueryString()).respond(200, []);
+      http.expectGET(buildQueryString()).respond(200, []);
 
       service.getImage(imageName, region, credentials).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result).toBe(null);
     });

--- a/app/scripts/modules/amazon/src/image/image.reader.spec.js
+++ b/app/scripts/modules/amazon/src/image/image.reader.spec.js
@@ -1,8 +1,5 @@
 'use strict';
 import { mockHttpClient } from 'core/api/mock/jasmine';
-
-import { API } from '@spinnaker/core';
-
 import { AwsImageReader } from './image.reader';
 
 describe('Service: aws Image Reader', function () {
@@ -19,9 +16,7 @@ describe('Service: aws Image Reader', function () {
     var query = 'abc',
       region = 'us-west-1';
 
-    function buildQueryString() {
-      return API.baseUrl + '/images/find?provider=aws&q=' + query + '&region=' + region;
-    }
+    const buildQueryString = () => `/images/find?provider=aws&q=${query}&region=${region}`;
 
     it('queries gate when 3 characters are supplied', async function () {
       const http = mockHttpClient();
@@ -96,9 +91,7 @@ describe('Service: aws Image Reader', function () {
       region = 'us-west-1',
       credentials = 'test';
 
-    function buildQueryString() {
-      return [API.baseUrl, 'images', credentials, region, imageName].join('/') + '?provider=aws';
-    }
+    const buildQueryString = () => `/images/${credentials}/${region}/${imageName}?provider=aws`;
 
     it('returns null if server returns 404 or an empty list', async function () {
       const http = mockHttpClient();

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.spec.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.spec.js
@@ -9,9 +9,8 @@ describe('Service: InstanceType', function () {
   });
 
   beforeEach(
-    window.inject(function (_awsInstanceTypeService_, _$httpBackend_) {
+    window.inject(function (_awsInstanceTypeService_) {
       this.awsInstanceTypeService = _awsInstanceTypeService_;
-      this.$httpBackend = _$httpBackend_;
 
       this.allTypes = [
         { account: 'test', region: 'us-west-2', name: 'm1.small', availabilityZone: 'us-west-2a' },
@@ -31,10 +30,6 @@ describe('Service: InstanceType', function () {
       ];
     }),
   );
-
-  afterEach(function () {
-    this.$httpBackend.verifyNoOutstandingRequest();
-  });
 
   describe('getAllTypesByRegion', function () {
     it('returns types, indexed by region', async function () {

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.spec.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.spec.js
@@ -1,8 +1,6 @@
 'use strict';
 import { mockHttpClient } from 'core/api/mock/jasmine';
 
-import { API } from '@spinnaker/core';
-
 describe('Service: InstanceType', function () {
   beforeEach(function () {
     window.module(require('./awsInstanceType.service').name);
@@ -34,7 +32,7 @@ describe('Service: InstanceType', function () {
   describe('getAllTypesByRegion', function () {
     it('returns types, indexed by region', async function () {
       const http = mockHttpClient();
-      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+      http.expectGET('/instanceTypes').respond(200, this.allTypes);
 
       let results = null;
       this.awsInstanceTypeService.getAllTypesByRegion().then(function (result) {
@@ -50,7 +48,7 @@ describe('Service: InstanceType', function () {
   describe('getAvailableTypesForRegions', function () {
     it('returns results for a single region', async function () {
       const http = mockHttpClient();
-      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+      http.expectGET('/instanceTypes').respond(200, this.allTypes);
 
       let results = null,
         service = this.awsInstanceTypeService;
@@ -65,7 +63,7 @@ describe('Service: InstanceType', function () {
 
     it('returns empty list for region with no instance types', async function () {
       const http = mockHttpClient();
-      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+      http.expectGET('/instanceTypes').respond(200, this.allTypes);
 
       let results = null,
         service = this.awsInstanceTypeService;
@@ -80,7 +78,7 @@ describe('Service: InstanceType', function () {
 
     it('returns an intersection when multiple regions are provided', async function () {
       const http = mockHttpClient();
-      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+      http.expectGET('/instanceTypes').respond(200, this.allTypes);
 
       let results = null,
         service = this.awsInstanceTypeService;
@@ -110,7 +108,7 @@ describe('Service: InstanceType', function () {
 
     it('sorts instance types by family then class size', async function () {
       const http = mockHttpClient();
-      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+      http.expectGET('/instanceTypes').respond(200, this.allTypes);
 
       let results = null,
         service = this.awsInstanceTypeService;

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.spec.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 
 import { API } from '@spinnaker/core';
 
@@ -36,23 +37,25 @@ describe('Service: InstanceType', function () {
   });
 
   describe('getAllTypesByRegion', function () {
-    it('returns types, indexed by region', function () {
-      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+    it('returns types, indexed by region', async function () {
+      const http = mockHttpClient();
+      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       let results = null;
       this.awsInstanceTypeService.getAllTypesByRegion().then(function (result) {
         results = result;
       });
 
-      this.$httpBackend.flush();
+      await http.flush();
       expect(results['us-west-2'].length).toBe(2);
       expect(_.map(results['us-west-2'], 'name').sort()).toEqual(['m1.small', 'm2.xlarge']);
     });
   });
 
   describe('getAvailableTypesForRegions', function () {
-    it('returns results for a single region', function () {
-      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+    it('returns results for a single region', async function () {
+      const http = mockHttpClient();
+      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       let results = null,
         service = this.awsInstanceTypeService;
@@ -61,12 +64,13 @@ describe('Service: InstanceType', function () {
         results = service.getAvailableTypesForRegions(result, ['us-west-2']);
       });
 
-      this.$httpBackend.flush();
+      await http.flush();
       expect(results).toEqual(['m1.small', 'm2.xlarge']);
     });
 
-    it('returns empty list for region with no instance types', function () {
-      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+    it('returns empty list for region with no instance types', async function () {
+      const http = mockHttpClient();
+      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       let results = null,
         service = this.awsInstanceTypeService;
@@ -75,12 +79,13 @@ describe('Service: InstanceType', function () {
         results = service.getAvailableTypesForRegions(result, ['us-west-3']);
       });
 
-      this.$httpBackend.flush();
+      await http.flush();
       expect(results).toEqual([]);
     });
 
-    it('returns an intersection when multiple regions are provided', function () {
-      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+    it('returns an intersection when multiple regions are provided', async function () {
+      const http = mockHttpClient();
+      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       let results = null,
         service = this.awsInstanceTypeService;
@@ -89,7 +94,7 @@ describe('Service: InstanceType', function () {
         results = service.getAvailableTypesForRegions(result, ['us-west-2', 'eu-west-1']);
       });
 
-      this.$httpBackend.flush();
+      await http.flush();
       expect(results).toEqual(['m2.xlarge']);
     });
 
@@ -108,8 +113,9 @@ describe('Service: InstanceType', function () {
       expect(service.filterInstanceTypes(types, 'hvm', true)).toEqual(['c400.a', 'c300.a', 'c3.a']);
     });
 
-    it('sorts instance types by family then class size', function () {
-      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+    it('sorts instance types by family then class size', async function () {
+      const http = mockHttpClient();
+      http.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       let results = null,
         service = this.awsInstanceTypeService;
@@ -118,7 +124,7 @@ describe('Service: InstanceType', function () {
         results = service.getAvailableTypesForRegions(result, ['us-east-1']);
       });
 
-      this.$httpBackend.flush();
+      await http.flush();
       expect(results).toEqual([
         'm4.large',
         'm4.xlarge',

--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
@@ -1,5 +1,5 @@
-import { mockHttpClient } from 'core/api/mock/jasmine';
 import React from 'react';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock, IHttpBackendService } from 'angular';
 import { ShallowWrapper, ReactWrapper, shallow, mount } from 'enzyme';
 
@@ -71,7 +71,7 @@ describe('<AmazonImageSelectInput/>', () => {
       const http = mockHttpClient();
       const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
       http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, null);
-      http.expectGET(`${baseUrl}/images/find?q=${application.name}*`).respond([]);
+      http.expectGET(`${baseUrl}/images/find?q=${application.name}*`).respond(200, []);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} value={value} />);
       await http.flush();
     });

--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { mock, IHttpBackendService } from 'angular';
+import { mock } from 'angular';
 import { ShallowWrapper, ReactWrapper, shallow, mount } from 'enzyme';
 
 import { IAmazonImage } from 'amazon/image';
@@ -19,16 +19,13 @@ const imageName = 'fancypackage-1.0.0-h005.6c8b5fe-x86_64-20181206030728-xenial-
 const amiId = 'fake-abcd123';
 
 describe('<AmazonImageSelectInput/>', () => {
-  let $httpBackend: IHttpBackendService;
   let shallowComponent: ShallowWrapper<IAmazonImageSelectorProps, IAmazonImageSelectorState>;
   let mountedComponent: ReactWrapper<IAmazonImageSelectorProps, IAmazonImageSelectorState>;
 
   beforeEach(mock.module(REACT_MODULE));
-  beforeEach(mock.inject((_$httpBackend_: IHttpBackendService) => ($httpBackend = _$httpBackend_)));
+  beforeEach(mock.inject());
 
   afterEach(() => {
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
     shallowComponent && shallowComponent.unmount();
     mountedComponent && mountedComponent.unmount();
   });

--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
@@ -6,12 +6,8 @@ import { ShallowWrapper, ReactWrapper, shallow, mount } from 'enzyme';
 import { IAmazonImage } from 'amazon/image';
 import { Application } from 'core/application';
 import { REACT_MODULE } from 'core/reactShims';
-import { SETTINGS } from 'core/config';
 
 import { AmazonImageSelectInput, IAmazonImageSelectorProps, IAmazonImageSelectorState } from './AmazonImageSelectInput';
-
-const baseUrl = SETTINGS.gateUrl;
-
 const application = new Application('testapp', null, []);
 const region = 'us-region-1';
 const credentials = 'prodaccount';
@@ -41,14 +37,14 @@ describe('<AmazonImageSelectInput/>', () => {
   describe('fetches package images when mounted', () => {
     it('using application name when no amiId is present in the initial value', async () => {
       const http = mockHttpClient();
-      http.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, []);
+      http.expectGET(`/images/find?q=testapp*`).respond(200, []);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} />);
       await http.flush();
     });
 
     it('and updates isLoadingPackageImages', async () => {
       const http = mockHttpClient();
-      http.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, []);
+      http.expectGET(`/images/find?q=testapp*`).respond(200, []);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} />);
       expect(shallowComponent.state().isLoadingPackageImages).toBe(true);
       await http.flush();
@@ -58,8 +54,8 @@ describe('<AmazonImageSelectInput/>', () => {
     it('using fetching image by amiId and looking up via the imageName', async () => {
       const http = mockHttpClient();
       const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
-      http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, [value]);
-      http.expectGET(`${baseUrl}/images/find?q=fancypackage-*`).respond(200, []);
+      http.expectGET(`/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, [value]);
+      http.expectGET(`/images/find?q=fancypackage-*`).respond(200, []);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} value={value} />);
       await http.flush();
     });
@@ -67,8 +63,8 @@ describe('<AmazonImageSelectInput/>', () => {
     it('using application name when an amiId is present in the initial value, but the image was not found', async () => {
       const http = mockHttpClient();
       const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
-      http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, null);
-      http.expectGET(`${baseUrl}/images/find?q=${application.name}*`).respond(200, []);
+      http.expectGET(`/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, null);
+      http.expectGET(`/images/find?q=${application.name}*`).respond(200, []);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} value={value} />);
       await http.flush();
     });
@@ -79,8 +75,8 @@ describe('<AmazonImageSelectInput/>', () => {
     const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
     const backendValue = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
     const onChange = jasmine.createSpy('onChange');
-    http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, [backendValue]);
-    http.expectGET(`${baseUrl}/images/find?q=fancypackage-*`).respond(200, [backendValue]);
+    http.expectGET(`/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, [backendValue]);
+    http.expectGET(`/images/find?q=fancypackage-*`).respond(200, [backendValue]);
     mountedComponent = mount(<AmazonImageSelectInput {...baseProps} onChange={onChange} value={value} />);
     await http.flush();
 
@@ -91,8 +87,8 @@ describe('<AmazonImageSelectInput/>', () => {
     const http = mockHttpClient();
     const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
     const noResults = [] as IAmazonImage[];
-    http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, noResults);
-    http.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, noResults);
+    http.expectGET(`/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, noResults);
+    http.expectGET(`/images/find?q=testapp*`).respond(200, noResults);
     const onChange = jasmine.createSpy('onChange');
     mountedComponent = mount(<AmazonImageSelectInput {...baseProps} onChange={onChange} value={value} />);
     await http.flush();

--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import React from 'react';
 import { mock, IHttpBackendService } from 'angular';
 import { ShallowWrapper, ReactWrapper, shallow, mount } from 'enzyme';
@@ -41,59 +42,63 @@ describe('<AmazonImageSelectInput/>', () => {
   };
 
   describe('fetches package images when mounted', () => {
-    it('using application name when no amiId is present in the initial value', () => {
-      $httpBackend.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, []);
+    it('using application name when no amiId is present in the initial value', async () => {
+      const http = mockHttpClient();
+      http.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, []);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} />);
-      $httpBackend.flush();
+      await http.flush();
     });
 
-    it('and updates isLoadingPackageImages', () => {
-      $httpBackend.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, []);
+    it('and updates isLoadingPackageImages', async () => {
+      const http = mockHttpClient();
+      http.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, []);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} />);
       expect(shallowComponent.state().isLoadingPackageImages).toBe(true);
-      $httpBackend.flush();
+      await http.flush();
       expect(shallowComponent.state().isLoadingPackageImages).toBe(false);
     });
 
-    it('using fetching image by amiId and looking up via the imageName', () => {
+    it('using fetching image by amiId and looking up via the imageName', async () => {
+      const http = mockHttpClient();
       const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
-      $httpBackend.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, [value]);
-      $httpBackend.expectGET(`${baseUrl}/images/find?q=fancypackage-*`).respond(200, []);
+      http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, [value]);
+      http.expectGET(`${baseUrl}/images/find?q=fancypackage-*`).respond(200, []);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} value={value} />);
-      $httpBackend.flush();
+      await http.flush();
     });
 
-    it('using application name when an amiId is present in the initial value, but the image was not found', () => {
+    it('using application name when an amiId is present in the initial value, but the image was not found', async () => {
+      const http = mockHttpClient();
       const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
-      $httpBackend.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, null);
-      $httpBackend.expectGET(`${baseUrl}/images/find?q=${application.name}*`).respond([]);
+      http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, null);
+      http.expectGET(`${baseUrl}/images/find?q=${application.name}*`).respond([]);
       shallowComponent = shallow(<AmazonImageSelectInput {...baseProps} value={value} />);
-      $httpBackend.flush();
+      await http.flush();
     });
   });
 
-  it('calls onChange with the backend image when the package images are loaded', () => {
+  it('calls onChange with the backend image when the package images are loaded', async () => {
+    const http = mockHttpClient();
     const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
     const backendValue = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
     const onChange = jasmine.createSpy('onChange');
-    $httpBackend
-      .expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`)
-      .respond(200, [backendValue]);
-    $httpBackend.expectGET(`${baseUrl}/images/find?q=fancypackage-*`).respond(200, [backendValue]);
+    http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, [backendValue]);
+    http.expectGET(`${baseUrl}/images/find?q=fancypackage-*`).respond(200, [backendValue]);
     mountedComponent = mount(<AmazonImageSelectInput {...baseProps} onChange={onChange} value={value} />);
-    $httpBackend.flush();
+    await http.flush();
 
     expect(onChange).toHaveBeenCalledWith(backendValue);
   });
 
-  it('calls onChange with null image when the image is not found in the package images', () => {
+  it('calls onChange with null image when the image is not found in the package images', async () => {
+    const http = mockHttpClient();
     const value = AmazonImageSelectInput.makeFakeImage(imageName, amiId, region);
     const noResults = [] as IAmazonImage[];
-    $httpBackend.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, noResults);
-    $httpBackend.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, noResults);
+    http.expectGET(`${baseUrl}/images/${credentials}/${region}/${amiId}?provider=aws`).respond(200, noResults);
+    http.expectGET(`${baseUrl}/images/find?q=testapp*`).respond(200, noResults);
     const onChange = jasmine.createSpy('onChange');
     mountedComponent = mount(<AmazonImageSelectInput {...baseProps} onChange={onChange} value={value} />);
-    $httpBackend.flush();
+    await http.flush();
 
     expect(onChange).toHaveBeenCalledWith(undefined);
   });

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
@@ -8,8 +8,7 @@ describe('Service: awsServerGroup', function () {
   beforeEach(window.module(require('./serverGroupCommandBuilder.service').name));
 
   beforeEach(
-    window.inject(function (_$httpBackend_, awsServerGroupCommandBuilder, _instanceTypeService_, _$q_, $rootScope) {
-      this.$httpBackend = _$httpBackend_;
+    window.inject(function (awsServerGroupCommandBuilder, _instanceTypeService_, _$q_, $rootScope) {
       this.service = awsServerGroupCommandBuilder;
       this.$q = _$q_;
       this.$scope = $rootScope;

--- a/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
+++ b/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
@@ -28,51 +28,38 @@ describe('VpcReader', function () {
   });
 
   it('adds label to vpc, including (deprecated) if deprecated field is true', async function () {
-    const http = mockHttpClient();
-    var result = null;
+    const http = mockHttpClient({ autoFlush: true });
+    http.expectGET(API.baseUrl + '/networks/aws').respond(200, [
+      { name: 'vpc1', id: 'vpc-1', deprecated: true },
+      { name: 'vpc2', id: 'vpc-2', deprecated: false },
+      { name: 'vpc3', id: 'vpc-3' },
+    ]);
 
-    VpcReader.listVpcs().then(function (vpcs) {
-      result = vpcs;
-    });
+    const vpcs = await VpcReader.listVpcs();
 
-    await http.flush();
-    $scope.$digest();
-
-    expect(result[0].label).toBe('vpc1 (deprecated)');
-    expect(result[0].deprecated).toBe(true);
-    expect(result[1].label).toBe('vpc2');
-    expect(result[1].deprecated).toBe(false);
-    expect(result[2].label).toBe('vpc3');
-    expect(result[2].deprecated).toBe(false);
+    expect(vpcs[0].label).toBe('vpc1 (deprecated)');
+    expect(vpcs[0].deprecated).toBe(true);
+    expect(vpcs[1].label).toBe('vpc2');
+    expect(vpcs[1].deprecated).toBe(false);
+    expect(vpcs[2].label).toBe('vpc3');
+    expect(vpcs[2].deprecated).toBe(false);
   });
 
   it('retrieves vpc name - not label - from id', async function () {
-    const http = mockHttpClient();
-    var result = null;
+    const http = mockHttpClient({ autoFlush: true });
+    http.expectGET(API.baseUrl + '/networks/aws').respond(200, [
+      { name: 'vpc1', id: 'vpc-1', deprecated: true },
+      { name: 'vpc2', id: 'vpc-2', deprecated: false },
+      { name: 'vpc3', id: 'vpc-3' },
+    ]);
 
-    VpcReader.getVpcName('vpc-1').then(function (name) {
-      result = name;
-    });
+    const vpc1 = await VpcReader.getVpcName('vpc-1');
+    expect(vpc1).toBe('vpc1');
 
-    await http.flush();
-    $scope.$digest();
+    const vpc2 = await VpcReader.getVpcName('vpc-2');
+    expect(vpc2).toBe('vpc2');
 
-    expect(result).toBe('vpc1');
-
-    VpcReader.getVpcName('vpc-2').then(function (name) {
-      result = name;
-    });
-
-    $scope.$digest();
-
-    expect(result).toBe('vpc2');
-
-    VpcReader.getVpcName('vpc-4').then(function (name) {
-      result = name;
-    });
-
-    $scope.$digest();
-
-    expect(result).toBe(null);
+    const vpc4 = await VpcReader.getVpcName('vpc-4');
+    expect(vpc4).toBe(null);
   });
 });

--- a/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
+++ b/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
@@ -1,8 +1,5 @@
 'use strict';
 import { mockHttpClient } from 'core/api/mock/jasmine';
-
-import { API } from '@spinnaker/core';
-
 import { VpcReader } from '../vpc/VpcReader';
 
 describe('VpcReader', function () {
@@ -20,7 +17,7 @@ describe('VpcReader', function () {
 
   it('adds label to vpc, including (deprecated) if deprecated field is true', async function () {
     const http = mockHttpClient({ autoFlush: true });
-    http.expectGET(API.baseUrl + '/networks/aws').respond(200, [
+    http.expectGET('/networks/aws').respond(200, [
       { name: 'vpc1', id: 'vpc-1', deprecated: true },
       { name: 'vpc2', id: 'vpc-2', deprecated: false },
       { name: 'vpc3', id: 'vpc-3' },
@@ -38,7 +35,7 @@ describe('VpcReader', function () {
 
   it('retrieves vpc name - not label - from id', async function () {
     const http = mockHttpClient({ autoFlush: true });
-    http.expectGET(API.baseUrl + '/networks/aws').respond(200, [
+    http.expectGET('/networks/aws').respond(200, [
       { name: 'vpc1', id: 'vpc-1', deprecated: true },
       { name: 'vpc2', id: 'vpc-2', deprecated: false },
       { name: 'vpc3', id: 'vpc-3' },

--- a/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
+++ b/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
@@ -6,25 +6,16 @@ import { API } from '@spinnaker/core';
 import { VpcReader } from '../vpc/VpcReader';
 
 describe('VpcReader', function () {
-  var $httpBackend, $scope;
+  var $scope;
 
   beforeEach(
-    window.inject(function (_$httpBackend_, $rootScope) {
-      $httpBackend = _$httpBackend_;
+    window.inject(function ($rootScope) {
       $scope = $rootScope.$new();
     }),
   );
 
   afterEach(function () {
     VpcReader.resetCache();
-  });
-
-  beforeEach(function () {
-    $httpBackend.whenGET(API.baseUrl + '/networks/aws').respond(200, [
-      { name: 'vpc1', id: 'vpc-1', deprecated: true },
-      { name: 'vpc2', id: 'vpc-2', deprecated: false },
-      { name: 'vpc3', id: 'vpc-3' },
-    ]);
   });
 
   it('adds label to vpc, including (deprecated) if deprecated field is true', async function () {

--- a/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
+++ b/app/scripts/modules/amazon/src/vpc/VpcReader.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 
 import { API } from '@spinnaker/core';
 
@@ -26,14 +27,15 @@ describe('VpcReader', function () {
     ]);
   });
 
-  it('adds label to vpc, including (deprecated) if deprecated field is true', function () {
+  it('adds label to vpc, including (deprecated) if deprecated field is true', async function () {
+    const http = mockHttpClient();
     var result = null;
 
     VpcReader.listVpcs().then(function (vpcs) {
       result = vpcs;
     });
 
-    $httpBackend.flush();
+    await http.flush();
     $scope.$digest();
 
     expect(result[0].label).toBe('vpc1 (deprecated)');
@@ -44,14 +46,15 @@ describe('VpcReader', function () {
     expect(result[2].deprecated).toBe(false);
   });
 
-  it('retrieves vpc name - not label - from id', function () {
+  it('retrieves vpc name - not label - from id', async function () {
+    const http = mockHttpClient();
     var result = null;
 
     VpcReader.getVpcName('vpc-1').then(function (name) {
       result = name;
     });
 
-    $httpBackend.flush();
+    await http.flush();
     $scope.$digest();
 
     expect(result).toBe('vpc1');

--- a/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mount } from 'enzyme';
 
-import { API, IArtifactAccount, IArtifactAccountPair, StageArtifactSelector } from '@spinnaker/core';
+import { IArtifactAccount, IArtifactAccountPair, StageArtifactSelector } from '@spinnaker/core';
 import { mockDeployStage, mockPipeline } from '@spinnaker/mocks';
 import { ConfigFileArtifactList } from './ConfigFileArtifactList';
 
@@ -51,7 +51,7 @@ describe('<ConfigFileArtifactList/>', () => {
         types: ['http'],
       },
     ];
-    http.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
+    http.expectGET(`/artifacts/credentials`).respond(200, body);
 
     // artifact intentionally left null indicating an expected artifact
     const configArtifacts = [

--- a/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import React from 'react';
 import { mock } from 'angular';
 import { mount } from 'enzyme';
@@ -27,14 +28,15 @@ describe('<ConfigFileArtifactList/>', () => {
     expect(wrapper.find(StageArtifactSelector).length).toBe(0);
   });
 
-  it('renders 2 children of StageArtifactSelector when 2 artifacts are passed in', () => {
+  it('renders 2 children of StageArtifactSelector when 2 artifacts are passed in', async () => {
+    const http = mockHttpClient();
     const body: IArtifactAccount[] = [
       {
         name: 'http-acc',
         types: ['http'],
       },
     ];
-    $httpBackend.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
+    http.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
 
     const configArtifacts = [
       {
@@ -62,17 +64,18 @@ describe('<ConfigFileArtifactList/>', () => {
       />,
     );
     expect(wrapper.find(StageArtifactSelector).length).toBe(2);
-    $httpBackend.flush();
+    await http.flush();
   });
 
-  it('renders 1 children of StageArtifactSelector when 1 expectedArtifacts are passed in', () => {
+  it('renders 1 children of StageArtifactSelector when 1 expectedArtifacts are passed in', async () => {
+    const http = mockHttpClient();
     const body: IArtifactAccount[] = [
       {
         name: 'http-acc',
         types: ['http'],
       },
     ];
-    $httpBackend.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
+    http.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
 
     // artifact intentionally left null indicating an expected artifact
     const configArtifacts = [
@@ -91,6 +94,6 @@ describe('<ConfigFileArtifactList/>', () => {
       />,
     );
     expect(wrapper.find(StageArtifactSelector).length).toBe(1);
-    $httpBackend.flush();
+    await http.flush();
   });
 });

--- a/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
@@ -1,6 +1,5 @@
-import { mockHttpClient } from 'core/api/mock/jasmine';
 import React from 'react';
-import { mock } from 'angular';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mount } from 'enzyme';
 
 import { API, IArtifactAccount, IArtifactAccountPair, StageArtifactSelector } from '@spinnaker/core';
@@ -8,13 +7,6 @@ import { mockDeployStage, mockPipeline } from '@spinnaker/mocks';
 import { ConfigFileArtifactList } from './ConfigFileArtifactList';
 
 describe('<ConfigFileArtifactList/>', () => {
-  let $httpBackend: ng.IHttpBackendService;
-  beforeEach(
-    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
-      $httpBackend = _$httpBackend_;
-    }),
-  );
-
   it('renders empty children when null/empty artifacts are passed in', () => {
     const configArtifacts: IArtifactAccountPair[] = [];
     const wrapper = mount(
@@ -30,29 +22,13 @@ describe('<ConfigFileArtifactList/>', () => {
 
   it('renders 2 children of StageArtifactSelector when 2 artifacts are passed in', async () => {
     const http = mockHttpClient();
-    const body: IArtifactAccount[] = [
-      {
-        name: 'http-acc',
-        types: ['http'],
-      },
-    ];
-    http.expectGET(`${API.baseUrl}/artifacts/credentials`).respond(200, body);
+    const body: IArtifactAccount[] = [{ name: 'http-acc', types: ['http'] }];
+    http.expectGET(`/artifacts/credentials`).respond(200, body);
+    http.expectGET(`/artifacts/credentials`).respond(200, body);
 
     const configArtifacts = [
-      {
-        account: 'http-acc',
-        id: '123abc',
-        artifact: {
-          id: '123abc',
-        },
-      },
-      {
-        account: 'http-acc',
-        id: '1234abcd',
-        artifact: {
-          id: '1234abcd',
-        },
-      },
+      { account: 'http-acc', id: '123abc', artifact: { id: '123abc' } },
+      { account: 'http-acc', id: '1234abcd', artifact: { id: '1234abcd' } },
     ];
 
     const wrapper = mount(

--- a/app/scripts/modules/azure/src/image/image.reader.spec.js
+++ b/app/scripts/modules/azure/src/image/image.reader.spec.js
@@ -1,8 +1,6 @@
 'use strict';
 import { mockHttpClient } from 'core/api/mock/jasmine';
 
-import { API } from '@spinnaker/core';
-
 describe('Service: Azure Image Reader', function () {
   var service;
 
@@ -18,9 +16,7 @@ describe('Service: Azure Image Reader', function () {
     var query = 'abc',
       region = 'usw';
 
-    function buildQueryString() {
-      return API.baseUrl + '/images/find?provider=azure&q=' + query + '&region=' + region;
-    }
+    const buildQueryString = () => `/images/find?provider=azure&q=${query}&region=${region}`;
 
     it('queries gate when 3 characters are supplied', async function () {
       const http = mockHttpClient();
@@ -80,9 +76,7 @@ describe('Service: Azure Image Reader', function () {
       region = 'usw',
       credentials = 'test';
 
-    function buildQueryString() {
-      return [API.baseUrl, 'images', credentials, region, imageName].join('/') + '?provider=azure';
-    }
+    const buildQueryString = () => `/images/${credentials}/${region}/${imageName}?provider=azure`;
 
     it('returns null if server returns 404 or an empty list', async function () {
       const http = mockHttpClient();

--- a/app/scripts/modules/azure/src/image/image.reader.spec.js
+++ b/app/scripts/modules/azure/src/image/image.reader.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 
 import { API } from '@spinnaker/core';
 
@@ -27,27 +28,29 @@ describe('Service: Azure Image Reader', function () {
       return API.baseUrl + '/images/find?provider=azure&q=' + query + '&region=' + region;
     }
 
-    it('queries gate when 3 characters are supplied', function () {
+    it('queries gate when 3 characters are supplied', async function () {
+      const http = mockHttpClient();
       var result = null;
 
-      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      http.expectGET(buildQueryString()).respond(200, [{ success: true }]);
 
       service.findImages({ provider: 'azure', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
     });
 
-    it('queries gate when more than 3 characters are supplied', function () {
+    it('queries gate when more than 3 characters are supplied', async function () {
+      const http = mockHttpClient();
       var result = null;
 
       query = 'abcd';
 
-      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      http.expectGET(buildQueryString()).respond(200, [{ success: true }]);
 
       var promise = service.findImages({ provider: 'azure', q: query, region: region });
 
@@ -55,23 +58,24 @@ describe('Service: Azure Image Reader', function () {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
     });
 
-    it('returns an empty array when server errors', function () {
+    it('returns an empty array when server errors', async function () {
+      const http = mockHttpClient();
       query = 'abc';
       var result = null;
 
-      $httpBackend.when('GET', buildQueryString()).respond(404, {});
+      http.expectGET(buildQueryString()).respond(404, {});
 
       service.findImages({ provider: 'azure', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(0);
     });
@@ -86,28 +90,29 @@ describe('Service: Azure Image Reader', function () {
       return [API.baseUrl, 'images', credentials, region, imageName].join('/') + '?provider=azure';
     }
 
-    it('returns null if server returns 404 or an empty list', function () {
+    it('returns null if server returns 404 or an empty list', async function () {
+      const http = mockHttpClient();
       var result = 'not null';
 
-      $httpBackend.when('GET', buildQueryString()).respond(404, {});
+      http.expectGET(buildQueryString()).respond(404, {});
 
       service.getImage(imageName, region, credentials).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result).toBe(null);
 
       result = 'not null';
 
-      $httpBackend.when('GET', buildQueryString()).respond(200, []);
+      http.expectGET(buildQueryString()).respond(200, []);
 
       service.getImage(imageName, region, credentials).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result).toBe(null);
     });

--- a/app/scripts/modules/azure/src/image/image.reader.spec.js
+++ b/app/scripts/modules/azure/src/image/image.reader.spec.js
@@ -4,21 +4,15 @@ import { mockHttpClient } from 'core/api/mock/jasmine';
 import { API } from '@spinnaker/core';
 
 describe('Service: Azure Image Reader', function () {
-  var service, $httpBackend;
+  var service;
 
   beforeEach(window.module(require('./image.reader').name));
 
   beforeEach(
-    window.inject(function (azureImageReader, _$httpBackend_) {
+    window.inject(function (azureImageReader) {
       service = azureImageReader;
-      $httpBackend = _$httpBackend_;
     }),
   );
-
-  afterEach(function () {
-    $httpBackend.verifyNoOutstandingRequest();
-    $httpBackend.verifyNoOutstandingExpectation();
-  });
 
   describe('findImages', function () {
     var query = 'abc',

--- a/app/scripts/modules/azure/src/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/src/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -1,10 +1,7 @@
 'use strict';
-
-import { API, ApplicationModelBuilder } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
 
 describe('Controller: azureCreateLoadBalancerCtrl', function () {
-  var $httpBackend;
-
   // load the controller's module
   beforeEach(window.module(require('./createLoadBalancer.controller').name));
 
@@ -25,13 +22,6 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
         isNew: true,
         loadBalancerType: 'Azure Load Balancer',
       });
-    }),
-  );
-
-  beforeEach(
-    window.inject(function (_$httpBackend_) {
-      // Set up the mock http service responses
-      $httpBackend = _$httpBackend_;
     }),
   );
 

--- a/app/scripts/modules/azure/src/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/src/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -46,11 +46,4 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
     expect(this.$scope.existingLoadBalancerNames).toEqual(undefined);
     expect(lb.providerType).toEqual(undefined);
   });
-
-  it('makes the expected REST calls for data for a new loadbalancer', function () {
-    $httpBackend.when('GET', API.baseUrl + '/networks').respond([]);
-    $httpBackend.when('GET', API.baseUrl + '/securityGroups').respond({});
-    $httpBackend.when('GET', API.baseUrl + '/credentials?expand=true').respond([]);
-    $httpBackend.when('GET', API.baseUrl + '/subnets').respond([]);
-  });
 });

--- a/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { AccountService, API, SECURITY_GROUP_READER } from '@spinnaker/core';
+import { AccountService, SECURITY_GROUP_READER } from '@spinnaker/core';
 
 describe('Controller: Azure.CreateSecurityGroup', function () {
   beforeEach(window.module(SECURITY_GROUP_READER, require('./CreateSecurityGroupCtrl').name));
@@ -69,7 +69,7 @@ describe('Controller: Azure.CreateSecurityGroup', function () {
 
     it('initializes with no firewalls available for ingress permissions', async function () {
       const http = mockHttpClient();
-      http.expectGET(API.baseUrl + '/networks').respond([]);
+      http.expectGET('/networks').respond([]);
       this.initializeCtrl();
       await http.flush();
       expect(this.$scope.securityGroup.securityRules.length).toBe(0);

--- a/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -3,8 +3,6 @@ import { mockHttpClient } from 'core/api/mock/jasmine';
 import { AccountService, API, SECURITY_GROUP_READER } from '@spinnaker/core';
 
 describe('Controller: Azure.CreateSecurityGroup', function () {
-  var $httpBackend;
-
   beforeEach(window.module(SECURITY_GROUP_READER, require('./CreateSecurityGroupCtrl').name));
 
   describe('filtering', function () {
@@ -66,13 +64,6 @@ describe('Controller: Azure.CreateSecurityGroup', function () {
 
           this.$scope.$digest();
         };
-      }),
-    );
-
-    beforeEach(
-      window.inject(function (_$httpBackend_) {
-        // Set up the mock http service responses
-        $httpBackend = _$httpBackend_;
       }),
     );
 

--- a/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 
 import { AccountService, API, SECURITY_GROUP_READER } from '@spinnaker/core';
 
@@ -76,8 +77,9 @@ describe('Controller: Azure.CreateSecurityGroup', function () {
       }),
     );
 
-    it('initializes with no firewalls available for ingress permissions', function () {
-      $httpBackend.when('GET', API.baseUrl + '/networks').respond([]);
+    it('initializes with no firewalls available for ingress permissions', async function () {
+      const http = mockHttpClient();
+      http.expectGET(API.baseUrl + '/networks').respond([]);
       this.initializeCtrl();
       expect(this.$scope.securityGroup.securityRules.length).toBe(0);
     });

--- a/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 import { mockHttpClient } from 'core/api/mock/jasmine';
-
 import { AccountService, API, SECURITY_GROUP_READER } from '@spinnaker/core';
 
 describe('Controller: Azure.CreateSecurityGroup', function () {
@@ -81,6 +80,7 @@ describe('Controller: Azure.CreateSecurityGroup', function () {
       const http = mockHttpClient();
       http.expectGET(API.baseUrl + '/networks').respond([]);
       this.initializeCtrl();
+      await http.flush();
       expect(this.$scope.securityGroup.securityRules.length).toBe(0);
     });
   });

--- a/app/scripts/modules/core/src/account/AccountService.spec.ts
+++ b/app/scripts/modules/core/src/account/AccountService.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock } from 'angular';
 import { $rootScope } from 'ngimport';
 
@@ -19,8 +20,9 @@ describe('Service: AccountService', () => {
 
   afterEach(SETTINGS.resetToOriginal);
 
-  it('should filter the list of accounts by provider when supplied', (done) => {
-    $httpBackend.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(200, [
+  it('should filter the list of accounts by provider when supplied', async (done) => {
+    const http = mockHttpClient();
+    http.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(200, [
       { name: 'test', type: 'aws' },
       { name: 'prod', type: 'aws' },
       { name: 'prod', type: 'gce' },
@@ -32,13 +34,14 @@ describe('Service: AccountService', () => {
       expect(accounts.map((account: IAccount) => account.name)).toEqual(['test', 'prod']);
       done();
     });
-    $httpBackend.flush();
+    await http.flush();
     setTimeout(() => $rootScope.$digest());
   });
 
   describe('getAllAccountDetailsForProvider', () => {
-    it('should return details for each account', (done) => {
-      $httpBackend.expectGET(API.baseUrl + '/credentials?expand=true').respond(200, [
+    it('should return details for each account', async (done) => {
+      const http = mockHttpClient();
+      http.expectGET(API.baseUrl + '/credentials?expand=true').respond(200, [
         { name: 'test', type: 'aws' },
         { name: 'prod', type: 'aws' },
       ]);
@@ -49,18 +52,19 @@ describe('Service: AccountService', () => {
         expect(details[1].name).toBe('prod');
         done();
       });
-      $httpBackend.flush();
+      await http.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
-    it('should fall back to an empty array if an exception occurs when listing accounts', (done) => {
-      $httpBackend.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(429, null);
+    it('should fall back to an empty array if an exception occurs when listing accounts', async (done) => {
+      const http = mockHttpClient();
+      http.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(429, null);
 
       AccountService.getAllAccountDetailsForProvider('aws').then((details: any[]) => {
         expect(details).toEqual([]);
         done();
       });
-      $httpBackend.flush();
+      await http.flush();
       setTimeout(() => $rootScope.$digest());
     });
   });
@@ -75,66 +79,72 @@ describe('Service: AccountService', () => {
       spyOn(CloudProviderRegistry, 'listRegisteredProviders').and.returnValue(registeredProviders);
     });
 
-    it('should list all providers when no application provided', (done) => {
+    it('should list all providers when no application provided', async (done) => {
+      const http = mockHttpClient();
       AccountService.listProviders().then((result: string[]) => {
         expect(result).toEqual(['aws', 'cf', 'gce']);
         done();
       });
-      $httpBackend.flush();
+      await http.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
-    it('should filter out providers not registered', (done) => {
+    it('should filter out providers not registered', async (done) => {
+      const http = mockHttpClient();
       registeredProviders.pop();
       AccountService.listProviders().then((result: string[]) => {
         expect(result).toEqual(['aws', 'gce']);
         done();
       });
-      $httpBackend.flush();
+      await http.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
-    it('should fall back to the defaultProviders if none configured for the application', (done) => {
+    it('should fall back to the defaultProviders if none configured for the application', async (done) => {
+      const http = mockHttpClient();
       const application: any = { attributes: { cloudProviders: [] } };
       SETTINGS.defaultProviders = ['gce', 'cf'];
       AccountService.listProviders(application).then((result: string[]) => {
         expect(result).toEqual(['cf', 'gce']);
         done();
       });
-      $httpBackend.flush();
+      await http.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
-    it('should return the intersection of those configured for the application and those available from the server', (done) => {
+    it('should return the intersection of those configured for the application and those available from the server', async (done) => {
+      const http = mockHttpClient();
       const application: any = { attributes: { cloudProviders: ['gce', 'cf', 'unicron'] } };
       SETTINGS.defaultProviders = ['aws'];
       AccountService.listProviders(application).then((result: string[]) => {
         expect(result).toEqual(['cf', 'gce']);
         done();
       });
-      $httpBackend.flush();
+      await http.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
-    it('should return an empty array if none of the app providers are available from the server', (done) => {
+    it('should return an empty array if none of the app providers are available from the server', async (done) => {
+      const http = mockHttpClient();
       const application: any = { attributes: { cloudProviders: ['lamp', 'ceiling', 'fan'] } };
       SETTINGS.defaultProviders = ['foo'];
       AccountService.listProviders(application).then((result: string[]) => {
         expect(result).toEqual([]);
         done();
       });
-      $httpBackend.flush();
+      await http.flush();
       setTimeout(() => $rootScope.$digest());
     });
 
-    it('should fall back to all registered available providers if no defaults configured and none configured on app', (done) => {
+    it('should fall back to all registered available providers if no defaults configured and none configured on app', async (done) => {
+      const http = mockHttpClient();
       const application: any = { attributes: { cloudProviders: [] } };
       delete SETTINGS.defaultProviders;
       AccountService.listProviders(application).then((result: string[]) => {
         expect(result).toEqual(['aws', 'cf', 'gce']);
         done();
       });
-      $httpBackend.flush();
+      await http.flush();
       setTimeout(() => $rootScope.$digest());
     });
   });

--- a/app/scripts/modules/core/src/account/AccountService.spec.ts
+++ b/app/scripts/modules/core/src/account/AccountService.spec.ts
@@ -2,7 +2,6 @@ import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock } from 'angular';
 import { $rootScope } from 'ngimport';
 
-import { API } from 'core/api/ApiService';
 import { SETTINGS } from 'core/config/settings';
 
 import { AccountService, IAccount } from './AccountService';
@@ -16,7 +15,7 @@ describe('Service: AccountService', () => {
   it('should filter the list of accounts by provider when supplied', async (done) => {
     const http = mockHttpClient();
     http
-      .expectGET(`${API.baseUrl}/credentials`)
+      .expectGET(`/credentials`)
       .withParams({ expand: true })
       .respond(200, [
         { name: 'test', type: 'aws' },

--- a/app/scripts/modules/core/src/account/AccountService.spec.ts
+++ b/app/scripts/modules/core/src/account/AccountService.spec.ts
@@ -9,25 +9,21 @@ import { AccountService, IAccount } from './AccountService';
 import { CloudProviderRegistry } from '../cloudProvider';
 
 describe('Service: AccountService', () => {
-  let $httpBackend: ng.IHttpBackendService;
-
-  beforeEach(
-    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
-      $httpBackend = _$httpBackend_;
-    }),
-  );
+  beforeEach(mock.inject());
   beforeEach(() => AccountService.initialize());
-
   afterEach(SETTINGS.resetToOriginal);
 
   it('should filter the list of accounts by provider when supplied', async (done) => {
     const http = mockHttpClient();
-    http.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(200, [
-      { name: 'test', type: 'aws' },
-      { name: 'prod', type: 'aws' },
-      { name: 'prod', type: 'gce' },
-      { name: 'gce-test', type: 'gce' },
-    ]);
+    http
+      .expectGET(`${API.baseUrl}/credentials`)
+      .withParams({ expand: true })
+      .respond(200, [
+        { name: 'test', type: 'aws' },
+        { name: 'prod', type: 'aws' },
+        { name: 'prod', type: 'gce' },
+        { name: 'gce-test', type: 'gce' },
+      ]);
 
     AccountService.listAccounts('aws').then((accounts: IAccount[]) => {
       expect(accounts.length).toBe(2);
@@ -41,10 +37,13 @@ describe('Service: AccountService', () => {
   describe('getAllAccountDetailsForProvider', () => {
     it('should return details for each account', async (done) => {
       const http = mockHttpClient();
-      http.expectGET(API.baseUrl + '/credentials?expand=true').respond(200, [
-        { name: 'test', type: 'aws' },
-        { name: 'prod', type: 'aws' },
-      ]);
+      http
+        .expectGET('/credentials')
+        .withParams({ expand: true })
+        .respond(200, [
+          { name: 'test', type: 'aws' },
+          { name: 'prod', type: 'aws' },
+        ]);
 
       AccountService.getAllAccountDetailsForProvider('aws').then((details: any) => {
         expect(details.length).toBe(2);
@@ -58,7 +57,7 @@ describe('Service: AccountService', () => {
 
     it('should fall back to an empty array if an exception occurs when listing accounts', async (done) => {
       const http = mockHttpClient();
-      http.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(429, null);
+      http.expectGET('/credentials').withParams({ expand: true }).respond(429, null);
 
       AccountService.getAllAccountDetailsForProvider('aws').then((details: any[]) => {
         expect(details).toEqual([]);
@@ -70,82 +69,90 @@ describe('Service: AccountService', () => {
   });
 
   describe('listProviders', () => {
-    let registeredProviders: string[];
-    beforeEach(() => {
-      registeredProviders = ['aws', 'gce', 'cf'];
-      $httpBackend
-        .whenGET(`${API.baseUrl}/credentials?expand=true`)
-        .respond(200, [{ type: 'aws' }, { type: 'gce' }, { type: 'cf' }]);
+    const providers = [{ type: 'aws' }, { type: 'gce' }, { type: 'cf' }];
+    const registeredProviders = ['aws', 'gce', 'cf'];
+
+    const setupTest = () => {
+      const http = mockHttpClient();
+      http.expectGET('/credentials').withParams({ expand: true }).respond(200, providers);
       spyOn(CloudProviderRegistry, 'listRegisteredProviders').and.returnValue(registeredProviders);
-    });
+      return http;
+    };
 
     it('should list all providers when no application provided', async (done) => {
-      const http = mockHttpClient();
+      const http = setupTest();
+
       AccountService.listProviders().then((result: string[]) => {
         expect(result).toEqual(['aws', 'cf', 'gce']);
         done();
       });
+
       await http.flush();
-      setTimeout(() => $rootScope.$digest());
     });
 
     it('should filter out providers not registered', async (done) => {
       const http = mockHttpClient();
-      registeredProviders.pop();
+      http.expectGET('/credentials').withParams({ expand: true }).respond(200, providers.slice(0, 2));
+      spyOn(CloudProviderRegistry, 'listRegisteredProviders').and.returnValue(registeredProviders.slice(0, 2));
+
       AccountService.listProviders().then((result: string[]) => {
         expect(result).toEqual(['aws', 'gce']);
         done();
       });
+
       await http.flush();
-      setTimeout(() => $rootScope.$digest());
     });
 
     it('should fall back to the defaultProviders if none configured for the application', async (done) => {
-      const http = mockHttpClient();
+      const http = setupTest();
+
       const application: any = { attributes: { cloudProviders: [] } };
       SETTINGS.defaultProviders = ['gce', 'cf'];
       AccountService.listProviders(application).then((result: string[]) => {
         expect(result).toEqual(['cf', 'gce']);
         done();
       });
+
       await http.flush();
-      setTimeout(() => $rootScope.$digest());
     });
 
     it('should return the intersection of those configured for the application and those available from the server', async (done) => {
-      const http = mockHttpClient();
+      const http = setupTest();
+
       const application: any = { attributes: { cloudProviders: ['gce', 'cf', 'unicron'] } };
       SETTINGS.defaultProviders = ['aws'];
       AccountService.listProviders(application).then((result: string[]) => {
         expect(result).toEqual(['cf', 'gce']);
         done();
       });
+
       await http.flush();
-      setTimeout(() => $rootScope.$digest());
     });
 
     it('should return an empty array if none of the app providers are available from the server', async (done) => {
-      const http = mockHttpClient();
+      const http = setupTest();
+
       const application: any = { attributes: { cloudProviders: ['lamp', 'ceiling', 'fan'] } };
       SETTINGS.defaultProviders = ['foo'];
       AccountService.listProviders(application).then((result: string[]) => {
         expect(result).toEqual([]);
         done();
       });
+
       await http.flush();
-      setTimeout(() => $rootScope.$digest());
     });
 
     it('should fall back to all registered available providers if no defaults configured and none configured on app', async (done) => {
-      const http = mockHttpClient();
+      const http = setupTest();
+
       const application: any = { attributes: { cloudProviders: [] } };
       delete SETTINGS.defaultProviders;
       AccountService.listProviders(application).then((result: string[]) => {
         expect(result).toEqual(['aws', 'cf', 'gce']);
         done();
       });
+
       await http.flush();
-      setTimeout(() => $rootScope.$digest());
     });
   });
 });

--- a/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
@@ -1,5 +1,5 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { IHttpBackendService, mock } from 'angular';
+import { mock } from 'angular';
 import { find } from 'lodash';
 
 import { REACT_MODULE } from 'core/reactShims';
@@ -18,7 +18,6 @@ describe('Service: Cluster', function () {
   beforeEach(mock.module(CLUSTER_SERVICE, REACT_MODULE));
 
   let clusterService: ClusterService;
-  let $httpBackend: IHttpBackendService;
   let application: Application;
 
   function buildTask(config: { status: string; variables: { [key: string]: any } }) {
@@ -31,8 +30,7 @@ describe('Service: Cluster', function () {
   }
 
   beforeEach(
-    mock.inject((_$httpBackend_: IHttpBackendService, _clusterService_: ClusterService) => {
-      $httpBackend = _$httpBackend_;
+    mock.inject((_clusterService_: ClusterService) => {
       clusterService = _clusterService_;
 
       application = ApplicationModelBuilder.createApplicationForTests(
@@ -56,14 +54,14 @@ describe('Service: Cluster', function () {
   describe('lazy cluster fetching', () => {
     it('switches to lazy cluster fetching if there are more than the on demand threshold for clusters', async () => {
       const http = mockHttpClient();
-      const clusters = Array(SETTINGS.onDemandClusterThreshold + 1);
+      const clusters = [...Array(SETTINGS.onDemandClusterThreshold + 1)];
       http.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
       http.expectGET(API.baseUrl + '/applications/app/serverGroups?clusters=').respond(200, []);
       let serverGroups: IServerGroup[] = null;
       clusterService.loadServerGroups(application).then((result: IServerGroup[]) => (serverGroups = result));
       await http.flush();
-      expect(application.serverGroups.fetchOnDemand).toBe(true);
       expect(serverGroups).toEqual([]);
+      expect(application.serverGroups.fetchOnDemand).toBe(true);
     });
 
     it('does boring regular fetching when there are less than the on demand threshold for clusters', async () => {

--- a/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
@@ -9,7 +9,6 @@ import { IInstanceCounts, IServerGroup } from 'core/domain';
 import { Application } from 'core/application/application.model';
 
 import { CLUSTER_SERVICE, ClusterService } from './cluster.service';
-import { API } from '../api/ApiService';
 import { SETTINGS } from 'core/config/settings';
 
 const ClusterState = State.ClusterState;
@@ -55,8 +54,8 @@ describe('Service: Cluster', function () {
     it('switches to lazy cluster fetching if there are more than the on demand threshold for clusters', async () => {
       const http = mockHttpClient();
       const clusters = [...Array(SETTINGS.onDemandClusterThreshold + 1)];
-      http.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
-      http.expectGET(API.baseUrl + '/applications/app/serverGroups?clusters=').respond(200, []);
+      http.expectGET('/applications/app/clusters').respond(200, { test: clusters });
+      http.expectGET('/applications/app/serverGroups?clusters=').respond(200, []);
       let serverGroups: IServerGroup[] = null;
       clusterService.loadServerGroups(application).then((result: IServerGroup[]) => (serverGroups = result));
       await http.flush();
@@ -67,8 +66,8 @@ describe('Service: Cluster', function () {
     it('does boring regular fetching when there are less than the on demand threshold for clusters', async () => {
       const http = mockHttpClient();
       const clusters = Array(SETTINGS.onDemandClusterThreshold);
-      http.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
-      http.expectGET(API.baseUrl + '/applications/app/serverGroups').respond(200, []);
+      http.expectGET('/applications/app/clusters').respond(200, { test: clusters });
+      http.expectGET('/applications/app/serverGroups').respond(200, []);
       let serverGroups: IServerGroup[] = null;
       clusterService.loadServerGroups(application).then((result: IServerGroup[]) => (serverGroups = result));
       await http.flush();
@@ -81,8 +80,8 @@ describe('Service: Cluster', function () {
       spyOn(ClusterState.filterModel.asFilterModel, 'applyParamsToUrl').and.callFake(() => {});
       const clusters = Array(250);
       ClusterState.filterModel.asFilterModel.sortFilter.clusters = { 'test:myapp': true };
-      http.expectGET(API.baseUrl + '/applications/app/clusters').respond(200, { test: clusters });
-      http.expectGET(API.baseUrl + '/applications/app/serverGroups').respond(200, []);
+      http.expectGET('/applications/app/clusters').respond(200, { test: clusters });
+      http.expectGET('/applications/app/serverGroups').respond(200, []);
       let serverGroups: IServerGroup[] = null;
       clusterService.loadServerGroups(application).then((result: IServerGroup[]) => (serverGroups = result));
       await http.flush();

--- a/app/scripts/modules/core/src/function/function.read.service.spec.ts
+++ b/app/scripts/modules/core/src/function/function.read.service.spec.ts
@@ -1,10 +1,8 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { API, FunctionReader, IFunctionSourceData } from 'core';
-import { mock } from 'angular';
 import { IFunctionTransformer } from 'core/function/function.transformer';
 
 describe('FunctionReadService', () => {
-  let $httpBackend: ng.IHttpBackendService;
   const functionTransformerMock: IFunctionTransformer = {
     normalizeFunction: (data): IFunctionSourceData => {
       return data;
@@ -14,44 +12,20 @@ describe('FunctionReadService', () => {
     },
   };
 
-  beforeEach(
-    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
-      $httpBackend = _$httpBackend_;
-    }),
-  );
-
   describe('loadFunctions', () => {
     it(`should set cloudprovider if not set`, async (done) => {
       const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
       http.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
-        {
-          name: 'account1',
-          provider: 'aws',
-          type: 'aws',
-        },
-        {
-          name: 'account1',
-          provider: 'aws',
-          type: 'aws',
-        },
+        { name: 'account1', provider: 'aws', type: 'aws' },
+        { name: 'account1', provider: 'aws', type: 'aws' },
       ]);
 
       functionReader.loadFunctions('app1').then((data) => {
         expect(data).toEqual([
-          {
-            name: 'account1',
-            cloudProvider: 'aws',
-            provider: 'aws',
-            type: 'aws',
-          },
-          {
-            name: 'account1',
-            cloudProvider: 'aws',
-            provider: 'aws',
-            type: 'aws',
-          },
+          { name: 'account1', cloudProvider: 'aws', provider: 'aws', type: 'aws' },
+          { name: 'account1', cloudProvider: 'aws', provider: 'aws', type: 'aws' },
         ]);
 
         done();
@@ -65,34 +39,14 @@ describe('FunctionReadService', () => {
       const functionReader = new FunctionReader(functionTransformerMock);
 
       http.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
-        {
-          name: 'account1',
-          cloudProvider: 'fluffyCloud',
-          provider: 'aws',
-          type: 'aws',
-        },
-        {
-          name: 'account1',
-          cloudProvider: 'fluffyCloud',
-          provider: 'aws',
-          type: 'aws',
-        },
+        { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
+        { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
       ]);
 
       functionReader.loadFunctions('app1').then((data) => {
         expect(data).toEqual([
-          {
-            name: 'account1',
-            cloudProvider: 'fluffyCloud',
-            provider: 'aws',
-            type: 'aws',
-          },
-          {
-            name: 'account1',
-            cloudProvider: 'fluffyCloud',
-            provider: 'aws',
-            type: 'aws',
-          },
+          { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
+          { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
         ]);
 
         done();
@@ -107,45 +61,18 @@ describe('FunctionReadService', () => {
       const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      http.expectGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
-        expect(params).toEqual({
-          provider: 'aws',
-          account: 'acct1',
-          region: 'us-west-1',
-          functionName: 'runner1',
-        });
-
-        return [
-          200,
-          [
-            {
-              name: 'account1',
-              provider: 'aws',
-              type: 'aws',
-            },
-            {
-              name: 'account1',
-              provider: 'aws',
-              type: 'aws',
-            },
-          ],
-        ];
-      });
+      http
+        .expectGET(/.*\/functions/)
+        .withParams({ provider: 'aws', account: 'acct1', region: 'us-west-1', functionName: 'runner1' })
+        .respond(200, [
+          { name: 'account1', provider: 'aws', type: 'aws' },
+          { name: 'account1', provider: 'aws', type: 'aws' },
+        ]);
 
       functionReader.getFunctionDetails('aws', 'acct1', 'us-west-1', 'runner1').then((data) => {
         expect(data).toEqual([
-          {
-            name: 'account1',
-            cloudProvider: 'aws',
-            provider: 'aws',
-            type: 'aws',
-          },
-          {
-            name: 'account1',
-            cloudProvider: 'aws',
-            provider: 'aws',
-            type: 'aws',
-          },
+          { name: 'account1', cloudProvider: 'aws', provider: 'aws', type: 'aws' },
+          { name: 'account1', cloudProvider: 'aws', provider: 'aws', type: 'aws' },
         ]);
 
         done();
@@ -158,47 +85,18 @@ describe('FunctionReadService', () => {
       const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      http.expectGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
-        expect(params).toEqual({
-          provider: 'aws',
-          account: 'acct1',
-          region: 'us-west-1',
-          functionName: 'runner1',
-        });
-
-        return [
-          200,
-          [
-            {
-              name: 'account1',
-              cloudProvider: 'fluffyCloud',
-              provider: 'aws',
-              type: 'aws',
-            },
-            {
-              name: 'account1',
-              cloudProvider: 'fluffyCloud',
-              provider: 'aws',
-              type: 'aws',
-            },
-          ],
-        ];
-      });
+      http
+        .expectGET(/.*\/functions/)
+        .withParams({ provider: 'aws', account: 'acct1', region: 'us-west-1', functionName: 'runner1' })
+        .respond(200, [
+          { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
+          { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
+        ]);
 
       functionReader.getFunctionDetails('aws', 'acct1', 'us-west-1', 'runner1').then((data) => {
         expect(data).toEqual([
-          {
-            name: 'account1',
-            cloudProvider: 'fluffyCloud',
-            provider: 'aws',
-            type: 'aws',
-          },
-          {
-            name: 'account1',
-            cloudProvider: 'fluffyCloud',
-            provider: 'aws',
-            type: 'aws',
-          },
+          { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
+          { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
         ]);
 
         done();

--- a/app/scripts/modules/core/src/function/function.read.service.spec.ts
+++ b/app/scripts/modules/core/src/function/function.read.service.spec.ts
@@ -1,5 +1,5 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { API, FunctionReader, IFunctionSourceData } from 'core';
+import { FunctionReader, IFunctionSourceData } from 'core';
 import { IFunctionTransformer } from 'core/function/function.transformer';
 
 describe('FunctionReadService', () => {
@@ -17,7 +17,7 @@ describe('FunctionReadService', () => {
       const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      http.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
+      http.expectGET(`/applications/app1/functions`).respond(200, [
         { name: 'account1', provider: 'aws', type: 'aws' },
         { name: 'account1', provider: 'aws', type: 'aws' },
       ]);
@@ -38,7 +38,7 @@ describe('FunctionReadService', () => {
       const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      http.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
+      http.expectGET(`/applications/app1/functions`).respond(200, [
         { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
         { name: 'account1', cloudProvider: 'fluffyCloud', provider: 'aws', type: 'aws' },
       ]);

--- a/app/scripts/modules/core/src/function/function.read.service.spec.ts
+++ b/app/scripts/modules/core/src/function/function.read.service.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { API, FunctionReader, IFunctionSourceData } from 'core';
 import { mock } from 'angular';
 import { IFunctionTransformer } from 'core/function/function.transformer';
@@ -20,10 +21,11 @@ describe('FunctionReadService', () => {
   );
 
   describe('loadFunctions', () => {
-    it(`should set cloudprovider if not set`, (done) => {
+    it(`should set cloudprovider if not set`, async (done) => {
+      const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      $httpBackend.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
+      http.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
         {
           name: 'account1',
           provider: 'aws',
@@ -55,13 +57,14 @@ describe('FunctionReadService', () => {
         done();
       });
 
-      $httpBackend.flush();
+      await http.flush();
     });
 
-    it(`should not set cloudprovider if provided`, (done) => {
+    it(`should not set cloudprovider if provided`, async (done) => {
+      const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      $httpBackend.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
+      http.expectGET(`${API.baseUrl}/applications/app1/functions`).respond(200, [
         {
           name: 'account1',
           cloudProvider: 'fluffyCloud',
@@ -95,15 +98,16 @@ describe('FunctionReadService', () => {
         done();
       });
 
-      $httpBackend.flush();
+      await http.flush();
     });
   });
 
   describe('getFunctionDetails', () => {
-    it(`should set cloudprovider if not set`, (done) => {
+    it(`should set cloudprovider if not set`, async (done) => {
+      const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      $httpBackend.whenGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
+      http.expectGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
         expect(params).toEqual({
           provider: 'aws',
           account: 'acct1',
@@ -147,13 +151,14 @@ describe('FunctionReadService', () => {
         done();
       });
 
-      $httpBackend.flush();
+      await http.flush();
     });
 
-    it(`should not set cloudprovider if provided`, (done) => {
+    it(`should not set cloudprovider if provided`, async (done) => {
+      const http = mockHttpClient();
       const functionReader = new FunctionReader(functionTransformerMock);
 
-      $httpBackend.whenGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
+      http.expectGET(/.*\/functions\?.*/).respond((_method, _url, _data, _headers, params) => {
         expect(params).toEqual({
           provider: 'aws',
           account: 'acct1',
@@ -199,7 +204,7 @@ describe('FunctionReadService', () => {
         done();
       });
 
-      $httpBackend.flush();
+      await http.flush();
     });
   });
 });

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
@@ -1,24 +1,13 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { IHttpBackendService, mock } from 'angular';
+import { mock } from 'angular';
 
 import { API } from 'core/api/ApiService';
 
 import { IPagerDutyService, PagerDutyReader } from './pagerDuty.read.service';
 
 describe('PagerDutyReader', () => {
-  let $httpBackend: IHttpBackendService;
-
   beforeEach(mock.module());
-  beforeEach(
-    mock.inject((_$httpBackend_: IHttpBackendService) => {
-      $httpBackend = _$httpBackend_;
-    }),
-  );
-
-  afterEach(function () {
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
-  });
+  beforeEach(mock.inject());
 
   it('should return an empty array when configured to do so and invoked', async () => {
     const http = mockHttpClient();

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
@@ -1,8 +1,5 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock } from 'angular';
-
-import { API } from 'core/api/ApiService';
-
 import { IPagerDutyService, PagerDutyReader } from './pagerDuty.read.service';
 
 describe('PagerDutyReader', () => {
@@ -12,7 +9,7 @@ describe('PagerDutyReader', () => {
   it('should return an empty array when configured to do so and invoked', async () => {
     const http = mockHttpClient();
     const services: IPagerDutyService[] = [];
-    http.expectGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
+    http.expectGET(`/pagerDuty/services`).respond(200, services);
 
     let executed = false;
     PagerDutyReader.listServices().subscribe((pagerDutyServices: IPagerDutyService[]) => {
@@ -45,7 +42,7 @@ describe('PagerDutyReader', () => {
         status: 'active',
       },
     ];
-    http.expectGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
+    http.expectGET(`/pagerDuty/services`).respond(200, services);
 
     let executed = false;
     PagerDutyReader.listServices().subscribe((pagerDutyServices: IPagerDutyService[]) => {

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { IHttpBackendService, mock } from 'angular';
 
 import { API } from 'core/api/ApiService';
@@ -19,9 +20,10 @@ describe('PagerDutyReader', () => {
     $httpBackend.verifyNoOutstandingRequest();
   });
 
-  it('should return an empty array when configured to do so and invoked', () => {
+  it('should return an empty array when configured to do so and invoked', async () => {
+    const http = mockHttpClient();
     const services: IPagerDutyService[] = [];
-    $httpBackend.whenGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
+    http.expectGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
 
     let executed = false;
     PagerDutyReader.listServices().subscribe((pagerDutyServices: IPagerDutyService[]) => {
@@ -30,11 +32,12 @@ describe('PagerDutyReader', () => {
       executed = true; // can't use done() function b/c $digest is already in progress
     });
 
-    $httpBackend.flush();
+    await http.flush();
     expect(executed).toBeTruthy();
   });
 
-  it('should return a non-empty array when configured to do so and invoked', () => {
+  it('should return a non-empty array when configured to do so and invoked', async () => {
+    const http = mockHttpClient();
     const services: IPagerDutyService[] = [
       {
         name: 'one',
@@ -53,7 +56,7 @@ describe('PagerDutyReader', () => {
         status: 'active',
       },
     ];
-    $httpBackend.whenGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
+    http.expectGET(`${API.baseUrl}/pagerDuty/services`).respond(200, services);
 
     let executed = false;
     PagerDutyReader.listServices().subscribe((pagerDutyServices: IPagerDutyService[]) => {
@@ -62,7 +65,7 @@ describe('PagerDutyReader', () => {
       executed = true; // can't use done() function b/c $digest is already in progress
     });
 
-    $httpBackend.flush();
+    await http.flush();
     expect(executed).toBeTruthy();
   });
 });

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.spec.ts
@@ -1,7 +1,5 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock } from 'angular';
-
-import { API } from 'core/api/ApiService';
 import { IStage } from 'core/domain/IStage';
 import { IPipeline } from 'core/domain/IPipeline';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
@@ -87,7 +85,7 @@ describe('PipelineConfigService', () => {
       const http = mockHttpClient();
       const pipeline: IPipeline = buildPipeline({});
 
-      http.expectDELETE(API.baseUrl + '/pipelines/foo/bar%5Bbaz%5D').respond(200, '');
+      http.expectDELETE('/pipelines/foo/bar%5Bbaz%5D').respond(200, '');
 
       PipelineConfigService.deletePipeline('foo', pipeline, 'bar[baz]');
 
@@ -106,7 +104,7 @@ describe('PipelineConfigService', () => {
         buildPipeline({ id: 'c', name: 'first', application: 'app', index: 0, stages: [] }),
         buildPipeline({ id: 'd', name: 'third', application: 'app', index: 2, stages: [] }),
       ];
-      http.expectGET(API.baseUrl + '/applications/app/pipelineConfigs').respond(200, fromServer);
+      http.expectGET('/applications/app/pipelineConfigs').respond(200, fromServer);
 
       PipelineConfigService.getPipelinesForApplication('app').then((pipelines: IPipeline[]) => {
         result = pipelines;

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
@@ -1,16 +1,13 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { IDeferred, IHttpBackendService, IQService, IRootScopeService, IScope, mock } from 'angular';
+import { tick } from 'core/api/mock/mockHttpUtils';
+import { IDeferred, IQService, IRootScopeService, IScope, mock } from 'angular';
 
 import { SETTINGS } from 'core/config/settings';
 import { MANUAL_JUDGMENT_SERVICE, ManualJudgmentService } from './manualJudgment.service';
 import { ExecutionService } from 'core/pipeline/service/execution.service';
 
 describe('Service: manualJudgment', () => {
-  let $scope: IScope,
-    service: ManualJudgmentService,
-    $httpBackend: IHttpBackendService,
-    $q: IQService,
-    executionService: ExecutionService;
+  let $scope: IScope, service: ManualJudgmentService, $q: IQService, executionService: ExecutionService;
 
   beforeEach(mock.module(MANUAL_JUDGMENT_SERVICE, 'ui.router'));
 
@@ -19,13 +16,11 @@ describe('Service: manualJudgment', () => {
       (
         $rootScope: IRootScopeService,
         manualJudgmentService: ManualJudgmentService,
-        _$httpBackend_: IHttpBackendService,
         _$q_: IQService,
         _executionService_: ExecutionService,
       ) => {
         $scope = $rootScope.$new();
         service = manualJudgmentService;
-        $httpBackend = _$httpBackend_;
         $q = _$q_;
         executionService = _executionService_;
       },
@@ -57,6 +52,7 @@ describe('Service: manualJudgment', () => {
       // waitForExecutionMatches...
       deferred.resolve();
       $scope.$digest();
+      await tick();
 
       expect(succeeded).toBe(true);
     });
@@ -64,8 +60,8 @@ describe('Service: manualJudgment', () => {
     it('should fail when waitUntilExecutionMatches fails', async () => {
       const http = mockHttpClient();
       const deferred: IDeferred<boolean> = $q.defer();
-      let succeeded = false,
-        failed = false;
+      let succeeded = false;
+      let failed = false;
 
       http.expectPATCH(requestUrl).respond(200, '');
       spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
@@ -82,6 +78,7 @@ describe('Service: manualJudgment', () => {
       // waitForExecutionMatches...
       deferred.reject();
       $scope.$digest();
+      await tick();
 
       expect(succeeded).toBe(false);
       expect(failed).toBe(true);
@@ -89,8 +86,8 @@ describe('Service: manualJudgment', () => {
 
     it('should fail when patch call fails', async () => {
       const http = mockHttpClient();
-      let succeeded = false,
-        failed = false;
+      let succeeded = false;
+      let failed = false;
 
       http.expectPATCH(requestUrl).respond(503, '');
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
@@ -2,7 +2,6 @@ import { mockHttpClient } from 'core/api/mock/jasmine';
 import { tick } from 'core/api/mock/mockHttpUtils';
 import { IDeferred, IQService, IRootScopeService, IScope, mock } from 'angular';
 
-import { SETTINGS } from 'core/config/settings';
 import { MANUAL_JUDGMENT_SERVICE, ManualJudgmentService } from './manualJudgment.service';
 import { ExecutionService } from 'core/pipeline/service/execution.service';
 
@@ -32,7 +31,7 @@ describe('Service: manualJudgment', () => {
     beforeEach(() => {
       execution = { id: 'ex-id' };
       stage = { id: 'stage-id' };
-      requestUrl = [SETTINGS.gateUrl, 'pipelines', execution.id, 'stages', stage.id].join('/');
+      requestUrl = `/pipelines/${execution.id}/stages/${stage.id}`;
     });
 
     it('should resolve when execution status matches request', async () => {

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { IDeferred, IHttpBackendService, IQService, IRootScopeService, IScope, mock } from 'angular';
 
 import { SETTINGS } from 'core/config/settings';
@@ -39,17 +40,18 @@ describe('Service: manualJudgment', () => {
       requestUrl = [SETTINGS.gateUrl, 'pipelines', execution.id, 'stages', stage.id].join('/');
     });
 
-    it('should resolve when execution status matches request', () => {
+    it('should resolve when execution status matches request', async () => {
+      const http = mockHttpClient();
       const deferred: IDeferred<boolean> = $q.defer();
       let succeeded = false;
 
-      $httpBackend.expectPATCH(requestUrl).respond(200, '');
+      http.expectPATCH(requestUrl).respond(200, '');
       spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
       spyOn(executionService, 'updateExecution').and.stub();
 
       service.provideJudgment(null, execution, stage, 'continue').then(() => (succeeded = true));
 
-      $httpBackend.flush();
+      await http.flush();
       expect(succeeded).toBe(false);
 
       // waitForExecutionMatches...
@@ -59,12 +61,13 @@ describe('Service: manualJudgment', () => {
       expect(succeeded).toBe(true);
     });
 
-    it('should fail when waitUntilExecutionMatches fails', () => {
+    it('should fail when waitUntilExecutionMatches fails', async () => {
+      const http = mockHttpClient();
       const deferred: IDeferred<boolean> = $q.defer();
       let succeeded = false,
         failed = false;
 
-      $httpBackend.expectPATCH(requestUrl).respond(200, '');
+      http.expectPATCH(requestUrl).respond(200, '');
       spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
 
       service.provideJudgment(null, execution, stage, 'continue').then(
@@ -72,7 +75,7 @@ describe('Service: manualJudgment', () => {
         () => (failed = true),
       );
 
-      $httpBackend.flush();
+      await http.flush();
       expect(succeeded).toBe(false);
       expect(failed).toBe(false);
 
@@ -84,18 +87,19 @@ describe('Service: manualJudgment', () => {
       expect(failed).toBe(true);
     });
 
-    it('should fail when patch call fails', () => {
+    it('should fail when patch call fails', async () => {
+      const http = mockHttpClient();
       let succeeded = false,
         failed = false;
 
-      $httpBackend.expectPATCH(requestUrl).respond(503, '');
+      http.expectPATCH(requestUrl).respond(503, '');
 
       service.provideJudgment(null, execution, stage, 'continue').then(
         () => (succeeded = true),
         () => (failed = true),
       );
 
-      $httpBackend.flush();
+      await http.flush();
       expect(succeeded).toBe(false);
       expect(failed).toBe(true);
     });

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -5,7 +5,6 @@ import { REACT_MODULE } from 'core/reactShims';
 import { EXECUTION_SERVICE, ExecutionService } from './execution.service';
 import { IExecution } from 'core/domain';
 import { Application } from 'core/application';
-import { SETTINGS } from 'core/config/settings';
 import * as State from 'core/state';
 
 describe('Service: executionService', () => {
@@ -91,7 +90,7 @@ describe('Service: executionService', () => {
       const http = mockHttpClient();
       let failed = false;
       const executionId = 'abc';
-      const deleteUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
+      const deleteUrl = `/pipelines/${executionId}`;
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
       http.expectDELETE(deleteUrl).respond(500, []);
@@ -107,8 +106,8 @@ describe('Service: executionService', () => {
       const http = mockHttpClient();
       let completed = false;
       const executionId = 'abc';
-      const pauseUrl = [SETTINGS.gateUrl, 'pipelines', executionId, 'pause'].join('/');
-      const singleExecutionUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
+      const pauseUrl = `/pipelines/${executionId}/pause`;
+      const singleExecutionUrl = `/pipelines/${executionId}`;
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
       http.expectPUT(pauseUrl).respond(200, []);
@@ -131,8 +130,8 @@ describe('Service: executionService', () => {
       const http = mockHttpClient();
       let completed = false;
       const executionId = 'abc';
-      const pauseUrl = [SETTINGS.gateUrl, 'pipelines', executionId, 'resume'].join('/');
-      const singleExecutionUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
+      const pauseUrl = `/pipelines/${executionId}/resume`;
+      const singleExecutionUrl = `/pipelines/${executionId}`;
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
       http.expectPUT(pauseUrl).respond(200, []);
@@ -179,7 +178,7 @@ describe('Service: executionService', () => {
     it('resolves when the execution matches the closure', async () => {
       const http = mockHttpClient();
       const executionId = 'abc';
-      const url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
+      const url = `/pipelines/${executionId}`;
       let succeeded = false;
 
       http.expectGET(url).respond(200, { thingToMatch: true });
@@ -197,7 +196,7 @@ describe('Service: executionService', () => {
     it('polls until the execution matches, then resolves', async () => {
       const http = mockHttpClient();
       const executionId = 'abc';
-      const url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
+      const url = `/pipelines/${executionId}`;
       let succeeded = false;
 
       http.expectGET(url).respond(200, { thingToMatch: false });
@@ -229,7 +228,7 @@ describe('Service: executionService', () => {
     it('rejects if execution retrieval fails', async () => {
       const http = mockHttpClient();
       const executionId = 'abc';
-      const url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
+      const url = `/pipelines/${executionId}`;
       let succeeded = false;
       let failed = false;
 
@@ -429,7 +428,7 @@ describe('Service: executionService', () => {
     const applicationName = 'deck';
     const application: Application = { name: applicationName, executions: { refresh: () => $q.when(null) } } as any;
     const pipelineId = '01DC2VMFBZ5PFW5G6SMKWW5CZC';
-    const url = [SETTINGS.gateUrl, 'pipelines', pipelineId].join('/');
+    const url = `/pipelines/${pipelineId}`;
     const execution: any = {}; // Stub execution
 
     it('resolves when the pipeline exists', async () => {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -1,5 +1,5 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { IHttpBackendService, IQProvider, IQService, ITimeoutService, mock, noop } from 'angular';
+import { IQProvider, IQService, ITimeoutService, mock, noop } from 'angular';
 import { REACT_MODULE } from 'core/reactShims';
 
 import { EXECUTION_SERVICE, ExecutionService } from './execution.service';
@@ -10,7 +10,6 @@ import * as State from 'core/state';
 
 describe('Service: executionService', () => {
   let executionService: ExecutionService;
-  let $httpBackend: IHttpBackendService;
   let timeout: ITimeoutService;
   let $q: IQService;
 
@@ -24,27 +23,14 @@ describe('Service: executionService', () => {
   );
 
   beforeEach(
-    mock.inject(
-      (
-        _executionService_: ExecutionService,
-        _$httpBackend_: IHttpBackendService,
-        _$timeout_: ITimeoutService,
-        _$q_: IQService,
-      ) => {
-        executionService = _executionService_;
-        $httpBackend = _$httpBackend_;
-        timeout = _$timeout_;
-        $q = _$q_;
-        State.initialize();
-        State.ExecutionState.filterModel.asFilterModel.sortFilter.count = 3;
-      },
-    ),
+    mock.inject((_executionService_: ExecutionService, _$timeout_: ITimeoutService, _$q_: IQService) => {
+      executionService = _executionService_;
+      timeout = _$timeout_;
+      $q = _$q_;
+      State.initialize();
+      State.ExecutionState.filterModel.asFilterModel.sortFilter.count = 3;
+    }),
   );
-
-  afterEach(() => {
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
-  });
 
   describe('cancelling pipeline', () => {
     it('should wait until pipeline is not running, then resolve', async () => {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { IHttpBackendService, IQProvider, IQService, ITimeoutService, mock, noop } from 'angular';
 import { REACT_MODULE } from 'core/reactShims';
 
@@ -46,130 +47,137 @@ describe('Service: executionService', () => {
   });
 
   describe('cancelling pipeline', () => {
-    it('should wait until pipeline is not running, then resolve', () => {
+    it('should wait until pipeline is not running, then resolve', async () => {
+      const http = mockHttpClient();
       let completed = false;
       const executionId = 'abc';
       const cancelUrl = [SETTINGS.gateUrl, 'pipelines', executionId, 'cancel'].join('/');
       const checkUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
-      $httpBackend.expectPUT(cancelUrl).respond(200, []);
-      $httpBackend.expectGET(checkUrl).respond(200, { id: executionId, status: 'RUNNING' });
+      http.expectPUT(cancelUrl).respond(200, []);
+      http.expectGET(checkUrl).respond(200, { id: executionId, status: 'RUNNING' });
 
       executionService.cancelExecution(application, executionId).then(() => (completed = true));
-      $httpBackend.flush();
+      await http.flush();
       expect(completed).toBe(false);
 
-      $httpBackend.expectGET(checkUrl).respond(200, { id: executionId, status: 'CANCELED' });
+      http.expectGET(checkUrl).respond(200, { id: executionId, status: 'CANCELED' });
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
       expect(completed).toBe(true);
     });
 
-    it('should propagate rejection from failed cancel', () => {
+    it('should propagate rejection from failed cancel', async () => {
+      const http = mockHttpClient();
       let failed = false;
       const executionId = 'abc';
       const cancelUrl = [SETTINGS.gateUrl, 'pipelines', executionId, 'cancel'].join('/');
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
-      $httpBackend.expectPUT(cancelUrl).respond(500, []);
+      http.expectPUT(cancelUrl).respond(500, []);
 
       executionService.cancelExecution(application, executionId).then(noop, () => (failed = true));
-      $httpBackend.flush();
+      await http.flush();
       expect(failed).toBe(true);
     });
   });
 
   describe('deleting pipeline', () => {
-    it('should wait until pipeline is missing, then resolve', () => {
+    it('should wait until pipeline is missing, then resolve', async () => {
+      const http = mockHttpClient();
       let completed = false;
       const executionId = 'abc';
       const deleteUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       const checkUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
-      $httpBackend.expectDELETE(deleteUrl).respond(200, []);
-      $httpBackend.expectGET(checkUrl).respond(200, { id: executionId });
+      http.expectDELETE(deleteUrl).respond(200, []);
+      http.expectGET(checkUrl).respond(200, { id: executionId });
 
       executionService.deleteExecution(application, executionId).then(() => (completed = true));
-      $httpBackend.flush();
+      await http.flush();
       expect(completed).toBe(false);
 
-      $httpBackend.expectGET(checkUrl).respond(404, null);
+      http.expectGET(checkUrl).respond(404, null);
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
       expect(completed).toBe(true);
     });
 
-    it('should propagate rejection from failed delete', () => {
+    it('should propagate rejection from failed delete', async () => {
+      const http = mockHttpClient();
       let failed = false;
       const executionId = 'abc';
       const deleteUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
-      $httpBackend.expectDELETE(deleteUrl).respond(500, []);
+      http.expectDELETE(deleteUrl).respond(500, []);
 
       executionService.deleteExecution(application, executionId).then(noop, () => (failed = true));
-      $httpBackend.flush();
+      await http.flush();
       expect(failed).toBe(true);
     });
   });
 
   describe('pausing pipeline', () => {
-    it('should wait until pipeline is PAUSED, then resolve', () => {
+    it('should wait until pipeline is PAUSED, then resolve', async () => {
+      const http = mockHttpClient();
       let completed = false;
       const executionId = 'abc';
       const pauseUrl = [SETTINGS.gateUrl, 'pipelines', executionId, 'pause'].join('/');
       const singleExecutionUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
-      $httpBackend.expectPUT(pauseUrl).respond(200, []);
-      $httpBackend.expectGET(singleExecutionUrl).respond(200, { id: executionId, status: 'RUNNING' });
+      http.expectPUT(pauseUrl).respond(200, []);
+      http.expectGET(singleExecutionUrl).respond(200, { id: executionId, status: 'RUNNING' });
 
       executionService.pauseExecution(application, executionId).then(() => (completed = true));
-      $httpBackend.flush();
+      await http.flush();
       expect(completed).toBe(false);
 
-      $httpBackend.expectGET(singleExecutionUrl).respond(200, { id: executionId, status: 'PAUSED' });
+      http.expectGET(singleExecutionUrl).respond(200, { id: executionId, status: 'PAUSED' });
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
 
       expect(completed).toBe(true);
     });
   });
 
   describe('resuming pipeline', () => {
-    it('should wait until pipeline is RUNNING, then resolve', () => {
+    it('should wait until pipeline is RUNNING, then resolve', async () => {
+      const http = mockHttpClient();
       let completed = false;
       const executionId = 'abc';
       const pauseUrl = [SETTINGS.gateUrl, 'pipelines', executionId, 'resume'].join('/');
       const singleExecutionUrl = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
 
-      $httpBackend.expectPUT(pauseUrl).respond(200, []);
-      $httpBackend.expectGET(singleExecutionUrl).respond(200, { id: executionId, status: 'PAUSED' });
+      http.expectPUT(pauseUrl).respond(200, []);
+      http.expectGET(singleExecutionUrl).respond(200, { id: executionId, status: 'PAUSED' });
 
       executionService.resumeExecution(application, executionId).then(() => (completed = true));
-      $httpBackend.flush();
+      await http.flush();
       expect(completed).toBe(false);
 
-      $httpBackend.expectGET(singleExecutionUrl).respond(200, { id: executionId, status: 'RUNNING' });
+      http.expectGET(singleExecutionUrl).respond(200, { id: executionId, status: 'RUNNING' });
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
 
       expect(completed).toBe(true);
     });
   });
 
   describe('when fetching pipelines', () => {
-    it('should resolve the promise if a 200 response is received with empty array', () => {
+    it('should resolve the promise if a 200 response is received with empty array', async () => {
+      const http = mockHttpClient();
       const url = [SETTINGS.gateUrl, 'applications', 'deck', 'pipelines?limit=3&expand=false'].join('/');
 
-      $httpBackend.expectGET(url).respond(200, []);
+      http.expectGET(url).respond(200, []);
 
       const responsePromise = executionService.getExecutions('deck');
 
-      $httpBackend.flush();
+      await http.flush();
 
       responsePromise
         .then((result) => {
@@ -181,14 +189,15 @@ describe('Service: executionService', () => {
         });
     });
 
-    it('should reject the promise if a 429 response is received', () => {
+    it('should reject the promise if a 429 response is received', async () => {
+      const http = mockHttpClient();
       const url = [SETTINGS.gateUrl, 'applications', 'deck', 'pipelines?limit=3&expand=false'].join('/');
 
-      $httpBackend.expectGET(url).respond(429, []);
+      http.expectGET(url).respond(429, []);
 
       const responsePromise = executionService.getExecutions('deck');
 
-      $httpBackend.flush();
+      await http.flush();
 
       responsePromise
         .then((result) => {
@@ -201,12 +210,13 @@ describe('Service: executionService', () => {
   });
 
   describe('waitUntilExecutionMatches', () => {
-    it('resolves when the execution matches the closure', () => {
+    it('resolves when the execution matches the closure', async () => {
+      const http = mockHttpClient();
       const executionId = 'abc';
       const url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       let succeeded = false;
 
-      $httpBackend.expectGET(url).respond(200, { thingToMatch: true });
+      http.expectGET(url).respond(200, { thingToMatch: true });
 
       executionService
         .waitUntilExecutionMatches(executionId, (execution) => (execution as any).thingToMatch)
@@ -214,16 +224,17 @@ describe('Service: executionService', () => {
 
       expect(succeeded).toBe(false);
 
-      $httpBackend.flush();
+      await http.flush();
       expect(succeeded).toBe(true);
     });
 
-    it('polls until the execution matches, then resolves', () => {
+    it('polls until the execution matches, then resolves', async () => {
+      const http = mockHttpClient();
       const executionId = 'abc';
       const url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       let succeeded = false;
 
-      $httpBackend.expectGET(url).respond(200, { thingToMatch: false });
+      http.expectGET(url).respond(200, { thingToMatch: false });
 
       executionService
         .waitUntilExecutionMatches(executionId, (execution) => (execution as any).thingToMatch)
@@ -231,31 +242,32 @@ describe('Service: executionService', () => {
 
       expect(succeeded).toBe(false);
 
-      $httpBackend.flush();
+      await http.flush();
       expect(succeeded).toBe(false);
 
       // no match, retrying
-      $httpBackend.expectGET(url).respond(200, { thingToMatch: false });
+      http.expectGET(url).respond(200, { thingToMatch: false });
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
 
       expect(succeeded).toBe(false);
 
       // still no match, retrying again
-      $httpBackend.expectGET(url).respond(200, { thingToMatch: true });
+      http.expectGET(url).respond(200, { thingToMatch: true });
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
 
       expect(succeeded).toBe(true);
     });
 
-    it('rejects if execution retrieval fails', () => {
+    it('rejects if execution retrieval fails', async () => {
+      const http = mockHttpClient();
       const executionId = 'abc';
       const url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
       let succeeded = false;
       let failed = false;
 
-      $httpBackend.expectGET(url).respond(200, { thingToMatch: false });
+      http.expectGET(url).respond(200, { thingToMatch: false });
 
       executionService
         .waitUntilExecutionMatches(executionId, (execution) => (execution as any).thingToMatch)
@@ -267,14 +279,14 @@ describe('Service: executionService', () => {
       expect(succeeded).toBe(false);
       expect(failed).toBe(false);
 
-      $httpBackend.flush();
+      await http.flush();
 
       // no match, retrying
       expect(succeeded).toBe(false);
       expect(failed).toBe(false);
-      $httpBackend.expectGET(url).respond(500, '');
+      http.expectGET(url).respond(500, '');
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
       expect(succeeded).toBe(false);
       expect(failed).toBe(true);
     });
@@ -454,10 +466,11 @@ describe('Service: executionService', () => {
     const url = [SETTINGS.gateUrl, 'pipelines', pipelineId].join('/');
     const execution: any = {}; // Stub execution
 
-    it('resolves when the pipeline exists', () => {
+    it('resolves when the pipeline exists', async () => {
+      const http = mockHttpClient();
       let succeeded = false;
 
-      $httpBackend.expectGET(url).respond(200, execution);
+      http.expectGET(url).respond(200, execution);
 
       executionService
         .waitUntilTriggeredPipelineAppears(application, pipelineId)
@@ -465,14 +478,15 @@ describe('Service: executionService', () => {
 
       expect(succeeded).toBe(false);
 
-      $httpBackend.flush();
+      await http.flush();
       expect(succeeded).toBe(true);
     });
 
-    it('does not resolve when the pipeline does not exist', () => {
+    it('does not resolve when the pipeline does not exist', async () => {
+      const http = mockHttpClient();
       let succeeded = false;
 
-      $httpBackend.expectGET(url).respond(404, null);
+      http.expectGET(url).respond(404, null);
 
       executionService
         .waitUntilTriggeredPipelineAppears(application, pipelineId)
@@ -480,14 +494,15 @@ describe('Service: executionService', () => {
 
       expect(succeeded).toBe(false);
 
-      $httpBackend.flush();
+      await http.flush();
       expect(succeeded).toBe(false);
     });
 
-    it('resolves when the pipeline exists on a later poll', () => {
+    it('resolves when the pipeline exists on a later poll', async () => {
+      const http = mockHttpClient();
       let succeeded = false;
 
-      $httpBackend.expectGET(url).respond(404, null);
+      http.expectGET(url).respond(404, null);
 
       executionService
         .waitUntilTriggeredPipelineAppears(application, pipelineId)
@@ -495,14 +510,14 @@ describe('Service: executionService', () => {
 
       expect(succeeded).toBe(false);
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(succeeded).toBe(false);
 
       // return success on the second GET request
-      $httpBackend.expectGET(url).respond(200, execution);
+      http.expectGET(url).respond(200, execution);
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
 
       expect(succeeded).toBe(true);
     });

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -13,20 +13,18 @@ import {
 } from './securityGroupTransformer.service';
 
 describe('Service: securityGroupReader', function () {
-  let $q: ng.IQService, $httpBackend: ng.IHttpBackendService, $scope: ng.IRootScopeService, reader: SecurityGroupReader;
+  let $q: ng.IQService, $scope: ng.IRootScopeService, reader: SecurityGroupReader;
 
   beforeEach(mock.module(SECURITY_GROUP_TRANSFORMER_SERVICE, SECURITY_GROUP_READER));
   beforeEach(
     mock.inject(function (
       _$q_: ng.IQService,
-      _$httpBackend_: ng.IHttpBackendService,
       $rootScope: ng.IRootScopeService,
       _providerServiceDelegate_: any,
       securityGroupTransformer: SecurityGroupTransformerService,
       _securityGroupReader_: SecurityGroupReader,
     ) {
       reader = _securityGroupReader_;
-      $httpBackend = _$httpBackend_;
       $q = _$q_;
       $scope = $rootScope.$new();
 

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -1,7 +1,6 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock } from 'angular';
 
-import { API } from 'core/api/ApiService';
 import { Application } from 'core/application/application.model';
 import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { InfrastructureCaches } from 'core/cache';
@@ -83,7 +82,7 @@ describe('Service: securityGroupReader', function () {
     application.loadBalancers.refresh();
     $scope.$digest();
 
-    http.expectGET(`${API.baseUrl}/securityGroups`).respond(200, {
+    http.expectGET(`/securityGroups`).respond(200, {
       test: {
         aws: {
           'us-east-1': [{ name: 'not-cached' }],
@@ -107,7 +106,7 @@ describe('Service: securityGroupReader', function () {
       prod: { 'us-east-1': { 'sg-2': { name: 'matched-prod' } } },
     };
 
-    http.expectGET(`${API.baseUrl}/securityGroups/test/us-east-1/sg-123?provider=aws&vpcId=vpc-1`).respond(200, {
+    http.expectGET(`/securityGroups/test/us-east-1/sg-123?provider=aws&vpcId=vpc-1`).respond(200, {
       inboundRules: [
         { securityGroup: { accountName: 'test', id: 'sg-345' } },
         { securityGroup: { accountName: 'test', id: 'sg-2' } },
@@ -166,7 +165,7 @@ describe('Service: securityGroupReader', function () {
     application.getDataSource('loadBalancers').refresh();
     $scope.$digest();
 
-    http.expectGET(API.baseUrl + '/securityGroups').respond(200, {
+    http.expectGET('/securityGroups').respond(200, {
       test: {
         aws: {
           'us-east-1': [{ name: 'not-cached', id: 'not-cached-id', vpcId: null }],

--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
@@ -51,7 +51,7 @@ describe('serverGroupWriter', function () {
     async function postTask(http: MockHttpClient, serverGroupCommand: IServerGroupCommand): Promise<ITaskCommand> {
       let submitted: ITaskCommand = {};
       http
-        .expectPOST(`${API.baseUrl}/tasks`)
+        .expectPOST(`/tasks`)
         .respond(200, { ref: '/1' })
         .onRequestReceived((resp) => (submitted = resp.data));
 
@@ -63,7 +63,7 @@ describe('serverGroupWriter', function () {
         refresh: noop,
       };
 
-      http.expectGET(API.baseUrl + '/tasks/1').respond(200, {});
+      http.expectGET('/tasks/1').respond(200, {});
       serverGroupWriter.cloneServerGroup(serverGroupCommand, application);
       await http.flush();
 

--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock, noop } from 'angular';
 
 import { API } from 'core/api/ApiService';
@@ -42,9 +43,10 @@ describe('serverGroupWriter', function () {
     });
   });
 
-  it('should inject defined objects', function () {
+  it('should inject defined objects', async function () {
+    const http = mockHttpClient();
     expect(API).toBeDefined();
-    expect($httpBackend).toBeDefined();
+    expect(http).toBeDefined();
     expect(serverGroupTransformer).toBeDefined();
     expect(serverGroupWriter).toBeDefined();
   });

--- a/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
@@ -1,7 +1,6 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock, IRootScopeService, IScope } from 'angular';
 
-import { API } from 'core/api/ApiService';
 import { SubnetReader } from 'core/subnet/subnet.read.service';
 import { ISubnet } from 'core/domain';
 
@@ -17,7 +16,7 @@ describe('SubnetReader', function () {
   it('adds label to subnet, including (deprecated) if deprecated field is true', async function () {
     const http = mockHttpClient();
     http
-      .expectGET(API.baseUrl + '/subnets')
+      .expectGET('/subnets')
       .respond(200, [
         { purpose: 'internal', deprecated: true },
         { purpose: 'external', deprecated: false },

--- a/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
@@ -18,7 +18,7 @@ describe('SubnetReader', function () {
   it('adds label to subnet, including (deprecated) if deprecated field is true', async function () {
     const http = mockHttpClient();
     http
-      .whenGET(API.baseUrl + '/subnets')
+      .expectGET(API.baseUrl + '/subnets')
       .respond(200, [
         { purpose: 'internal', deprecated: true },
         { purpose: 'external', deprecated: false },

--- a/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock, IHttpBackendService, IRootScopeService, IScope } from 'angular';
 
 import { API } from 'core/api/ApiService';
@@ -14,8 +15,9 @@ describe('SubnetReader', function () {
     }),
   );
 
-  it('adds label to subnet, including (deprecated) if deprecated field is true', function () {
-    $httpBackend
+  it('adds label to subnet, including (deprecated) if deprecated field is true', async function () {
+    const http = mockHttpClient();
+    http
       .whenGET(API.baseUrl + '/subnets')
       .respond(200, [
         { purpose: 'internal', deprecated: true },
@@ -29,7 +31,7 @@ describe('SubnetReader', function () {
       result = subnets;
     });
 
-    $httpBackend.flush();
+    await http.flush();
     $scope.$digest();
 
     expect(result[0].label).toBe('internal (deprecated)');

--- a/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.spec.ts
@@ -1,16 +1,15 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { mock, IHttpBackendService, IRootScopeService, IScope } from 'angular';
+import { mock, IRootScopeService, IScope } from 'angular';
 
 import { API } from 'core/api/ApiService';
 import { SubnetReader } from 'core/subnet/subnet.read.service';
 import { ISubnet } from 'core/domain';
 
 describe('SubnetReader', function () {
-  let $httpBackend: IHttpBackendService, $scope: IScope;
+  let $scope: IScope;
 
   beforeEach(
-    mock.inject(function (_$httpBackend_: IHttpBackendService, $rootScope: IRootScopeService) {
-      $httpBackend = _$httpBackend_;
+    mock.inject(function ($rootScope: IRootScopeService) {
       $scope = $rootScope.$new();
     }),
   );

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
@@ -4,7 +4,6 @@ import { IModalServiceInstance } from 'angular-ui-bootstrap';
 import { $q, $timeout } from 'ngimport';
 import Spy = jasmine.Spy;
 
-import { API } from 'core/api/ApiService';
 import { ITask } from 'core/domain';
 import { TaskMonitor } from './TaskMonitor';
 import { OrchestratedItemTransformer } from 'core/orchestratedItem/orchestratedItem.transformer';
@@ -46,13 +45,13 @@ describe('TaskMonitor', () => {
 
       $timeout.flush(); // still running first time
 
-      http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
+      http.expectGET('/tasks/a').respond(200, { status: 'RUNNING' });
       $timeout.flush();
       await http.flush();
       expect(monitor.task.isCompleted).toBe(false);
       expect((monitor.application.getDataSource('runningTasks').refresh as Spy).calls.count()).toBe(1);
 
-      http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
+      http.expectGET('/tasks/a').respond(200, { status: 'SUCCEEDED' });
       $timeout.flush(); // complete second time
       await http.flush();
 
@@ -111,12 +110,12 @@ describe('TaskMonitor', () => {
 
       $timeout.flush(); // still running first time
 
-      http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
+      http.expectGET('/tasks/a').respond(200, { status: 'RUNNING' });
       $timeout.flush();
       await http.flush();
       expect(monitor.task.isCompleted).toBe(false);
 
-      http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'TERMINAL' });
+      http.expectGET('/tasks/a').respond(200, { status: 'TERMINAL' });
       $timeout.flush(); // complete second time
       await http.flush();
 

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
@@ -11,12 +11,11 @@ import { OrchestratedItemTransformer } from 'core/orchestratedItem/orchestratedI
 import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 
 describe('TaskMonitor', () => {
-  let $scope: ng.IScope, $httpBackend: ng.IHttpBackendService;
+  let $scope: ng.IScope;
 
   beforeEach(
-    mock.inject(($rootScope: ng.IRootScopeService, _$httpBackend_: ng.IHttpBackendService) => {
+    mock.inject(($rootScope: ng.IRootScopeService) => {
       $scope = $rootScope.$new();
-      $httpBackend = _$httpBackend_;
     }),
   );
 

--- a/app/scripts/modules/core/src/task/task.read.service.spec.js
+++ b/app/scripts/modules/core/src/task/task.read.service.spec.js
@@ -1,7 +1,5 @@
 'use strict';
 import { mockHttpClient } from 'core/api/mock/jasmine';
-
-import { API } from 'core/api/ApiService';
 import { TaskReader } from './task.read.service';
 
 describe('Service: taskReader', function () {
@@ -75,7 +73,7 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // still running
-      http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      http.expectGET('/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
       timeout.flush();
       await http.flush();
 
@@ -83,7 +81,7 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // succeeds
-      http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'SUCCEEDED' });
+      http.expectGET('/tasks/1').respond(200, { id: 1, status: 'SUCCEEDED' });
       timeout.flush();
       await http.flush();
 
@@ -113,14 +111,14 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // still running
-      http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      http.expectGET('/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
       timeout.flush();
       await http.flush();
       expect(completed).toBe(false);
       expect(failed).toBe(false);
 
       // succeeds
-      http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'TERMINAL' });
+      http.expectGET('/tasks/1').respond(200, { id: 1, status: 'TERMINAL' });
       timeout.flush();
       await http.flush();
       expect(completed).toBe(false);
@@ -129,7 +127,7 @@ describe('Service: taskReader', function () {
 
     it('polls task and rejects if task is not returned from getTask call', async function () {
       const http = mockHttpClient({ autoFlush: true });
-      http.expectGET(API.baseUrl + '/tasks/1').respond(500, {});
+      http.expectGET('/tasks/1').respond(500, {});
       const task = await TaskReader.getTask(1);
 
       let completed = false,

--- a/app/scripts/modules/core/src/task/task.write.service.spec.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.spec.ts
@@ -1,7 +1,5 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { mock, IHttpBackendService, ITimeoutService } from 'angular';
-
-import { API } from 'core/api/ApiService';
+import { mock, ITimeoutService } from 'angular';
 import { TaskWriter } from './task.write.service';
 
 describe('Service: TaskWriter', () => {
@@ -17,8 +15,8 @@ describe('Service: TaskWriter', () => {
     it('should wait until task is canceled, then resolve', async () => {
       const http = mockHttpClient();
       const taskId = 'abc';
-      const cancelUrl = [API.baseUrl, 'tasks', taskId, 'cancel'].join('/');
-      const checkUrl = [API.baseUrl, 'tasks', taskId].join('/');
+      const cancelUrl = `/tasks/${taskId}/cancel`;
+      const checkUrl = `/tasks/${taskId}`;
       let completed = false;
 
       http.expectPUT(cancelUrl).respond(200, []);

--- a/app/scripts/modules/core/src/task/task.write.service.spec.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock, IHttpBackendService, ITimeoutService } from 'angular';
 
 import { API } from 'core/api/ApiService';
@@ -20,26 +21,27 @@ describe('Service: TaskWriter', () => {
   });
 
   describe('cancelling task', () => {
-    it('should wait until task is canceled, then resolve', () => {
+    it('should wait until task is canceled, then resolve', async () => {
+      const http = mockHttpClient();
       const taskId = 'abc';
       const cancelUrl = [API.baseUrl, 'tasks', taskId, 'cancel'].join('/');
       const checkUrl = [API.baseUrl, 'tasks', taskId].join('/');
       let completed = false;
 
-      $httpBackend.expectPUT(cancelUrl).respond(200, []);
-      $httpBackend.expectGET(checkUrl).respond(200, { id: taskId });
+      http.expectPUT(cancelUrl).respond(200, []);
+      http.expectGET(checkUrl).respond(200, { id: taskId });
 
       TaskWriter.cancelTask(taskId).then(() => (completed = true));
-      $httpBackend.flush();
+      await http.flush();
       expect(completed).toBe(false);
 
-      $httpBackend.expectGET(checkUrl).respond(200, { id: taskId });
+      http.expectGET(checkUrl).respond(200, { id: taskId });
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
 
-      $httpBackend.expectGET(checkUrl).respond(200, { status: 'CANCELED' });
+      http.expectGET(checkUrl).respond(200, { status: 'CANCELED' });
       timeout.flush();
-      $httpBackend.flush();
+      await http.flush();
       expect(completed).toBe(true);
     });
   });

--- a/app/scripts/modules/core/src/task/task.write.service.spec.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.spec.ts
@@ -5,20 +5,13 @@ import { API } from 'core/api/ApiService';
 import { TaskWriter } from './task.write.service';
 
 describe('Service: TaskWriter', () => {
-  let $httpBackend: IHttpBackendService;
   let timeout: ITimeoutService;
 
   beforeEach(
-    mock.inject((_$httpBackend_: IHttpBackendService, _$timeout_: ITimeoutService) => {
-      $httpBackend = _$httpBackend_;
+    mock.inject((_$timeout_: ITimeoutService) => {
       timeout = _$timeout_;
     }),
   );
-
-  afterEach(() => {
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
-  });
 
   describe('cancelling task', () => {
     it('should wait until task is canceled, then resolve', async () => {

--- a/app/scripts/modules/dcos/image/image.reader.spec.js
+++ b/app/scripts/modules/dcos/image/image.reader.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import { mockHttpClient } from 'core/api/mock/jasmine';
 
 import { API } from '@spinnaker/core';
 
@@ -27,27 +28,29 @@ describe('Service: DCOS Image Reader', function () {
       return API.baseUrl + '/images/find?provider=dcos&q=' + query + '&region=' + region;
     }
 
-    it('queries gate when 3 characters are supplied', function () {
+    it('queries gate when 3 characters are supplied', async function () {
+      const http = mockHttpClient();
       var result = null;
 
-      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      http.expectGET(buildQueryString()).respond(200, [{ success: true }]);
 
       service.findImages({ provider: 'dcos', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
     });
 
-    it('queries gate when more than 3 characters are supplied', function () {
+    it('queries gate when more than 3 characters are supplied', async function () {
+      const http = mockHttpClient();
       var result = null;
 
       query = 'abcd';
 
-      $httpBackend.when('GET', buildQueryString()).respond(200, [{ success: true }]);
+      http.expectGET(buildQueryString()).respond(200, [{ success: true }]);
 
       var promise = service.findImages({ provider: 'dcos', q: query, region: region });
 
@@ -55,23 +58,24 @@ describe('Service: DCOS Image Reader', function () {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(1);
       expect(result[0].success).toBe(true);
     });
 
-    it('returns an empty array when server errors', function () {
+    it('returns an empty array when server errors', async function () {
+      const http = mockHttpClient();
       query = 'abc';
       var result = null;
 
-      $httpBackend.when('GET', buildQueryString()).respond(404, {});
+      http.expectGET(buildQueryString()).respond(404, {});
 
       service.findImages({ provider: 'dcos', q: query, region: region }).then(function (results) {
         result = results;
       });
 
-      $httpBackend.flush();
+      await http.flush();
 
       expect(result.length).toBe(0);
     });

--- a/app/scripts/modules/dcos/image/image.reader.spec.js
+++ b/app/scripts/modules/dcos/image/image.reader.spec.js
@@ -1,8 +1,6 @@
 'use strict';
 import { mockHttpClient } from 'core/api/mock/jasmine';
 
-import { API } from '@spinnaker/core';
-
 describe('Service: DCOS Image Reader', function () {
   var service;
 
@@ -18,9 +16,7 @@ describe('Service: DCOS Image Reader', function () {
     var query = 'abc',
       region = 'usw';
 
-    function buildQueryString() {
-      return API.baseUrl + '/images/find?provider=dcos&q=' + query + '&region=' + region;
-    }
+    const buildQueryString = () => `/images/find?provider=dcos&q=${query}&region=${region}`;
 
     it('queries gate when 3 characters are supplied', async function () {
       const http = mockHttpClient();

--- a/app/scripts/modules/dcos/image/image.reader.spec.js
+++ b/app/scripts/modules/dcos/image/image.reader.spec.js
@@ -4,21 +4,15 @@ import { mockHttpClient } from 'core/api/mock/jasmine';
 import { API } from '@spinnaker/core';
 
 describe('Service: DCOS Image Reader', function () {
-  var service, $httpBackend;
+  var service;
 
   beforeEach(window.module(require('./image.reader').name));
 
   beforeEach(
-    window.inject(function (dcosImageReader, _$httpBackend_) {
+    window.inject(function (dcosImageReader) {
       service = dcosImageReader;
-      $httpBackend = _$httpBackend_;
     }),
   );
-
-  afterEach(function () {
-    $httpBackend.verifyNoOutstandingRequest();
-    $httpBackend.verifyNoOutstandingExpectation();
-  });
 
   describe('findImages', function () {
     var query = 'abc',

--- a/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -1,3 +1,4 @@
+import { mockHttpClient } from 'core/api/mock/jasmine';
 import { IControllerService, IRootScopeService, IScope, mock, noop } from 'angular';
 import { StateService } from '@uirouter/core';
 
@@ -181,11 +182,12 @@ describe('Controller: oracleCreateLoadBalancerCtrl', function () {
     expect(controller.listeners[0].sslConfiguration.certificateName).not.toBeDefined();
   });
 
-  it('makes the expected REST calls for data for a new loadbalancer', function () {
-    $httpBackend.expect('GET', API.baseUrl + '/networks/oracle').respond([]);
-    $httpBackend.expect('GET', API.baseUrl + '/subnets/oracle').respond([]);
-    $httpBackend.flush();
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
+  it('makes the expected REST calls for data for a new loadbalancer', async function () {
+    const http = mockHttpClient();
+    http.expect('GET', API.baseUrl + '/networks/oracle').respond([]);
+    http.expect('GET', API.baseUrl + '/subnets/oracle').respond([]);
+    await http.flush();
+    http.verifyNoOutstandingExpectation();
+    http.verifyNoOutstandingRequest();
   });
 });

--- a/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -2,7 +2,7 @@ import { mockHttpClient } from 'core/api/mock/jasmine';
 import { IControllerService, IRootScopeService, IScope, mock, noop } from 'angular';
 import { StateService } from '@uirouter/core';
 
-import { API, ApplicationModelBuilder } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
 
 import { ORACLE_LOAD_BALANCER_CREATE_CONTROLLER, OracleLoadBalancerController } from './createLoadBalancer.controller';
 import {
@@ -193,8 +193,8 @@ describe('Controller: oracleCreateLoadBalancerCtrl', function () {
 
   it('makes the expected REST calls for data for a new loadbalancer', async function () {
     const http = mockHttpClient();
-    http.expect('GET', API.baseUrl + '/networks/oracle').respond(200, []);
-    http.expect('GET', API.baseUrl + '/subnets/oracle').respond(200, []);
+    http.expectGET('/networks/oracle').respond(200, []);
+    http.expectGET('/subnets/oracle').respond(200, []);
     initController();
 
     await http.flush();


### PR DESCRIPTION
This PR includes all the commits from #8775.  #8775 should be merged separately before this PR gets merged.

Migrates all use of `$httpBackend` to `MockHttpClient` except for:

- `APIServiceDeprecated.spec.ts`
- `AuthenticationInitializer.ts`