### PR TITLE
feat(amazon): Display updated ALB redirect config

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -796,6 +796,7 @@ const Action = (props: {
   configureRedirect: (action: IListenerAction) => void;
 }) => {
   if (props.action.type !== 'authenticate-oidc') {
+    const redirectConfig = props.action.redirectActionConfig || props.action.redirectConfig;
     // TODO: Support redirect
     return (
       <div className="horizontal top">
@@ -824,15 +825,15 @@ const Action = (props: {
         {props.action.type === 'redirect' && (
           <dl className="dl-horizontal dl-narrow">
             <dt>Host</dt>
-            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).host}</dd>
+            <dd>{redirectConfig.host}</dd>
             <dt>Path</dt>
-            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).path}</dd>
+            <dd>{redirectConfig.path}</dd>
             <dt>Port</dt>
-            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).port}</dd>
+            <dd>{redirectConfig.port}</dd>
             <dt>Protocol</dt>
-            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).protocol}</dd>
+            <dd>{redirectConfig.protocol}</dd>
             <dt>Status Code</dt>
-            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).statusCode}</dd>
+            <dd>{redirectConfig.statusCode}</dd>
             <dt>
               <button
                 className="btn btn-link no-padding"

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -407,6 +407,7 @@ export class ALBListeners
     ConfigureOidcConfigModal.show({ config: action.authenticateOidcConfig })
       .then((config: any) => {
         action.authenticateOidcConfig = config;
+        this.updateListeners(); // pushes change to formik, needed due to prop mutation
       })
       .catch(() => {});
   };
@@ -415,6 +416,7 @@ export class ALBListeners
     ConfigureRedirectConfigModal.show({ config: action.redirectActionConfig })
       .then((config: any) => {
         action.redirectActionConfig = config;
+        this.updateListeners(); // pushes change to formik, needed due to prop mutation
       })
       .catch(() => {});
   };
@@ -796,7 +798,7 @@ const Action = (props: {
   if (props.action.type !== 'authenticate-oidc') {
     // TODO: Support redirect
     return (
-      <div className="horizontal middle" style={{ height: '30px' }}>
+      <div className="horizontal top">
         <select
           className="form-control input-sm"
           style={{ width: '80px' }}
@@ -820,13 +822,27 @@ const Action = (props: {
           </select>
         )}
         {props.action.type === 'redirect' && (
-          <button
-            className="btn btn-link no-padding"
-            type="button"
-            onClick={() => props.configureRedirect(props.action)}
-          >
-            Configure...
-          </button>
+          <dl className="dl-horizontal dl-narrow">
+            <dt>Host</dt>
+            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).host}</dd>
+            <dt>Path</dt>
+            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).path}</dd>
+            <dt>Port</dt>
+            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).port}</dd>
+            <dt>Protocol</dt>
+            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).protocol}</dd>
+            <dt>Status Code</dt>
+            <dd>{(props.action.redirectActionConfig || props.action.redirectConfig).statusCode}</dd>
+            <dt>
+              <button
+                className="btn btn-link no-padding"
+                type="button"
+                onClick={() => props.configureRedirect(props.action)}
+              >
+                Configure...
+              </button>
+            </dt>
+          </dl>
         )}
       </div>
     );


### PR DESCRIPTION
After configuring a redirect in the ConfigureRedirectConfigModal, the new (or updated) config is not shown in the Edit Load Balancer modal. This makes it difficult to review your changes for mistakes, or even know whether your config actually took effect.

### Before (there is a config, it is just not shown):
![image](https://user-images.githubusercontent.com/1633736/103833183-2ccc3000-5035-11eb-9577-0e4702444dc7.png)

### After:
![image](https://user-images.githubusercontent.com/1633736/103832421-145b1600-5033-11eb-9486-8702930744e4.png)
