### PR TITLE
feat(core/deploymentStrategy): Add a preview for Highlander deploys

### DIFF
--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/highlander/HighlanderPreview.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/highlander/HighlanderPreview.tsx
@@ -8,6 +8,11 @@ import { HealthCounts } from 'core/healthCounts';
 import { IDeploymentStrategyAdditionalFieldsProps } from '../../deploymentStrategy.registry';
 
 export function HighlanderPreview(props: IDeploymentStrategyAdditionalFieldsProps) {
+  const isPipeline = props.command.viewState.mode === 'editPipeline';
+  return isPipeline ? null : <HighlanderPreviewCmp {...props} />;
+}
+
+export function HighlanderPreviewCmp(props: IDeploymentStrategyAdditionalFieldsProps) {
   const { credentials, region, application, stack, freeFormDetails } = props.command;
   const cluster = NameUtils.getClusterName(application, stack, freeFormDetails);
   const fetchit = useData(() => REST('/applications').path(application, 'serverGroups').get<IServerGroup[]>(), [], []);

--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/highlander/HighlanderPreview.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/highlander/HighlanderPreview.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Spinner } from 'core/widgets';
+import { REST } from 'core/api';
+import { useData } from 'core/presentation';
+import { NameUtils } from 'core/naming';
+import { IServerGroup } from 'core/domain';
+import { HealthCounts } from 'core/healthCounts';
+import { IDeploymentStrategyAdditionalFieldsProps } from '../../deploymentStrategy.registry';
+
+export function HighlanderPreview(props: IDeploymentStrategyAdditionalFieldsProps) {
+  const { credentials, region, application, stack, freeFormDetails } = props.command;
+  const cluster = NameUtils.getClusterName(application, stack, freeFormDetails);
+  const fetchit = useData(() => REST('/applications').path(application, 'serverGroups').get<IServerGroup[]>(), [], []);
+  const { backingData, ...command } = props.command;
+  const { capacity } = command;
+
+  const serverGroups = fetchit.result.filter((sg) => {
+    return sg.cluster === cluster && sg.account === credentials && sg.region === region;
+  });
+
+  if (fetchit.status === 'PENDING') {
+    return <Spinner />;
+  }
+
+  if (fetchit.status === 'REJECTED') {
+    return <pre>{fetchit.error}</pre>;
+  }
+
+  const currentUpCount = serverGroups.reduce((total, sg) => total + sg.instanceCounts.up, 0);
+
+  const pluralize = (str: string, val: number | string) => (val === 1 ? str : str + 's');
+  const containStr = serverGroups.length === 1 ? 'contains' : 'contain';
+  const serverGroupStr = pluralize('server group', serverGroups.length);
+  const instanceStr = pluralize('instance', currentUpCount);
+
+  return (
+    <div className="flex-container-v margin-between-md">
+      <div>
+        Highlander will create a new server group with {capacity.desired} {pluralize('instance', capacity.desired)}.
+      </div>
+      <div>
+        Then it will destroy the following {serverGroups.length} {serverGroupStr} which currently {containStr}{' '}
+        {currentUpCount} healthy {instanceStr}:
+      </div>
+
+      <ul>
+        {serverGroups.map((sg) => (
+          <li key={sg.name} className="flex-container-h margin-between-lg">
+            <span className="bold">{sg.name}</span> <HealthCounts container={sg.instanceCounts} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/highlander/highlander.strategy.ts
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/highlander/highlander.strategy.ts
@@ -1,3 +1,4 @@
+import { HighlanderPreview } from './HighlanderPreview';
 import { DeploymentStrategyRegistry } from '../../deploymentStrategy.registry';
 
 DeploymentStrategyRegistry.registerStrategy({
@@ -5,4 +6,5 @@ DeploymentStrategyRegistry.registerStrategy({
   description:
     'Destroys <i>all</i> previous server groups in the cluster as soon as new server group passes health checks',
   key: 'highlander',
+  AdditionalFieldsComponent: HighlanderPreview,
 });


### PR DESCRIPTION
Finally got around to implementing this feature request for Highlander strategy.  We could add a similar preview for Red/Black if we can predict the behavior accurately enough in Deck.

<img width="894" alt="Screen Shot 2021-01-04 at 5 10 02 PM" src="https://user-images.githubusercontent.com/2053478/103595360-134dab80-4eb0-11eb-88eb-0dc8178acda7.png">
<img width="899" alt="Screen Shot 2021-01-04 at 5 09 25 PM" src="https://user-images.githubusercontent.com/2053478/103595361-13e64200-4eb0-11eb-8e0a-60fe4478e152.png">
