### PR TITLE
refactor(core): Extract server group name previewer into its own component

### DIFF
--- a/app/scripts/modules/core/src/serverGroup/configure/common/ServerGroupNamePreview.tsx
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/ServerGroupNamePreview.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+export interface IServerGroupNamePreviewProps {
+  createsNewCluster: boolean;
+  latestServerGroupName: string;
+  mode: string;
+  namePreview: string;
+  navigateToLatestServerGroup: () => void;
+}
+
+export const ServerGroupNamePreview = ({
+  createsNewCluster,
+  latestServerGroupName,
+  mode,
+  namePreview,
+  navigateToLatestServerGroup,
+}: IServerGroupNamePreviewProps) => {
+  const showPreviewAsWarning = (mode === 'create' && !createsNewCluster) || (mode !== 'create' && createsNewCluster);
+
+  return (
+    <div className="form-group">
+      <div className="col-md-12">
+        <div className={`well-compact ${showPreviewAsWarning ? 'alert alert-warning' : 'well'}`}>
+          <h5 className="text-center">
+            <p>Your server group will be in the cluster:</p>
+            <p>
+              <strong>
+                {namePreview}
+                {createsNewCluster && <span> (new cluster)</span>}
+              </strong>
+            </p>
+            {!createsNewCluster && mode === 'create' && latestServerGroupName && (
+              <div className="text-left">
+                <p>There is already a server group in this cluster. Do you want to clone it?</p>
+                <p>
+                  Cloning copies the entire configuration from the selected server group, allowing you to modify
+                  whichever fields (e.g. image) you need to change in the new server group.
+                </p>
+                <p>
+                  To clone a server group, select "Clone" from the "Server Group Actions" menu in the details view of
+                  the server group.
+                </p>
+                <p>
+                  <a className="clickable" onClick={navigateToLatestServerGroup}>
+                    Go to details for {latestServerGroupName}
+                  </a>
+                </p>
+              </div>
+            )}
+          </h5>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/scripts/modules/core/src/serverGroup/configure/common/index.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/index.ts
@@ -3,4 +3,5 @@ export * from './deployInitializer.component';
 export * from './serverGroupCommandBuilder.service';
 export * from './serverGroupCommandRegistry.provider';
 export * from './serverGroupConfiguration.service';
+export * from './ServerGroupNamePreview';
 export * from './wizard/fields';

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -14,6 +14,7 @@ import {
   AccountSelectInput,
   AccountTag,
   ServerGroupDetailsField,
+  ServerGroupNamePreview,
 } from '@spinnaker/core';
 
 import { DockerImageAndTagSelector, DockerImageUtils } from '@spinnaker/docker';
@@ -38,7 +39,6 @@ export interface IServerGroupBasicSettingsState {
   namePreview: string;
   createsNewCluster: boolean;
   latestServerGroup: IServerGroup;
-  showPreviewAsWarning: boolean;
 }
 
 export class ServerGroupBasicSettings
@@ -64,10 +64,8 @@ export class ServerGroupBasicSettings
   private getStateFromProps(props: IServerGroupBasicSettingsProps) {
     const { app } = props;
     const { values } = props.formik;
-    const { mode } = values.viewState;
     const namePreview = NameUtils.getClusterName(app.name, values.stack, values.freeFormDetails);
     const createsNewCluster = !app.clusters.find((c) => c.name === namePreview);
-    const showPreviewAsWarning = (mode === 'create' && !createsNewCluster) || (mode !== 'create' && createsNewCluster);
 
     const inCluster = (app.serverGroups.data as IServerGroup[])
       .filter((serverGroup) => {
@@ -80,7 +78,7 @@ export class ServerGroupBasicSettings
       .sort((a, b) => a.createdTime - b.createdTime);
     const latestServerGroup = inCluster.length ? inCluster.pop() : null;
 
-    return { namePreview, createsNewCluster, latestServerGroup, showPreviewAsWarning };
+    return { namePreview, createsNewCluster, latestServerGroup };
   }
 
   private accountUpdated = (account: string): void => {
@@ -172,7 +170,7 @@ export class ServerGroupBasicSettings
   public render() {
     const { app, formik } = this.props;
     const { errors, setFieldValue, values } = formik;
-    const { createsNewCluster, latestServerGroup, namePreview, showPreviewAsWarning } = this.state;
+    const { createsNewCluster, latestServerGroup, namePreview } = this.state;
 
     const accounts = values.backingData.accounts;
     const readOnlyFields = values.viewState.readOnlyFields || {};
@@ -285,39 +283,13 @@ export class ServerGroupBasicSettings
           />
         )}
         {!values.viewState.hideClusterNamePreview && (
-          <div className="form-group">
-            <div className="col-md-12">
-              <div className={`well-compact ${showPreviewAsWarning ? 'alert alert-warning' : 'well'}`}>
-                <h5 className="text-center">
-                  <p>Your Titus Job name will be:</p>
-                  <p>
-                    <strong>
-                      {namePreview}
-                      {createsNewCluster && <span> (new cluster)</span>}
-                    </strong>
-                  </p>
-                  {!createsNewCluster && values.viewState.mode === 'create' && latestServerGroup && (
-                    <div className="text-left">
-                      <p>There is already a server group in this cluster. Do you want to clone it?</p>
-                      <p>
-                        Cloning copies the entire configuration from the selected server group, allowing you to modify
-                        whichever fields (e.g. image) you need to change in the new server group.
-                      </p>
-                      <p>
-                        To clone a server group, select "Clone" from the "Server Group Actions" menu in the details view
-                        of the server group.
-                      </p>
-                      <p>
-                        <a className="clickable" onClick={this.navigateToLatestServerGroup}>
-                          Go to details for {latestServerGroup.name}
-                        </a>
-                      </p>
-                    </div>
-                  )}
-                </h5>
-              </div>
-            </div>
-          </div>
+          <ServerGroupNamePreview
+            createsNewCluster={createsNewCluster}
+            latestServerGroupName={latestServerGroup?.name}
+            mode={values.viewState.mode}
+            namePreview={namePreview}
+            navigateToLatestServerGroup={this.navigateToLatestServerGroup}
+          />
         )}
       </div>
     );


### PR DESCRIPTION
The preview of the server group name is duplicated for every cloud provider. This PR creates a core component, `ServerGroupNamePreview`, to take the place of these duplicates. The angular templates needed some additions to the controller to make it react-friendly. 
