### PR TITLE
Revert API request default timeout seconds

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -249,7 +249,7 @@ export function makeRequestBuilderConfig(pathPrefix?: string): IRequestBuilderCo
     cache: false,
     data: undefined,
     params: {},
-    timeout: (SETTINGS.pollSchedule || 3000) * 2 + 5000,
+    timeout: (SETTINGS.pollSchedule || 30000) * 2 + 5000,
     headers: { 'X-RateLimit-App': 'deck' },
   };
 }


### PR DESCRIPTION
## What
Increase the timeout seconds from

**1.24.0 default timeout**

```javascript
(SETTINGS.pollSchedule || 3000) * 2 + 5000,
```

to 

**< 1.24.0 default timeout**

```javascript
(SETTINGS.pollSchedule || 30000) * 2 + 5000,
```

## Why
Solves https://github.com/spinnaker/spinnaker/issues/6246.

This change was released in 1.24.0 in this PR ([Deprecate API.one('foo').all('bar').get() in favor of REST('/foo/bar').get() ](https://github.com/spinnaker/deck/pull/8760/files)). I think this changed happened intentionally during this refactor and I want to revert it because GetManifest request often requires duration of seconds.

When I upgraded to Spinnaker 1.24.0, the server group detail page often hung with loading because the browser GetManifest request is timeouts and retries again and again.

![Screen Shot 2020-12-21 at 23 40 03](https://user-images.githubusercontent.com/23056537/102798370-5873d700-43f4-11eb-817c-a7f082893e97.png)

