### PR TITLE
fix(amazon/loadBalancer): Fix target group health interface

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonHealth.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonHealth.ts
@@ -1,8 +1,14 @@
-import { IHealth } from '@spinnaker/core';
-
-import { ITargetGroup } from './IAmazonLoadBalancer';
+import { IHealth, ILoadBalancerHealth } from '@spinnaker/core';
 
 export interface IAmazonHealth extends IHealth {
-  targetGroups: ITargetGroup[];
-  type: string;
+  targetGroups: IAmazonTargetGroupHealth[];
+}
+
+export interface IAmazonTargetGroupHealth extends ILoadBalancerHealth {
+  // targetGroups[] have a 'targetGroupName' but not a 'name' field
+  targetGroupName: string;
+  name: never;
+  // Augmented to backend data in applyHealthCheckInfoToTargetGroups()
+  healthCheckProtocol?: string;
+  healthCheckPath?: string;
 }

--- a/app/scripts/modules/amazon/src/instance/details/utils.ts
+++ b/app/scripts/modules/amazon/src/instance/details/utils.ts
@@ -16,7 +16,7 @@ export const applyHealthCheckInfoToTargetGroups = (
 ) => {
   healthMetrics.forEach((metric) => {
     if (metric.type === 'TargetGroup') {
-      metric.targetGroups.forEach((tg: ITargetGroup) => {
+      metric.targetGroups.forEach((tg) => {
         const group = targetGroups.find((g) => g.name === tg.name && g.account === account) ?? ({} as ITargetGroup);
         const useTrafficPort = group.healthCheckPort === 'traffic-port' || isNil(group.healthCheckPort);
         const port = useTrafficPort ? group.port : group.healthCheckPort;

--- a/app/scripts/modules/amazon/src/loadBalancer/amazonLoadBalancerDataUtils.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/amazonLoadBalancerDataUtils.ts
@@ -24,9 +24,7 @@ export class AmazonLoadBalancerDataUtils {
     serverGroup.instances.forEach((instance) => {
       const tgHealth: IAmazonHealth = instance.health.find((h) => h.type === 'TargetGroup') as IAmazonHealth;
       if (tgHealth) {
-        const matchedHealth: ILoadBalancer = tgHealth.targetGroups.find(
-          (tg) => tg.name === match.name && tg.region === match.region && tg.account === match.account,
-        );
+        const matchedHealth: ILoadBalancer = tgHealth.targetGroups.find((tg) => tg.name === match.name);
 
         if (matchedHealth !== undefined && matchedHealth.healthState !== undefined) {
           const healthState = matchedHealth.healthState.toLowerCase();


### PR DESCRIPTION
Fix target group health interface to match the shape returned from the back end.
This surfaced a bug in passing instance counts for target groups (in the load balancer icon popover in a server group)


Missing health counts 👇 
<img width="684" alt="Screen Shot 2021-01-05 at 3 36 19 PM" src="https://user-images.githubusercontent.com/2053478/103715986-d13b6d00-4f76-11eb-8896-5a1b082c829a.png">
