### PR TITLE
fix(core/executions): Protect migrationStatus sorting if config is null

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroups.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroups.tsx
@@ -90,7 +90,7 @@ export class ExecutionGroups extends React.Component<IExecutionGroupsProps, IExe
     const hasGroups = groups.length > 0;
     const className = `row pipelines executions ${showingDetails ? 'showing-details' : ''}`;
 
-    const allGroups = groups
+    const allGroups = (groups || [])
       .filter((g: IExecutionGroup) => g?.config?.migrationStatus === 'Started')
       .concat(groups.filter((g) => g?.config?.migrationStatus !== 'Started'));
 

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroups.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroups.tsx
@@ -91,8 +91,8 @@ export class ExecutionGroups extends React.Component<IExecutionGroupsProps, IExe
     const className = `row pipelines executions ${showingDetails ? 'showing-details' : ''}`;
 
     const allGroups = groups
-      .filter((g: IExecutionGroup) => g.config.migrationStatus === 'Started')
-      .concat(groups.filter((g) => g.config.migrationStatus !== 'Started'));
+      .filter((g: IExecutionGroup) => g?.config?.migrationStatus === 'Started')
+      .concat(groups.filter((g) => g?.config?.migrationStatus !== 'Started'));
 
     const executionGroups = allGroups.map((group: IExecutionGroup) => (
       <ExecutionGroup parent={container} key={group.heading} group={group} application={this.props.application} />


### PR DESCRIPTION
If the pipeline config is `null`, an error is thrown while sorting pipelines by their `migrationStatus`. This adds optional chaining to prevent that. 
