### PR TITLE
feat(ecs): Add support for Capacity providers -  enhanced Deck UI

### DIFF
--- a/app/scripts/modules/ecs/src/ecsCluster/IEcsDescribeCluster.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/IEcsDescribeCluster.ts
@@ -1,0 +1,58 @@
+export interface IEcsDescribeCluster {
+  activeServicesCount : number,
+  attachments : IDescribeClusterAttachments,
+  attachmentsStatus : string,
+  capacityProviders : string[],
+  clusterArn : string,
+  clusterName : string,
+  defaultCapacityProviderStrategy : IDescribeClusterDefaultCapacityProviderStrategy[],
+  pendingTasksCount : number,
+  registeredContainerInstancesCount : number,
+  runningTasksCount : number,
+  settings : IDescribeClusterSettings[],
+  statistics : IDescribeClusterStatistics[],
+  status : string,
+  tags : IDescribeClusterTags[],
+  failures: IDescribeClusterFailures[]
+
+
+}
+
+export interface IDescribeClusterAttachments {
+  details : IDescribeClusterAttachmentDetails[],
+  id : string,
+  Status : string,
+  type : string
+}
+
+export interface IDescribeClusterAttachmentDetails {
+  name : string,
+  value : string
+}
+
+export interface IDescribeClusterDefaultCapacityProviderStrategy {
+  base : number,
+  capacityProvider : string,
+  weight : number
+}
+
+export interface IDescribeClusterSettings {
+  name : string,
+  value : string
+}
+
+export interface IDescribeClusterStatistics {
+  name : string,
+  value : string
+}
+
+export interface IDescribeClusterTags {
+  key : string,
+  value : string
+}
+
+export interface IDescribeClusterFailures {
+  arn : string,
+  detail : string,
+  reason : string
+}

--- a/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
@@ -2,10 +2,18 @@ import { module } from 'angular';
 
 import { REST } from '@spinnaker/core';
 import { IEcsClusterDescriptor } from './IEcsCluster';
+import {IEcsDescribeCluster} from "./IEcsDescribeCluster";
 
 export class EcsClusterReader {
   public listClusters(): PromiseLike<IEcsClusterDescriptor[]> {
     return REST('/ecs/ecsClusters').get();
+  }
+
+  public listDescribeClusters(account: string, region: string): PromiseLike<IEcsDescribeCluster[]> {
+    if(account != null && region != null) {
+      return REST('/ecs/ecsClusterDescriptions').path(account).path(region).get();
+    }
+    return null;
   }
 }
 

--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -38,6 +38,7 @@ import { IMetricAlarmDescriptor } from '../../metricAlarm/MetricAlarm';
 import { PlacementStrategyService } from '../../placementStrategy/placementStrategy.service';
 import { IPlacementStrategy } from '../../placementStrategy/IPlacementStrategy';
 import { IEcsClusterDescriptor } from '../../ecsCluster/IEcsCluster';
+import { IEcsDescribeCluster } from '../../ecsCluster/IEcsDescribeCluster'
 import { SecretReader } from '../../secrets/secret.read.service';
 import { ISecretDescriptor } from '../../secrets/ISecret';
 import { ServiceDiscoveryReader } from '../../serviceDiscovery/serviceDiscovery.read.service';
@@ -70,6 +71,7 @@ export interface IEcsServerGroupCommandBackingDataFiltered extends IServerGroupC
   targetGroups: string[];
   iamRoles: string[];
   ecsClusters: string[];
+  ecsDescribeCluster: IEcsDescribeCluster[];
   metricAlarms: IMetricAlarmDescriptor[];
   subnetTypes: ISubnet[];
   securityGroupNames: string[];
@@ -82,6 +84,7 @@ export interface IEcsServerGroupCommandBackingData extends IServerGroupCommandBa
   filtered: IEcsServerGroupCommandBackingDataFiltered;
   targetGroups: string[];
   ecsClusters: IEcsClusterDescriptor[];
+  ecsDescribeCluster: IEcsDescribeCluster[];
   iamRoles: IRoleDescriptor[];
   metricAlarms: IMetricAlarmDescriptor[];
   launchTypes: string[];
