### PR TITLE
fix(pipeline): Fixing lost history record for React stages

### DIFF
--- a/app/scripts/modules/core/src/pipeline/details/executionDetailsSection.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/details/executionDetailsSection.service.spec.ts
@@ -56,7 +56,7 @@ describe('executionDetailsSectionService', function () {
       $stateParams.details = 'c';
 
       service.synchronizeSection(['a', 'b']);
-
+      $timeout.flush();
       expect($state.includes).toHaveBeenCalledWith('**.execution');
       expect($state.go).toHaveBeenCalledWith('.', { details: 'a' }, { location: 'replace' });
     });
@@ -68,7 +68,7 @@ describe('executionDetailsSectionService', function () {
       $stateParams.details = undefined;
 
       service.synchronizeSection(['a', 'b']);
-
+      $timeout.flush();
       expect($state.includes).toHaveBeenCalledWith('**.execution');
       expect($state.go).toHaveBeenCalledWith('.', { details: 'a' }, { location: 'replace' });
     });

--- a/app/scripts/modules/core/src/pipeline/details/executionDetailsSection.service.ts
+++ b/app/scripts/modules/core/src/pipeline/details/executionDetailsSection.service.ts
@@ -26,8 +26,12 @@ export class ExecutionDetailsSectionService {
       details = availableSections[0];
     }
     if (!this.sectionIsValid(availableSections)) {
-      // use { location: 'replace' } to overwrite the invalid browser history state
-      this.$state.go('.', { details }, { location: 'replace' });
+      // Wrapping in a $timeout because for a React stage, this block is executed during a transitionSuccess hook
+      // meaning there is no location record to replace yet. Otherwise we incorrectly replace the previous record.
+      this.$timeout(() => {
+        // use { location: 'replace' } to overwrite the invalid browser history state
+        this.$state.go('.', { details }, { location: 'replace' });
+      });
     }
     if (onComplete) {
       this.pendingOnComplete = this.$timeout(onComplete);


### PR DESCRIPTION
This fixes some annoying situations where certain location records are lost because when navigating to a React stage, we are replacing the wrong history record. 

### For Example
1. Go to executions
2. Navigate to a stage that is not the same type as the first stage of a pipeline
3. Navigate to the permalink
4. Use the back icon to navigate up, back to the executions (with the same execution selected)
5. Use the browser's back feature to go back to the permalink

For pipelines where the first stage of the pipeline is a React stage (that is, the execution details is a React component), #5 will not take you to the permalink. In fact, the permalink is entirely missing from the browser's history stack.

### What's supposed to happen
1. Clicking on a stage will `toggleDetails` which transitions to a stage, but its available detail sections are not yet known.
https://github.com/spinnaker/deck/blob/0ca9259451433536c83ccf4bed78ddeaf04b750e/app/scripts/modules/core/src/pipeline/service/execution.service.ts#L193
2. As the stage renders, `synchronizeSection` is meant to come back and add the `details` param while replacing the above transition
https://github.com/spinnaker/deck/blob/de0ce7f000fe9d8f0fa73feaa2b58fec148a51e4/app/scripts/modules/core/src/pipeline/details/executionDetailsSection.service.ts#L29-L30

### However, in React stages
The `location: 'replace'` option ends up incorrectly replacing the previous history record (the permalink in the above example) because the `synchronizeSection` state transition is called within a `transitionSuccess` hook so the `toggleDetails` transition did not get flushed to the browser yet:

<details>
<summary>See stack trace showing `synchronizeSection` called within `transitionSuccess` hook</summary>

![image (1)](https://user-images.githubusercontent.com/1633736/102290989-f5b3a480-3ef6-11eb-83f5-65c802a7263d.png)
</details>

### Fix
Wrapping in a `$timeout` allows the `toggleDetails` transition to get flushed to the browser so that the transitions and history records are consistent between angular and React stages allowing the `synchronizeSection` transition to replace correctly. 🤷‍♂️ 