### PR TITLE
fix(core/projects): Fix duplicate Projects appearing in recent history (on search screen)

### DIFF
--- a/app/scripts/modules/core/src/projects/projects.states.ts
+++ b/app/scripts/modules/core/src/projects/projects.states.ts
@@ -73,6 +73,7 @@ module(PROJECTS_STATES_CONFIG, [
         },
         history: {
           type: 'projects',
+          keyParams: ['project'],
         },
       },
       children: [dashboard],


### PR DESCRIPTION
The recent history service uses the state's `.data` field to configure recent history behavior.


```
    $rootScope.$on('$stateChangeSuccess', (_event: IAngularEvent, toState: Ng1StateDeclaration, toParams: any) => {
      if (toState.data && toState.data.history) {
        const params = omit(toParams || {}, ['debug', 'vis', 'trace']);
        RecentHistoryService.addItem(toState.data.history.type, toState.name, params, toState.data.history.keyParams);
      }
    });
```


It uses `.data.history.keyParams` to check if a recent entry is already recorded.  It compares the configured router params with the stored values.


```
  private static getExisting(items: IRecentHistoryEntry[], params: any, keyParams: string[]): IRecentHistoryEntry {
    if (!keyParams || !keyParams.length) {
      return find(items, { params: omitBy(params, isUndefined) });
    }
    return items.find((item) => keyParams.every((p) => item.params[p] === params[p]));
  }
```