### PR TITLE
chore(package): amazon@0.0.285 cloudfoundry@0.0.109 core@0.0.539 ecs@0.0.275 kubernetes@0.0.57 titus@0.0.157

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.284",
+  "version": "0.0.285",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.108",
+  "version": "0.0.109",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.538",
+  "version": "0.0.539",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.274",
+  "version": "0.0.275",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/kubernetes",
   "license": "Apache-2.0",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.156",
+  "version": "0.0.157",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.285

169c601301a2f759cefdb3e414fcd5e7038c0b21 feat(amazon): Display updated ALB redirect config (#8830)
6904cb064db6733db513f44147a6344dc1cf89da fix(amazon): Security group names for standalone apps render incorrectly (#8816)
d005ea506316e413a8b044b902c58f8a772cedcb fix(amazon/loadBalancer): Fix target group health interface to match the back end, fix instance counts for target groups in the load balancer icon popover in a server group (#8828)
34b68b8f5a07e65fc343cfe75d06b72c6277dd59 fix(amazon/vpc): Fix error: "cannot setState on an unmounted component" by migrating to FC/useData (#8827)
cb30f14f27678c4c8f945676525eec203656c011 feat(aws): Allow ICMPv6 type ingress rules for security groups (#8814)

## cloudfoundry@0.0.109

95eacfb6f5cea460677aa0907b18555dedae4135 refactor(core/deployment): Update redblack fields without force updating (#8840)
84b592076f2e1eebc9fc63b3840575b719b30866 feat(cloudfoundry): Simplification (#8826)
a486688825659824da866f111e7f571700995578 feat(cloudfoundry): add create service binding stage (#8823)

## core@0.0.539

95eacfb6f5cea460677aa0907b18555dedae4135 refactor(core/deployment): Update redblack fields without force updating (#8840)
a027d62e40ab8366cb42f2512aef9692024d9b3a fix(gitlab): fix help text for gitlab artifacts
885874660148bd526e0a3172390f812a81ed31c6 feat(md): waiting status (#8836)
c7eb9f4eca327360aa419d910d4d1aade094603a feat(kubernetes): Raw resources UI MVP (#8800)
ef87a9e1b5ffd044452c6bab1bfaebbca1b83b29 fix(core/executions): Update migrated status to match API (#8831)
3a51af21b7954949b3f462ed633ce2280e3e517b fix(core/deploymentStrategy): do not show highlander preview in deploy stage config (only show in clone dialog)
8be06a036fec152eeddb075bf9968be29944c7ac feat(core/deploymentStrategy): Add a preview for Highlander deploys
c32c91accf42b7fe67220ceb545a3d5037adfdc4 fix(serverGroup): Increase the timeout for api request (#8812)
29a85a0d610fe01846855044a2bc77b323e1fc5f feat(core/executions): Render newly migrated execution groups  (#8807)
8f291c0d2bc41c6e88653588dbdbde62d568af25 fix(core/projects): Fix duplicate Projects appearing in recent history (on search screen) (#8806)

## ecs@0.0.275

a14ae08831c9a7b0fdc6a5253c6adc4be240f685 feat(ecs): migrate capacity provider wizard to react (#8824)

## kubernetes@0.0.57

c7eb9f4eca327360aa419d910d4d1aade094603a feat(kubernetes): Raw resources UI MVP (#8800)
a59e0f5bde7a7abc35277cbca127ab50ef10fc81 fix(kubernetes): Fix details link on pipeline deploy status for global resources (#8802)

## titus@0.0.157

82dca5f1014c8a81a2100485a2a5d5ed324309d2 feat(titus): Support SpEL for Run Job stage inputs (#8809)
f5e81b8c7160e9c4ba9802080dbad49a76b79b78 feat(titus): Support SpEL for Resources number inputs (#8808)

PR created via `modules/publish.js`