@@ -137,6 +140,7 @@ export interface IEcsServerGroupCommand extends IServerGroupCommand {
   serviceDiscoveryAssociations: IEcsServiceDiscoveryRegistryAssociation[];
   useTaskDefinitionArtifact: boolean;
 
+  ecsDescribeCluster: IEcsDescribeCluster[];
   subnetTypeChanged: (command: IEcsServerGroupCommand) => IServerGroupCommandResult;
   placementStrategyNameChanged: (command: IEcsServerGroupCommand) => IServerGroupCommandResult;
   regionIsDeprecated: (command: IEcsServerGroupCommand) => boolean;
@@ -242,6 +246,7 @@ export class EcsServerGroupConfigurationService {
         subnets: SubnetReader.listSubnetsByProvider('ecs'),
         iamRoles: this.iamRoleReader.listRoles('ecs'),
         ecsClusters: this.ecsClusterReader.listClusters(),
+        ecsDescribeCluster: this.ecsClusterReader.listDescribeClusters(cmd.credentials, cmd.region),
         metricAlarms: this.metricAlarmReader.listMetricAlarms(),
         securityGroups: this.securityGroupReader.getAllSecurityGroups(),
         launchTypes: this.$q.when(clone(this.launchTypes)),
@@ -263,6 +268,7 @@ export class EcsServerGroupConfigurationService {
         this.configureAvailableSubnetTypes(cmd);
         this.configureAvailableSecurityGroups(cmd);
         this.configureAvailableEcsClusters(cmd);
+        this.configureAvailableEcsDescribeClusters(cmd);
         this.configureAvailableSecrets(cmd);
         this.configureAvailableServiceDiscoveryRegistries(cmd);
         this.configureAvailableImages(cmd);
@@ -271,6 +277,46 @@ export class EcsServerGroupConfigurationService {
         this.applyOverrides('afterConfiguration', cmd);
         this.attachEventHandlers(cmd);
       });
+  }
+
+  public configureAvailableEcsDescribeClusters(command: IEcsServerGroupCommand): void {
+    if(command.credentials != null && command.region != null) {
+      this.$q.all({
+        ecsDescribeCluster: this.ecsClusterReader.listDescribeClusters(command.credentials, command.region)
+      }).then((result: Partial<IEcsServerGroupCommandBackingData>) => {
+        command.backingData.filtered.ecsDescribeCluster = chain(result.ecsDescribeCluster)
+          .map((cluster) => this.mapDescribeClusters(cluster))
+          .value();
+
+        command.backingData.ecsDescribeCluster = chain(result.ecsDescribeCluster)
+          .map((cluster) => this.mapDescribeClusters(cluster))
+          .value();
+
+      });
+    }
+    command.backingData.filtered.ecsDescribeCluster = chain(command.backingData.ecsDescribeCluster)
+      .map((cluster) => this.mapDescribeClusters(cluster))
+      .value();
+  }
+
+  public mapDescribeClusters(describeClusters: IEcsDescribeCluster) : IEcsDescribeCluster {
+    return {
+      activeServicesCount : describeClusters.activeServicesCount,
+      attachments : describeClusters.attachments,
+      attachmentsStatus : describeClusters.attachmentsStatus,
+      capacityProviders : describeClusters.capacityProviders,
+      clusterArn : describeClusters.clusterArn,
+      clusterName :describeClusters.clusterName,
+      defaultCapacityProviderStrategy : describeClusters.defaultCapacityProviderStrategy,
+      pendingTasksCount : describeClusters.pendingTasksCount,
+      registeredContainerInstancesCount : describeClusters.registeredContainerInstancesCount,
+      runningTasksCount : describeClusters.runningTasksCount,
+      settings : describeClusters.settings,
+      statistics : describeClusters.statistics,
+      status : describeClusters.status,
+      tags : describeClusters.tags,
+      failures: describeClusters.failures
+    };
   }
 
   public applyOverrides(phase: string, command: IEcsServerGroupCommand): void {
@@ -576,6 +622,7 @@ export class EcsServerGroupConfigurationService {
         this.configureAvailableSecurityGroups(command);
         this.configureAvailableSecrets(command);
         this.configureAvailableServiceDiscoveryRegistries(command);
+        this.configureAvailableEcsDescribeClusters(command);
       }
 
       return result;
@@ -602,6 +649,7 @@ export class EcsServerGroupConfigurationService {
         this.configureAvailableSecrets(command);
         this.configureAvailableServiceDiscoveryRegistries(command);
         this.configureAvailableRegions(command);
+        this.configureAvailableEcsDescribeClusters(command);
 
         if (!some(backingData.filtered.regions, { name: command.region })) {
           command.region = null;

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
@@ -164,6 +164,7 @@ module(ECS_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_ECS_CONTROLLER, [
         initializeCommand();
         initializeSelectOptions();
         initializeWatches();
+        changeCluster();
       });
     }
 
@@ -182,6 +183,13 @@ module(ECS_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_ECS_CONTROLLER, [
     function initializeSelectOptions() {
       processCommandUpdateResult($scope.command.credentialsChanged(serverGroupCommand));
       processCommandUpdateResult($scope.command.regionChanged(serverGroupCommand));
+    }
+
+    function changeCluster(){
+      $scope.$on('clusterChanged', function(event, args) {
+        $scope.capacityProviderState.useCapacityProviders = false;
+        $scope.command.choseDefaultCapacityProvider = false;
+      });
     }
 
     function createResultProcessor(method) {
@@ -246,12 +254,33 @@ module(ECS_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_ECS_CONTROLLER, [
     $scope.capacityProviderState = {
       useCapacityProviders:
         $scope.command.capacityProviderStrategy && $scope.command.capacityProviderStrategy.length > 0,
+      useDefaultCapacityProviders: $scope.command.choseDefaultCapacityProvider || $scope.command.capacityProviderStrategy && $scope.command.capacityProviderStrategy == 0,
       updateComputeOption: function (chosenOption) {
         if (chosenOption == 'launchType') {
           $scope.command.capacityProviderStrategy = [];
         } else if (chosenOption == 'capacityProviders') {
           $scope.command.launchType = '';
           $scope.command.capacityProviderStrategy = $scope.command.capacityProviderStrategy || [];
+          $scope.capacityProviderState.useDefaultCapacityProviders =  $scope.command.choseDefaultCapacityProvider || $scope.command.capacityProviderStrategy && $scope.command.capacityProviderStrategy == 0;
+          $scope.capacityProviderState.useDefaultCapacityProviders ? $scope.capacityProviderState.updateStrategy('defaultCapacityProvider') : $scope.capacityProviderState.updateStrategy('customCapacityProvider')
+        }
+      },
+
+      updateStrategy: function (choseDefaultCapacityProvider) {
+        $scope.command.choseDefaultCapacityProvider = "";
+        $scope.command.capacityProviderNames = [];
+        $scope.command.capacityProviderStrategy = [];
+        const data = ($scope.command.backingData.ecsDescribeCluster).filter(function (el) {
+          return el.clusterName == ($scope.command.ecsClusterName)
+        })[0]
+        if (choseDefaultCapacityProvider == 'defaultCapacityProvider') {
+          $scope.command.choseDefaultCapacityProvider = true;
+          if (data.defaultCapacityProviderStrategy.length > 0)
+            $scope.command.capacityProviderStrategy = data.defaultCapacityProviderStrategy;
+        } else if (choseDefaultCapacityProvider == 'customCapacityProvider') {
+          $scope.command.choseDefaultCapacityProvider = false;
+          if (data.capacityProviders.length > 0)
+            $scope.command.capacityProviderNames = data.capacityProviders
         }
       },
     };

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
@@ -41,7 +41,7 @@
       <div class="radio">
         <label>
           <input
-            data-test-id="CapacityProviders.default"
+            data-test-id="ServerGroup.capacityProviders.default"
             type="radio"
             ng-model="$ctrl.capacityProviderState.useDefaultCapacityProviders"
             ng-value="true"
@@ -54,7 +54,7 @@
       <div class="radio">
         <label>
           <input
-            data-test-id="CapacityProviders.custom"
+            data-test-id="ServerGroup.capacityProviders.custom"
             type="radio"
             ng-model="$ctrl.capacityProviderState.useDefaultCapacityProviders"
             ng-value="false"
@@ -77,14 +77,14 @@
             <input
               disabled= "{{$ctrl.capacityProviderState.useDefaultCapacityProviders}} ? 'disable' : 'enable'"
               type="text"
-              data-test-id="capacityProvider.name.{{ $index }}"
+              data-test-id="ServerGroup.defaultCapacityProvider.name.{{$index}}"
               class="form-control input-sm no-spel"
               ng-model="cp.capacityProvider"
             />
           </td>
           <td ng-if="!$ctrl.capacityProviderState.useDefaultCapacityProviders">
             <select ng-model="cp.capacityProvider"
-                    data-test-id="capacityProvider.base.{{ $index }}"
+                    data-test-id="ServerGroup.customCapacityProvider.name.{{$index}}"
                     class="form-control input-sm no-spel">
               <option ng-repeat="CP in $ctrl.command.capacityProviderNames" required>{{CP}}</option>
             </select>
@@ -93,7 +93,7 @@
             <input
               ng-disabled="$ctrl.capacityProviderState.useDefaultCapacityProviders"
               type="text"
-              data-test-id="capacityProvider.base.{{ $index }}"
+              data-test-id="ServerGroup.capacityProvider.base.{{$index}}"
               class="form-control input-sm no-spel"
               ng-model="cp.base"
             />
@@ -102,7 +102,7 @@
             <input
               ng-disabled="$ctrl.capacityProviderState.useDefaultCapacityProviders"
               type="text"
-              data-test-id="capacityProvider.weight.{{ $index }}"
+              data-test-id="ServerGroup.capacityProvider.weight.{{$index}}"
               class="form-control input-sm no-spel"
               ng-model="cp.weight"
             />
@@ -132,7 +132,7 @@
         </tfoot>
       </table>
       <div ng-if="$ctrl.command.capacityProviderStrategy.length == 0 && $ctrl.capacityProviderState.useDefaultCapacityProviders">
-        <span style="color:#c00">The cluster does not have a default capacity provider strategy defined. Set a default capacity provider strategy or use a custom strategy.</span>
+        <span style="color:#c00" data-test-id="ServerGroup.capacityProviders.default.error">The cluster does not have a default capacity provider strategy defined. Set a default capacity provider strategy or use a custom strategy.</span>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
@@ -38,63 +38,102 @@
       <help-field key="ecs.capacityProviderStrategy"></help-field>
     </div>
     <div>
+      <div class="radio">
+        <label>
+          <input
+            data-test-id="CapacityProviders.default"
+            type="radio"
+            ng-model="$ctrl.capacityProviderState.useDefaultCapacityProviders"
+            ng-value="true"
+            ng-click="$ctrl.capacityProviderState.updateStrategy('defaultCapacityProvider')"
+            id="computeOptionsLaunchType1"
+          />
+          Use cluster default
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input
+            data-test-id="CapacityProviders.custom"
+            type="radio"
+            ng-model="$ctrl.capacityProviderState.useDefaultCapacityProviders"
+            ng-value="false"
+            ng-click="$ctrl.capacityProviderState.updateStrategy('customCapacityProvider')"
+            id="computeOptionsCapacityProviders1"
+          />
+          Use custom (Advanced)
+        </label>
+      </div>
+
       <table class="table table-condensed packed tags">
         <thead>
-          <th style="width: 50%">Provider name <help-field key="ecs.capacityProviderName"></help-field></th>
-          <th style="width: 25%">Base <help-field key="ecs.capacityProviderBase"></help-field></th>
-          <th style="width: 25%">Weight <help-field key="ecs.capacityProviderWeight"></help-field></th>
+        <th style="width: 50%">Provider name <help-field key="ecs.capacityProviderName"></help-field></th>
+        <th style="width: 25%">Base <help-field key="ecs.capacityProviderBase"></help-field></th>
+        <th style="width: 25%">Weight <help-field key="ecs.capacityProviderWeight"></help-field></th>
         </thead>
         <tbody>
-          <tr ng-repeat="cp in $ctrl.command.capacityProviderStrategy">
-            <td>
-              <input
-                type="text"
-                data-test-id="capacityProvider.name.{{ $index }}"
-                class="form-control input-sm no-spel"
-                ng-model="cp.capacityProvider"
-              />
-            </td>
-            <td>
-              <input
-                type="text"
-                data-test-id="capacityProvider.base.{{ $index }}"
-                class="form-control input-sm no-spel"
-                ng-model="cp.base"
-              />
-            </td>
-            <td>
-              <input
-                type="text"
-                data-test-id="capacityProvider.weight.{{ $index }}"
-                class="form-control input-sm no-spel"
-                ng-model="cp.weight"
-              />
-            </td>
-            <td>
-              <div class="form-control-static">
-                <a class="btn-link sm-label" ng-click="$ctrl.command.capacityProviderStrategy.splice($index, 1)">
-                  <span class="glyphicon glyphicon-trash"></span>
-                  <span class="sr-only">Remove</span>
-                </a>
-              </div>
-            </td>
-          </tr>
+        <tr ng-repeat="cp in $ctrl.command.capacityProviderStrategy">
+          <td ng-if="$ctrl.capacityProviderState.useDefaultCapacityProviders">
+            <input
+              disabled= "{{$ctrl.capacityProviderState.useDefaultCapacityProviders}} ? 'disable' : 'enable'"
+              type="text"
+              data-test-id="capacityProvider.name.{{ $index }}"
+              class="form-control input-sm no-spel"
+              ng-model="cp.capacityProvider"
+            />
+          </td>
+          <td ng-if="!$ctrl.capacityProviderState.useDefaultCapacityProviders">
+            <select ng-model="cp.capacityProvider"
+                    data-test-id="capacityProvider.base.{{ $index }}"
+                    class="form-control input-sm no-spel">
+              <option ng-repeat="CP in $ctrl.command.capacityProviderNames" required>{{CP}}</option>
+            </select>
+          </td>
+          <td>
+            <input
+              ng-disabled="$ctrl.capacityProviderState.useDefaultCapacityProviders"
+              type="text"
+              data-test-id="capacityProvider.base.{{ $index }}"
+              class="form-control input-sm no-spel"
+              ng-model="cp.base"
+            />
+          </td>
+          <td>
+            <input
+              ng-disabled="$ctrl.capacityProviderState.useDefaultCapacityProviders"
+              type="text"
+              data-test-id="capacityProvider.weight.{{ $index }}"
+              class="form-control input-sm no-spel"
+              ng-model="cp.weight"
+            />
+          </td>
+          <td ng-if="!$ctrl.capacityProviderState.useDefaultCapacityProviders">
+            <div class="form-control-static">
+              <a class="btn-link sm-label" ng-click="$ctrl.command.capacityProviderStrategy.splice($index, 1)">
+                <span class="glyphicon glyphicon-trash"></span>
+                <span class="sr-only">Remove</span>
+              </a>
+            </div>
+          </td>
+        </tr>
         </tbody>
         <tfoot>
-          <tr>
-            <td colspan="3">
-              <button
-                class="btn btn-block btn-sm add-new"
-                ng-click="$ctrl.command.capacityProviderStrategy.push({})"
-                data-test-id="ServerGroup.addCapacityProvider"
-              >
-                <span class="glyphicon glyphicon-plus-sign"></span>
-                Add New Capacity Provider
-              </button>
-            </td>
-          </tr>
+        <tr ng-if="$ctrl.command.ecsClusterName && $ctrl.command.credentials && $ctrl.command.region && !$ctrl.capacityProviderState.useDefaultCapacityProviders">
+          <td colspan="3">
+            <button
+              class="btn btn-block btn-sm add-new"
+              ng-click="$ctrl.command.capacityProviderStrategy.push({})"
+              data-test-id="ServerGroup.addCapacityProvider">
+              <span class="glyphicon glyphicon-plus-sign"></span>
+              Add New Capacity Provider
+            </button>
+          </td>
+        </tr>
         </tfoot>
       </table>
+      <div ng-if="$ctrl.command.capacityProviderStrategy.length == 0 && $ctrl.capacityProviderState.useDefaultCapacityProviders">
+        <span style="color:#c00">The cluster does not have a default capacity provider strategy defined. Set a default capacity provider strategy or use a custom strategy.</span>
+      </div>
     </div>
   </div>
 

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
@@ -37,5 +37,13 @@ angular
           ModalWizard.markIncomplete('location');
         }
       });
+
+
+      $scope.clusterChanged = function ($clusterName){
+        $scope.$emit('clusterChanged', $clusterName);
+      };
+
+      $scope.clusterChanged.$inject = ['$scope'];
+
     },
   ]);

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/location/basicSettings.html
@@ -43,6 +43,7 @@
           class="form-control input-sm"
           required
           on-select="fieldChanged()"
+          ng-change="clusterChanged(command.ecsClusterName)"
         >
           <ui-select-match>{{$select.selected}}</ui-select-match>
           <ui-select-choices

--- a/test/functional/cypress/fixtures/ecs/shared/ecsClusters.json
+++ b/test/functional/cypress/fixtures/ecs/shared/ecsClusters.json
@@ -4,5 +4,18 @@
     "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/spinnaker-deployment-cluster",
     "name": "spinnaker-deployment-cluster",
     "region": "us-west-2"
+  },
+  {
+    "account": "ecs-my-aws-devel-acct",
+    "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/TestCluster",
+    "name": "TestCluster",
+    "region": "us-west-2"
+  },
+
+  {
+    "account": "ecs-my-aws-devel-acct",
+    "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/example-app-test-Cluster-NSnYsTXmCfV2",
+    "name": "example-app-test-Cluster-NSnYsTXmCfV2",
+    "region": "us-west-2"
   }
 ]

