### PR TITLE
chore(package): amazon@0.0.284 appengine@0.0.25 azure@0.0.263 cloudfoundry@0.0.108 core@0.0.538 docker@0.0.67 ecs@0.0.274 google@0.0.30 oracle@0.0.18 tencentcloud@0.0.13

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.283",
+  "version": "0.0.284",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/appengine",
   "license": "Apache-2.0",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/azure/package.json
+++ b/app/scripts/modules/azure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/azure",
   "license": "Apache-2.0",
-  "version": "0.0.262",
+  "version": "0.0.263",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.107",
+  "version": "0.0.108",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.537",
+  "version": "0.0.538",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/docker",
   "license": "Apache-2.0",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.273",
+  "version": "0.0.274",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/google",
   "license": "Apache-2.0",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/oracle/package.json
+++ b/app/scripts/modules/oracle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/oracle",
   "license": "Apache-2.0",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/tencentcloud/package.json
+++ b/app/scripts/modules/tencentcloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/tencentcloud",
   "license": "Apache-2.0",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.284

1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
39b08e72b4baef1063a3ab9b65584e6e4e73d3e2 refactor(api-deprecation): Prefer API.path('foo', 'bar') over API.path('foo').path('bar')
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()
807de9ada97154e3e8b699dece0f8d5ec4493942 test(mock-http-client): Remove unnecessary API.baseUrl prefix in expectGET/etc calls
924e80be96fcd9e72cae7381cb50b577fa2ca709 test(mock-http-client): Remove no longer needed references to $httpBackend in unit tests after migration to MockHttpClient
e1238187ffb851e2b2a6402004bc6a42e780ec9a test(mock-http-client): Manually fix tests which didn't pass after auto-migrating using the eslint rule migrate-to-mock-http-client --fix
ef5d8ea0661d360661831b57d3ee8457aae0ecfd test(mock-http-client): Run eslint rule migrate-to-mock-http-client --fix
4f13518f69d883daaf94877e9387afeeecd6bbc5 feat(aws): Add scheme to load balancer details (#8797)
969f4fe0e9ab75eef2ceb0a2287643425293e209 Avoid raw "$http" usage (#8790)
40ba12cfb786972b417913f4dd1390d1653c2cd9 fix(aws): Misc. fixes and new unit tests (#8742)

## appengine@0.0.25

807de9ada97154e3e8b699dece0f8d5ec4493942 test(mock-http-client): Remove unnecessary API.baseUrl prefix in expectGET/etc calls
e1238187ffb851e2b2a6402004bc6a42e780ec9a test(mock-http-client): Manually fix tests which didn't pass after auto-migrating using the eslint rule migrate-to-mock-http-client --fix
ef5d8ea0661d360661831b57d3ee8457aae0ecfd test(mock-http-client): Run eslint rule migrate-to-mock-http-client --fix
969f4fe0e9ab75eef2ceb0a2287643425293e209 Avoid raw "$http" usage (#8790)

## azure@0.0.263

1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
39b08e72b4baef1063a3ab9b65584e6e4e73d3e2 refactor(api-deprecation): Prefer API.path('foo', 'bar') over API.path('foo').path('bar')
46db35b063b8c9b457f3f3675cd81a11a867c070 refactor(api-deprecation): Migrate from API.get(queryparams) to .query(queryparams).get()
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()
807de9ada97154e3e8b699dece0f8d5ec4493942 test(mock-http-client): Remove unnecessary API.baseUrl prefix in expectGET/etc calls
924e80be96fcd9e72cae7381cb50b577fa2ca709 test(mock-http-client): Remove no longer needed references to $httpBackend in unit tests after migration to MockHttpClient
e1238187ffb851e2b2a6402004bc6a42e780ec9a test(mock-http-client): Manually fix tests which didn't pass after auto-migrating using the eslint rule migrate-to-mock-http-client --fix
ef5d8ea0661d360661831b57d3ee8457aae0ecfd test(mock-http-client): Run eslint rule migrate-to-mock-http-client --fix
c5614e4f814754bd251f8555604b511fae9c6efd test(azure): Remove test that asserts nothing
969f4fe0e9ab75eef2ceb0a2287643425293e209 Avoid raw "$http" usage (#8790)

## cloudfoundry@0.0.108

1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()

## core@0.0.538

4e6f9e3ef800091dd4b8702699f33628a87aa375 feat(core/api): Add 'deleteData' argument to REST().delete(deleteData); (#8804)
afec9f8a49c500e8a200bc029d8405186c62f577 chore: Migrate ApplicationReader.spec.ts and serverGroupWriter.service.spec to MockHttpClient
ecb1dbc3b385295c436216312cd47970eef9dca0 chore(rest): Migrate missed API usage to REST
d66c62419602d427cb6ab7ed06e06eae68c65b46 refactor(REST): Find all empty args REST() calls and pass in the endpoint variable, i.e., REST(endpoint)
1cb2c30f5aa6067cd5f5fde83ff167097a029ee3 fix(core/search): Switch back to deprecated API because search uses the ICache interface which REST() does not support
1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
39b08e72b4baef1063a3ab9b65584e6e4e73d3e2 refactor(api-deprecation): Prefer API.path('foo', 'bar') over API.path('foo').path('bar')
46db35b063b8c9b457f3f3675cd81a11a867c070 refactor(api-deprecation): Migrate from API.get(queryparams) to .query(queryparams).get()
6a1c0814cd5e0679f0e82fda4590bcdefbdf440b refactor(api-deprecation): Migrate from API.data({}).post() to .post({}) or.put({})
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()
807de9ada97154e3e8b699dece0f8d5ec4493942 test(mock-http-client): Remove unnecessary API.baseUrl prefix in expectGET/etc calls
924e80be96fcd9e72cae7381cb50b577fa2ca709 test(mock-http-client): Remove no longer needed references to $httpBackend in unit tests after migration to MockHttpClient
e1238187ffb851e2b2a6402004bc6a42e780ec9a test(mock-http-client): Manually fix tests which didn't pass after auto-migrating using the eslint rule migrate-to-mock-http-client --fix
ef5d8ea0661d360661831b57d3ee8457aae0ecfd test(mock-http-client): Run eslint rule migrate-to-mock-http-client --fix
9fe939c2fdf0a8ffe6efade125808253a1735a29 feat(core/api): Introduce a MockHttpClient.ts as a incremental replacement for AngularJS $httpBackend for unit tests. (#8775)
54d9f6cc07ac0e41a774a337b1e7c9ddf20f0e39 fix(pipeline): Fixing lost history record for React stages (#8801)
0ca9259451433536c83ccf4bed78ddeaf04b750e feat(core/ci): Integrating CI builds with Deck (#8798)
969f4fe0e9ab75eef2ceb0a2287643425293e209 Avoid raw "$http" usage (#8790)
6308695ab430ea13c71cadf328f8d627cdffa070 fix: use 'import type {} from package' to fix the webpack warnings for missing interface imports (#8794)
b971b5a00327ef6345995b4057e2594e2ed71233 fix(bake): make helm chart file path visible when the chart comes from a git/repo artifact (#8789)

## docker@0.0.67

1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
39b08e72b4baef1063a3ab9b65584e6e4e73d3e2 refactor(api-deprecation): Prefer API.path('foo', 'bar') over API.path('foo').path('bar')
46db35b063b8c9b457f3f3675cd81a11a867c070 refactor(api-deprecation): Migrate from API.get(queryparams) to .query(queryparams).get()
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()

## ecs@0.0.274

1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
39b08e72b4baef1063a3ab9b65584e6e4e73d3e2 refactor(api-deprecation): Prefer API.path('foo', 'bar') over API.path('foo').path('bar')
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()
8e2bed6814d88c0d3b8cf58fc48b66d3414367e1 feat(ecs): support multiple subnet types (#8724)

## google@0.0.30

1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
46db35b063b8c9b457f3f3675cd81a11a867c070 refactor(api-deprecation): Migrate from API.get(queryparams) to .query(queryparams).get()
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()
969f4fe0e9ab75eef2ceb0a2287643425293e209 Avoid raw "$http" usage (#8790)

## oracle@0.0.18

1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
39b08e72b4baef1063a3ab9b65584e6e4e73d3e2 refactor(api-deprecation): Prefer API.path('foo', 'bar') over API.path('foo').path('bar')
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()
807de9ada97154e3e8b699dece0f8d5ec4493942 test(mock-http-client): Remove unnecessary API.baseUrl prefix in expectGET/etc calls
e1238187ffb851e2b2a6402004bc6a42e780ec9a test(mock-http-client): Manually fix tests which didn't pass after auto-migrating using the eslint rule migrate-to-mock-http-client --fix
ef5d8ea0661d360661831b57d3ee8457aae0ecfd test(mock-http-client): Run eslint rule migrate-to-mock-http-client --fix
969f4fe0e9ab75eef2ceb0a2287643425293e209 Avoid raw "$http" usage (#8790)

## tencentcloud@0.0.13

1d4320a08f73093483cbb93784e9115c236b1f8a refactor(REST): Prefer REST('/foo/bar') over REST().path('foo', 'bar')
97bfbf67b5d359cc540918b62c99088ad82dfb1b refactor(api-deprecation): API is deprecated, switch to REST()
39b08e72b4baef1063a3ab9b65584e6e4e73d3e2 refactor(api-deprecation): Prefer API.path('foo', 'bar') over API.path('foo').path('bar')
587db3ab20040fb5c72fe48feb36eccd7d1f297a refactor(api-deprecation): Migrate from API.one/all/withParams/getList() to path/query/get()

PR created via `modules/publish.js`