### PR TITLE
feat(aws): Allow ICMPv6 type ingress rules for security groups

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -347,7 +347,7 @@ module(AMAZON_SECURITYGROUP_CONFIGURE_CONFIGSECURITYGROUP_MIXIN_CONTROLLER, [
 
     ctrl.updateRuleType = function (type, ruleset, index) {
       const rule = ruleset[index];
-      if (type === 'icmp') {
+      if (type === 'icmp' || type === 'icmpv6') {
         rule.startPort = 0;
         rule.endPort = 0;
       }

--- a/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupIngress.html
@@ -54,7 +54,7 @@
                 <select
                   class="form-control input-sm"
                   ng-model="rule.type"
-                  ng-options="protocol as protocol.toUpperCase() for protocol in ['tcp', 'udp', 'icmp']"
+                  ng-options="protocol as protocol.toUpperCase() for protocol in ['tcp', 'udp', 'icmp', 'icmpv6']"
                   ng-change="ctrl.updateRuleType(rule.type, securityGroup.securityGroupIngress, $index)"
                   required
                 ></select>


### PR DESCRIPTION
Add `ICMPv6` as an option for ingress rule protocol types. This is already supported on the BE. 