### PR TITLE
fix(core): Fix incorrect removal when merging serverGroups response

### DIFF
--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -110,8 +110,22 @@ export class ClusterService {
         }
       });
 
-      // splice is necessary to preserve referential equality
-      toRemove.forEach((idx) => data.splice(idx, 1));
+      // IMPORTANT!!! - toRemove must be forEach'ed in decending order, so that we splice backwards.
+      // For example, if we started with [0, 1, 2, 3, 4, 5] and wanted toRemove [0, 1],
+      // Blindly forEach'ing and splicing like so: toRemove.forEach(idx => data.splice(idx, 1))
+      // would result in the following at each step:
+      // data              // [0, 1, 2, 3, 4, 5]
+      // data.splice(0,1); // [1, 2, 3, 4, 5]
+      // data.splice(1,1); // [1, 3, 4, 5]           wait, what??
+      // If toRemove is in ascending order, every splice will cause everything to shift left
+      // and every remaning index will no longer be correct (off by 1 for every iteration)
+      // Works perfect in descending order though.
+      toRemove
+        // ensure indices are in descending order so splice can work properly
+        .sort()
+        .reverse()
+        // splice is necessary to preserve referential equality
+        .forEach((idx) => data.splice(idx, 1));
 
       // add any new ones
       serverGroups.forEach((serverGroup) => {


### PR DESCRIPTION
Since forever, it appears that we've been incorrectly removing `serverGroup`s when merging the response into the `serverGroups` datasource (to preserve referential equality and save on some, hopefully many, rerenders).

It all boils down these few lines:
```
data.forEach((serverGroup: IServerGroup, idx: number) => {
...
  toRemove.push(idx);
...
toRemove.forEach((idx) => data.splice(idx, 1));
```

Since we are pushing into `toRemove` while `forEach`ing data, the indices will naturally be in ascending order. However, as we iterate through the array of ascending indices to splice (remove) those elements out of `data`, we start from the left causing everything to the right to shift left by 1 every iteration. For example:

```
const toRemove =      [0, 1];
const data =          [0, 1, 2, 3, 4, 5];
data.splice(0, 1); // [1, 2, 3, 4, 5]
data.splice(1, 1); // [1, 3, 4, 5]
```

Removal of more than 1 element is pretty much guaranteed to be incorrect for everything but the very first removal.

This manifested as server groups disappearing on a applicationDataSource refresh interval, remaining absent for the entire refresh interval, and most likely coming back on the next refresh interval, if the user had not panic refreshed the page.

Whew!