--- a/test/functional/cypress/fixtures/ecs/shared/ecsDescribeClusters.json
+++ b/test/functional/cypress/fixtures/ecs/shared/ecsDescribeClusters.json
@@ -1,0 +1,76 @@
+[
+
+  {
+    "activeServicesCount": 2,
+    "attachments": [],
+    "capacityProviders": [],
+    "clusterArn": "arn:aws:ecs:us-west-2:123123123:cluster/spinnaker-deployment-cluster",
+    "clusterName": "spinnaker-deployment-cluster",
+    "defaultCapacityProviderStrategy": [],
+    "pendingTasksCount": 6,
+    "registeredContainerInstancesCount": 0,
+    "runningTasksCount": 0,
+    "settings": [
+      {
+        "name": "containerInsights",
+        "value": "disabled"
+      }
+    ],
+    "statistics": [],
+    "status": "ACTIVE",
+    "tags": []
+  },
+
+  {
+    "activeServicesCount": 2,
+    "attachments": [],
+    "capacityProviders": [
+      "FARGATE_SPOT",
+      "FARGATE"
+    ],
+    "clusterArn": "arn:aws:ecs:us-west-2:123123123:cluster/example-app-test-Cluster-NSnYsTXmCfV2",
+    "clusterName": "example-app-test-Cluster-NSnYsTXmCfV2",
+    "defaultCapacityProviderStrategy": [
+      {
+        "base": 0,
+        "capacityProvider": "FARGATE_SPOT",
+        "weight": 1
+      }
+    ],
+    "pendingTasksCount": 3,
+    "registeredContainerInstancesCount": 0,
+    "runningTasksCount": 1,
+    "settings": [
+      {
+        "name": "containerInsights",
+        "value": "disabled"
+      }
+    ],
+    "statistics": [],
+    "status": "ACTIVE",
+    "tags": []
+  },
+  {
+    "activeServicesCount": 0,
+    "attachments": [],
+    "capacityProviders": [
+      "FARGATE_SPOT",
+      "FARGATE"
+    ],
+    "clusterArn": "arn:aws:ecs:us-west-2:12312312312:cluster/TestCluster",
+    "clusterName": "TestCluster",
+    "defaultCapacityProviderStrategy": [],
+    "pendingTasksCount": 0,
+    "registeredContainerInstancesCount": 0,
+    "runningTasksCount": 0,
+    "settings": [
+      {
+        "name": "containerInsights",
+        "value": "disabled"
+      }
+    ],
+    "statistics": [],
+    "status": "ACTIVE",
+    "tags": []
+  }
+]


### PR DESCRIPTION
This PR adds a new enhanced version of UI to support Capacity Providers.

Currently, Capacity Provider UI section provides input fields to enter details about Capacity Provider Strategy for the server group. 
But new UI will have a drop down list for selecting a Capacity Provider. Plus now users can add default Capacity providers without typing in the details of default Capacity Provider by just clicking on the **use cluster default** option. Please refer the following screenshots for the more details. 

<img width="902" alt="New deck UI 1" src="https://user-images.githubusercontent.com/18301288/102648200-f0836f00-411b-11eb-9dd4-543131641b96.png">
<img width="900" alt="New deck UI 2" src="https://user-images.githubusercontent.com/18301288/102648207-f11c0580-411b-11eb-870b-77e08160b734.png">

Addresses [spinnaker/spinnaker#6242](https://github.com/spinnaker/spinnaker/issues/6242)