### PR TITLE
fix(amazon): Security group names for standalone apps render incorrectly

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -322,7 +322,8 @@ module(AMAZON_SECURITYGROUP_CONFIGURE_CONFIGSECURITYGROUP_MIXIN_CONTROLLER, [
 
     ctrl.updateName = function () {
       const { securityGroup } = $scope;
-      const name = NameUtils.getClusterName(application.name, securityGroup.stack, securityGroup.detail);
+      const appName = application.isStandalone ? application.name.split('-')[0] : application.name;
+      const name = NameUtils.getClusterName(appName, securityGroup.stack, securityGroup.detail);
       securityGroup.name = name;
       $scope.namePreview = name;
     };


### PR DESCRIPTION
For a standalone security group, the app's name is the security group name. When cloning a standalone security group, the previewer show `app-stack-detail-newstack-detail` instead of `app-newstack-newdetail`. This causes some confusion for users who need to clone their security group. 