### PR TITLE
fix(amazon/vpc): Fix error: "cannot call setState on an unmounted component" by migrating to FC/useData

### DIFF
--- a/app/scripts/modules/amazon/src/vpc/VpcTag.tsx
+++ b/app/scripts/modules/amazon/src/vpc/VpcTag.tsx
@@ -1,42 +1,24 @@
 import React from 'react';
-
+import { useData } from '@spinnaker/core';
 import { VpcReader } from './VpcReader';
 
 export interface IVpcTagProps {
   vpcId: string;
 }
 
-export interface IVpcTagState {
-  label: string;
-}
+const defaultLabel = 'None (EC2 Classic)';
 
-export class VpcTag extends React.Component<IVpcTagProps, IVpcTagState> {
-  private defaultLabel = 'None (EC2 Classic)';
+export function VpcTag(props: IVpcTagProps) {
+  const { vpcId } = props;
+  const fetchVpcLabel = useData(
+    async () => {
+      const name = await VpcReader.getVpcName(props.vpcId);
+      return name ? `${name} (${props.vpcId})` : `(${props.vpcId})`;
+    },
+    defaultLabel,
+    [vpcId],
+  );
 
-  constructor(props: IVpcTagProps) {
-    super(props);
-    this.state = { label: this.defaultLabel };
-    this.updateState(props);
-  }
-
-  private updateState(props: IVpcTagProps): void {
-    if (!props.vpcId) {
-      this.setState({ label: this.defaultLabel });
-    } else {
-      VpcReader.getVpcName(props.vpcId).then((name) => {
-        const label = name ? `${name} (${props.vpcId})` : `(${props.vpcId})`;
-        this.setState({ label });
-      });
-    }
-  }
-
-  public componentWillReceiveProps(nextProps: IVpcTagProps): void {
-    if (nextProps.vpcId !== this.props.vpcId) {
-      this.updateState(nextProps);
-    }
-  }
-
-  public render() {
-    return <span className="vpc-tag">{this.state.label}</span>;
-  }
+  const label = vpcId ? fetchVpcLabel.result : defaultLabel;
+  return <span className="vpc-tag">{label}</span>;
 }


### PR DESCRIPTION
The class component called setState in the constructor if the VPC is unknown.  It could also potentially call setState after the component was unmounted.  

Migrated to `useData` to avoid both cases.