### PR TITLE
feat(ecs): Add support for Capacity providers - enhanced Deck UI

### DIFF
--- a/app/scripts/modules/ecs/src/ecs.module.ts
+++ b/app/scripts/modules/ecs/src/ecs.module.ts
@@ -20,6 +20,7 @@ import { ECS_NETWORKING_REACT } from './serverGroup/configure/wizard/networking/
 import { SERVICE_DISCOVERY_REACT } from './serverGroup/configure/wizard/serviceDiscovery/ServiceDiscovery';
 import { TASK_DEFINITION_REACT } from './serverGroup/configure/wizard/taskDefinition/TaskDefinition';
 import { ECS_SECURITY_GROUP_MODULE } from './securityGroup/securityGroup.module';
+import { ECS_CAPACITY_PROVIDER_REACT } from "./serverGroup/configure/wizard/capacityProvider/CapacityProvider";
 
 import ecsLogo from './logo/ecs.logo.svg';
 import './logo/ecs.logo.less';
@@ -66,6 +67,7 @@ module(ECS_MODULE, [
   CONTAINER_REACT,
   ECS_NETWORKING_REACT,
   SERVICE_DISCOVERY_REACT,
+  ECS_CAPACITY_PROVIDER_REACT,
   ECS_SERVER_GROUP_LOGGING,
   ECS_CLUSTER_READ_SERVICE,
   ECS_SECRET_READ_SERVICE,

--- a/app/scripts/modules/ecs/src/ecsCluster/IEcsCapacityProvidersDetails.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/IEcsCapacityProvidersDetails.ts
@@ -1,0 +1,11 @@
+export interface IEcsCapacityProvidersDetails {
+  capacityProviders : string[],
+  clusterName : string,
+  defaultCapacityProviderStrategy : IEcsDefaultCapacityProviderStrategyItem[],
+}
+
+export interface IEcsDefaultCapacityProviderStrategyItem {
+  base : number,
+  capacityProvider : string,
+  weight : number
+}

--- a/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
@@ -2,10 +2,18 @@ import { module } from 'angular';
 
 import { REST } from '@spinnaker/core';
 import { IEcsClusterDescriptor } from './IEcsCluster';
+import {IEcsCapacityProvidersDetails} from "../ecsCluster/IEcsCapacityProvidersDetails";
 
 export class EcsClusterReader {
   public listClusters(): PromiseLike<IEcsClusterDescriptor[]> {
     return REST('/ecs/ecsClusters').get();
+  }
+
+  public listDescribeClusters(account: string, region: string): PromiseLike<IEcsCapacityProvidersDetails[]> {
+    if(account != null && region != null) {
+      return REST('/ecs/ecsClusterDescriptions').path(account).path(region).get();
+    }
+    return {} as PromiseLike<IEcsCapacityProvidersDetails[]>;
   }
 }
 

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/capacityProvider/CapacityProvider.tsx
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/capacityProvider/CapacityProvider.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+import {IEcsCapacityProviderStrategyItem, IEcsServerGroupCommand} from '../../serverGroupConfiguration.service';
+import { HelpField, withErrorBoundary, TetheredSelect } from  '@spinnaker/core';
+import {Option} from "react-select";
+import {Alert} from "react-bootstrap";
+
+export interface IEcsCapacityProviderProps {
+  command: IEcsServerGroupCommand;
+  notifyAngular: (key: string, value: any) => void;
+  configureCommand: (query: string) => PromiseLike<void>;
+}
+
+interface IEcsCapacityProviderState {
+  capacityProviderStrategy: IEcsCapacityProviderStrategyItem[],
+  defaultCapacityProviderStrategy: IEcsCapacityProviderStrategyItem[],
+  availableCapacityProviders: string[],
+  ecsClusterName: string,
+  useDefaultCapacityProviders: boolean,
+  capacityProviderLoadedFlag: boolean;
+}
+
+class EcsCapacityProvider extends React.Component<IEcsCapacityProviderProps, IEcsCapacityProviderState>{
+  constructor(props: IEcsCapacityProviderProps) {
+    super(props);
+    const cmd = this.props.command;
+
+    this.state = {
+      availableCapacityProviders: cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.availableCapacityProviders ? cmd.backingData.filtered.availableCapacityProviders : [],
+      defaultCapacityProviderStrategy: cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.defaultCapacityProviderStrategy ? cmd.backingData.filtered.defaultCapacityProviderStrategy : [],
+      ecsClusterName: cmd.ecsClusterName,
+      useDefaultCapacityProviders: cmd.useDefaultCapacityProviders || cmd.capacityProviderStrategy && cmd.capacityProviderStrategy.length == 0,
+      capacityProviderStrategy: cmd.capacityProviderStrategy.length > 0 ? cmd.capacityProviderStrategy : [],
+      capacityProviderLoadedFlag: false
+    };
+  }
+
+  public componentDidMount() {
+    this.props.configureCommand('1').then(() => {
+      const cmd = this.props.command;
+      const useDefaultCapacityProviders = this.state.useDefaultCapacityProviders;
+      this.setState({
+        availableCapacityProviders: cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.availableCapacityProviders ? cmd.backingData.filtered.availableCapacityProviders : [],
+        defaultCapacityProviderStrategy: cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.defaultCapacityProviderStrategy ? cmd.backingData.filtered.defaultCapacityProviderStrategy : [],
+        capacityProviderStrategy: useDefaultCapacityProviders && cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.defaultCapacityProviderStrategy ? cmd.backingData.filtered.defaultCapacityProviderStrategy : this.state.capacityProviderStrategy,
+        capacityProviderLoadedFlag: true,
+      });
+      this.props.notifyAngular('useDefaultCapacityProviders', this.state.useDefaultCapacityProviders);
+    });
+  }
+
+  private addCapacityProviderStrategy = () => {
+    const capacityProviderStrategy = this.state.capacityProviderStrategy;
+    capacityProviderStrategy.push({ capacityProvider: '', base: null, weight: null});
+    this.props.notifyAngular('capacityProviderStrategy', capacityProviderStrategy);
+    this.setState({ capacityProviderStrategy : capacityProviderStrategy });
+  };
+
+  private removeCapacityProviderStrategy = (index: number) => {
+    const capacityProviderStrategy = this.state.capacityProviderStrategy;
+    capacityProviderStrategy.splice(index, 1);
+    this.props.notifyAngular('capacityProviderStrategy', capacityProviderStrategy);
+    this.setState({capacityProviderStrategy : capacityProviderStrategy });
+  }
+
+  private updateCapacityProviderName = (index: number, targetCapacityProviderName: any) => {
+    const capacityProviderStrategy = this.state.capacityProviderStrategy;
+    const targetCapacityProviderStrategy = capacityProviderStrategy[index];
+    targetCapacityProviderStrategy.capacityProvider = targetCapacityProviderName.label;
+    this.props.notifyAngular('capacityProviderStrategy', capacityProviderStrategy);
+    this.setState({ capacityProviderStrategy: capacityProviderStrategy });
+  };
+
+  private updateCapacityProviderBase = (index: number, targetCapacityProviderBase: number) => {
+    const capacityProviderStrategy = this.state.capacityProviderStrategy;
+    const targetCapacityProviderStrategy = capacityProviderStrategy[index];
+    targetCapacityProviderStrategy.base = targetCapacityProviderBase;
+    this.props.notifyAngular('capacityProviderStrategy', capacityProviderStrategy);
+    this.setState({ capacityProviderStrategy: capacityProviderStrategy });
+  };
+
+  private updateCapacityProviderWeight = (index: number, targetCapacityProviderWeight: number) => {
+    const capacityProviderStrategy = this.state.capacityProviderStrategy;
+    const targetCapacityProviderStrategy = capacityProviderStrategy[index];
+    targetCapacityProviderStrategy.weight= targetCapacityProviderWeight;
+    this.props.notifyAngular('capacityProviderStrategy', capacityProviderStrategy);
+    this.setState({ capacityProviderStrategy: capacityProviderStrategy });
+  };
+
+  private updateCapacityProviderStrategy = (targetCapacityProviderType: string) => {
+    const useDefaultCapacityProviders = targetCapacityProviderType == 'defaultCapacityProvider';
+    this.setState({useDefaultCapacityProviders : useDefaultCapacityProviders});
+    this.props.notifyAngular("useDefaultCapacityProviders", useDefaultCapacityProviders);
+
+    if (useDefaultCapacityProviders) {
+      this.setState({capacityProviderStrategy : []});
+      this.props.notifyAngular('capacityProviderStrategy', []);
+      if (this.state.defaultCapacityProviderStrategy.length > 0){
+        this.setState({capacityProviderStrategy : this.state.defaultCapacityProviderStrategy});
+        this.props.notifyAngular('capacityProviderStrategy', this.state.defaultCapacityProviderStrategy );
+      }
+    } else {
+      this.setState({capacityProviderStrategy : []});
+      this.props.notifyAngular('capacityProviderStrategy', []);
+    }
+  };
+
+
+  render(): React.ReactElement<EcsCapacityProvider> {
+
+    const updateCapacityProviderName = this.updateCapacityProviderName;
+    const updateCapacityProviderBase = this.updateCapacityProviderBase;
+    const updateCapacityProviderWeight = this.updateCapacityProviderWeight;
+    const addCapacityProviderStrategy = this.addCapacityProviderStrategy;
+    const removeCapacityProviderStrategy = this.removeCapacityProviderStrategy;
+    const updateCapacityProviderStrategy = this.updateCapacityProviderStrategy;
+    const capacityProviderStrategy = this.state.capacityProviderStrategy;
+    const useDefaultCapacityProviders = this.state.useDefaultCapacityProviders;
+    const capacityProviderLoadedFlag = this.state.capacityProviderLoadedFlag;
+
+
+    const capacityProviderNames = this.state.availableCapacityProviders &&  this.state.availableCapacityProviders.length > 0 ?  this.state.availableCapacityProviders.map((capacityProviderNames) => {
+      return { label: `${capacityProviderNames}`, value: capacityProviderNames };
+    }) : []
+
+    const capacityProviderInputs = capacityProviderStrategy.length > 0 ? capacityProviderStrategy.map(function (mapping, index) {
+      return (
+        <tr key={index}>
+          {useDefaultCapacityProviders ? (
+            <td>
+              <input
+                data-test-id={"ServerGroup.defaultCapacityProvider.name." + index}
+                type="string"
+                className="form-control input-sm no-spel"
+                required={true}
+                value={mapping.capacityProvider}
+                disabled={true}
+              />
+            </td>
+          ) : (
+            <td data-test-id={"ServerGroup.customCapacityProvider.name." + index}>
+              <TetheredSelect
+                placeholder="Select capacity provider"
+                options={capacityProviderNames}
+                value={mapping.capacityProvider}
+                onChange={(e: Option) => {
+                  updateCapacityProviderName(index, e as Option<string>)
+                }}
+                clearable={false}
+              />
+            </td>
+          )}
+          <td>
+            <input
+              data-test-id={"ServerGroup.capacityProvider.base." + index}
+              disabled= {useDefaultCapacityProviders}
+              type="number"
+              className="form-control input-sm no-spel"
+              required={true}
+              value={mapping.base}
+              onChange={(e) => updateCapacityProviderBase(index, e.target.valueAsNumber)}
+            />
+          </td>
+          <td>
+            <input
+              data-test-id={"ServerGroup.capacityProvider.weight." + index}
+              disabled= {useDefaultCapacityProviders}
+              type="number"
+              className="form-control input-sm no-spel"
+              required={true}
+              value={mapping.weight}
+              onChange={(e) => updateCapacityProviderWeight(index, e.target.valueAsNumber)}
+            />
+          </td>
+          {!useDefaultCapacityProviders ? ( <td>
+            <div className="form-control-static">
+              <a className="btn-link sm-label" onClick={() => removeCapacityProviderStrategy(index)}>
+                <span className="glyphicon glyphicon-trash" />
+                <span className="sr-only">Remove</span>
+              </a>
+            </div>
+          </td> ) : ''}
+        </tr>
+      );
+    }) : useDefaultCapacityProviders && this.state.capacityProviderStrategy.length == 0 ?  (
+        <div className="sm-label-left" style={{width: "200%"}}>
+          <Alert color="warning"> The cluster does not have a default capacity provider strategy defined. Set a default capacity provider strategy or use a custom strategy.</Alert>
+        </div> )
+      : '';
+
+    const newCapacityProviderStrategy =   this.state.ecsClusterName && this.props.command.credentials && this.props.command.region && !useDefaultCapacityProviders ? (
+      <button data-test-id="ServerGroup.addCapacityProvider" className="btn btn-block btn-sm add-new" onClick={addCapacityProviderStrategy}>
+        <span className="glyphicon glyphicon-plus-sign" />
+        Add New Capacity Provider
+      </button>
+    ) : '';
+
+
+    return (
+      <div>
+        <div className="sm-label-left">
+          <b>Capacity Provider Strategy</b><HelpField id="ecs.capacityProviderStrategy" /> <br/>
+          <span>({this.state.ecsClusterName})</span>
+        </div>
+        <div className="radio">
+          <label>
+            <input
+              data-test-id="ServerGroup.capacityProviders.default"
+              type="radio"
+              checked={useDefaultCapacityProviders}
+              onClick={() => updateCapacityProviderStrategy("defaultCapacityProvider")}
+              id="computeOptionsLaunchType1"
+            />
+            Use cluster default
+          </label>
+        </div>
+        <div className="radio">
+          <label>
+            <input
+              data-test-id="ServerGroup.capacityProviders.custom"
+              type="radio"
+              checked= {!useDefaultCapacityProviders}
+              onClick={() => updateCapacityProviderStrategy('customCapacityProvider')}
+              id="computeOptionsCapacityProviders2"
+            />
+            Use custom (Advanced)
+          </label>
+        </div>
+        {capacityProviderLoadedFlag ? (
+          <table className="table table-condensed packed tags">
+            <thead>
+            <tr>
+              <th style={{ width: '50%' }}>Provider name<HelpField id="ecs.capacityProviderName" /></th>
+              <th style={{ width: '25%' }}>Base<HelpField id="ecs.capacityProviderBase" /></th>
+              <th style={{ width: '25%' }}>Weight<HelpField id="ecs.capacityProviderWeight" /></th>
+            </tr>
+            </thead>
+            <tbody>{capacityProviderInputs}</tbody>
+            <tfoot>
+            <tr>
+              <td colSpan={4}>{newCapacityProviderStrategy}</td>
+            </tr>
+            </tfoot>
+          </table>) : (
+          <div className="load medium">
+            <div className="message">Loading capacity providers...</div>
+            <div className="bars">
+              <div className="bar"></div>
+              <div className="bar"></div>
+              <div className="bar"></div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export const ECS_CAPACITY_PROVIDER_REACT = 'spinnaker.ecs.serverGroup.configure.wizard.capacityProvider.react';
+module(ECS_CAPACITY_PROVIDER_REACT, []).component(
+  'ecsCapacityProviderReact',
+  react2angular(withErrorBoundary(EcsCapacityProvider, 'ecsCapacityProviderReact'), [
+    'command',
+    'notifyAngular',
+    'configureCommand',]),
+);

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/capacityProvider/capacityProvider.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/capacityProvider/capacityProvider.html
@@ -1,13 +1,11 @@
 <div class="clearfix">
   <div class="row">
     <div class="col-md-12">
-      <ecs-server-group-horizontal-scaling
+      <ecs-capacity-provider-react
         command="command"
-        application="application"
-        capacity-provider-state="capacityProviderState"
         notify-angular="notifyAngular"
         configure-command="configureCommand"
-      ></ecs-server-group-horizontal-scaling>
+      ></ecs-capacity-provider-react>
     </div>
   </div>
 </div>

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
@@ -33,69 +33,8 @@
   </div>
 
   <div class="form-group" ng-if="$ctrl.capacityProviderState.useCapacityProviders">
-    <div class="sm-label-left">
-      <b>Capacity Provider Strategy</b>
-      <help-field key="ecs.capacityProviderStrategy"></help-field>
-    </div>
-    <div>
-      <table class="table table-condensed packed tags">
-        <thead>
-          <th style="width: 50%">Provider name <help-field key="ecs.capacityProviderName"></help-field></th>
-          <th style="width: 25%">Base <help-field key="ecs.capacityProviderBase"></help-field></th>
-          <th style="width: 25%">Weight <help-field key="ecs.capacityProviderWeight"></help-field></th>
-        </thead>
-        <tbody>
-          <tr ng-repeat="cp in $ctrl.command.capacityProviderStrategy">
-            <td>
-              <input
-                type="text"
-                data-test-id="capacityProvider.name.{{ $index }}"
-                class="form-control input-sm no-spel"
-                ng-model="cp.capacityProvider"
-              />
-            </td>
-            <td>
-              <input
-                type="text"
-                data-test-id="capacityProvider.base.{{ $index }}"
-                class="form-control input-sm no-spel"
-                ng-model="cp.base"
-              />
-            </td>
-            <td>
-              <input
-                type="text"
-                data-test-id="capacityProvider.weight.{{ $index }}"
-                class="form-control input-sm no-spel"
-                ng-model="cp.weight"
-              />
-            </td>
-            <td>
-              <div class="form-control-static">
-                <a class="btn-link sm-label" ng-click="$ctrl.command.capacityProviderStrategy.splice($index, 1)">
-                  <span class="glyphicon glyphicon-trash"></span>
-                  <span class="sr-only">Remove</span>
-                </a>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <td colspan="3">
-              <button
-                class="btn btn-block btn-sm add-new"
-                ng-click="$ctrl.command.capacityProviderStrategy.push({})"
-                data-test-id="ServerGroup.addCapacityProvider"
-              >
-                <span class="glyphicon glyphicon-plus-sign"></span>
-                Add New Capacity Provider
-              </button>
-            </td>
-          </tr>
-        </tfoot>
-      </table>
-    </div>
+    <ecs-capacity-provider-react command="$ctrl.command"
+                             notify-angular="$ctrl.notifyAngular" configure-command="$ctrl.configureCommand"/>
   </div>
 
   <div class="form-group" ng-if="!$ctrl.capacityProviderState.useCapacityProviders" style="padding-top: 10px">

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.js
@@ -12,6 +12,8 @@ module(ECS_SERVERGROUP_CONFIGURE_WIZARD_HORIZONTALSCALING_HORIZONTALSCALING_COMP
       command: '=',
       application: '=',
       capacityProviderState: '=',
+      notifyAngular: '=',
+      configureCommand: '=',
     },
     templateUrl: require('./horizontalScaling.component.html'),
   },

--- a/test/functional/cypress/fixtures/ecs/shared/ecsClusters.json
+++ b/test/functional/cypress/fixtures/ecs/shared/ecsClusters.json
@@ -4,5 +4,17 @@
     "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/spinnaker-deployment-cluster",
     "name": "spinnaker-deployment-cluster",
     "region": "us-west-2"
+  },
+  {
+    "account": "ecs-my-aws-devel-acct",
+    "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/TestCluster",
+    "name": "TestCluster",
+    "region": "us-west-2"
+  },
+  {
+    "account": "ecs-my-aws-devel-acct",
+    "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/example-app-test-Cluster-NSnYsTXmCfV2",
+    "name": "example-app-test-Cluster-NSnYsTXmCfV2",
+    "region": "us-west-2"
   }
 ]

--- a/test/functional/cypress/fixtures/ecs/shared/ecsDescribeClusters.json
+++ b/test/functional/cypress/fixtures/ecs/shared/ecsDescribeClusters.json
@@ -1,0 +1,29 @@
+[
+  {
+    "capacityProviders": [],
+    "clusterName": "spinnaker-deployment-cluster",
+    "defaultCapacityProviderStrategy": []
+  },
+  {
+    "capacityProviders": [
+      "FARGATE_SPOT",
+      "FARGATE"
+    ],
+    "clusterName": "example-app-test-Cluster-NSnYsTXmCfV2",
+    "defaultCapacityProviderStrategy": [
+      {
+        "base": 0,
+        "capacityProvider": "FARGATE_SPOT",
+        "weight": 1
+      }
+    ]
+  },
+  {
+    "capacityProviders": [
+      "FARGATE_SPOT",
+      "FARGATE"
+    ],
+    "clusterName": "TestCluster",
+    "defaultCapacityProviderStrategy": []
+  }
+]

--- a/test/functional/cypress/integration/ecs/server_group.spec.js
+++ b/test/functional/cypress/integration/ecs/server_group.spec.js
@@ -11,6 +11,7 @@ describe('amazon ecs: ECSApp Server Group', () => {
     cy.route('/applications/ecsapp/serverGroups', 'fixture:ecs/clusters/serverGroups.json');
     cy.route('/ecs/serviceDiscoveryRegistries', 'fixture:ecs/shared/serviceDiscoveryRegistries.json');
     cy.route('/ecs/ecsClusters', 'fixture:ecs/shared/ecsClusters.json');
+    cy.route('/ecs/ecsClusterDescriptions/**', 'fixture:ecs/shared/ecsDescribeClusters.json');
     cy.route('/ecs/secrets', []);
     cy.route('/ecs/cloudMetrics/alarms', []);
     cy.route('/artifacts/credentials', 'fixture:ecs/shared/artifacts.json');
@@ -135,6 +136,7 @@ describe('amazon ecs: ECSApp Server Group', () => {
 
     cy.get('[data-test-id="ServerGroup.stack"]').clear().type('edit');
     cy.get('[data-test-id="ServerGroup.details"]').clear().type('inputs');
+
     cy.get('[data-test-id="ServerGroup.useInputs"]').click();
     cy.get('[data-test-id="ContainerInputs.computeUnits"]').clear().type(1024);
     cy.get('[data-test-id="ContainerInputs.reservedMemory"]').clear().type(2048);
@@ -154,7 +156,7 @@ describe('amazon ecs: ECSApp Server Group', () => {
     cy.get('[data-test-id="Pipeline.revertChanges"]').click();
   });
 
-  it('edit an existing server group to use capacity providers', () => {
+  it('edit an existing server group to use default capacity providers', () => {
     cy.visit('#/applications/ecsapp/executions');
 
     cy.get('a:contains("Configure")').click();
@@ -163,19 +165,50 @@ describe('amazon ecs: ECSApp Server Group', () => {
 
     cy.get('[data-test-id="ServerGroup.stack"]').clear().type('edit');
     cy.get('[data-test-id="ServerGroup.details"]').clear().type('computeOptions');
+    cy.get('[data-test-id="ServerGroup.clusterName"]').type('example-app-test-Cluster-NSnYsTXmCfV2');
+    cy.get('span:contains("example-app-test-Cluster-NSnYsTXmCfV2")').click();
 
     cy.get('[data-test-id="ServerGroup.computeOptionsCapacityProviders"]').click();
-    cy.get('[data-test-id="ServerGroup.addCapacityProvider"]').click();
-    cy.get('[data-test-id="capacityProvider.name.0"]').type('FARGATE');
-    cy.get('[data-test-id="capacityProvider.base.0"]').type(1);
-    cy.get('[data-test-id="capacityProvider.weight.0"]').type(2);
+    cy.get('[data-test-id="ServerGroup.capacityProviders.default"]').click();
 
     cy.get('[data-test-id="ServerGroupWizard.submitButton"]').click();
     cy.get('.glyphicon-edit').click();
 
-    cy.get('[data-test-id="capacityProvider.name.0"]').should('have.value', 'FARGATE');
-    cy.get('[data-test-id="capacityProvider.base.0"]').should('have.value', '1');
-    cy.get('[data-test-id="capacityProvider.weight.0"]').should('have.value', '2');
+    cy.get('[data-test-id="ServerGroup.defaultCapacityProvider.name.0"]').should('have.value', 'FARGATE_SPOT');
+    cy.get('[data-test-id="ServerGroup.capacityProvider.base.0"]').should('have.value', '0');
+    cy.get('[data-test-id="ServerGroup.capacityProvider.weight.0"]').should('have.value', '1');
+
+    cy.get('[data-test-id="ServerGroupWizard.submitButton"]').click();
+    cy.get('[data-test-id="Pipeline.revertChanges"]').click();
+  });
+
+  it('edit an existing server group to use custom capacity providers', () => {
+    cy.visit('#/applications/ecsapp/executions');
+
+    cy.get('a:contains("Configure")').click();
+    cy.get('a:contains("Deploy")').click();
+    cy.get('.glyphicon-edit').click();
+
+    cy.get('[data-test-id="ServerGroup.stack"]').clear().type('edit');
+    cy.get('[data-test-id="ServerGroup.details"]').clear().type('computeOptions');
+    cy.get('[data-test-id="ServerGroup.clusterName"]').type('example-app-test-Cluster-NSnYsTXmCfV2');
+    cy.get('span:contains("example-app-test-Cluster-NSnYsTXmCfV2")').click();
+
+    cy.get('[data-test-id="ServerGroup.computeOptionsCapacityProviders"]').click();
+    cy.get('[data-test-id="ServerGroup.capacityProviders.custom"]').click();
+    cy.get('[data-test-id="ServerGroup.addCapacityProvider"]').click();
+
+    cy.get('[data-test-id="ServerGroup.customCapacityProvider.name.0"]').type('FARGATE_SPOT');
+    cy.get('.Select-option:contains("FARGATE_SPOT")').click();
+    cy.get('[data-test-id="ServerGroup.capacityProvider.base.0"]').type(1);
+    cy.get('[data-test-id="ServerGroup.capacityProvider.weight.0"]').type(2);
+
+    cy.get('[data-test-id="ServerGroupWizard.submitButton"]').click();
+    cy.get('.glyphicon-edit').click();
+
+    cy.get('[data-test-id="ServerGroup.customCapacityProvider.name.0"]').children().children().children(".Select-multi-value-wrapper").children().children('.Select-value-label').should('contain', 'FARGATE_SPOT');
+    cy.get('[data-test-id="ServerGroup.capacityProvider.base.0"]').should('have.value', '1');
+    cy.get('[data-test-id="ServerGroup.capacityProvider.weight.0"]').should('have.value', '2');
 
     cy.get('[data-test-id="ServerGroupWizard.submitButton"]').click();
     cy.get('[data-test-id="Pipeline.revertChanges"]').click();


### PR DESCRIPTION
This PR adds a new enhanced version of UI to support Capacity Providers.

Currently, Capacity Provider UI section provides input fields to enter details about Capacity Provider Strategy for the server group.
But new UI will have a drop down list for selecting a Capacity Provider. Plus now users can add default Capacity providers without typing in the details of default Capacity Provider by just clicking on the use cluster default option. Please refer the following screenshots for the more details.

<img width="903" alt="Screen Shot 2021-01-19 at 12 12 27 PM" src="https://user-images.githubusercontent.com/18301288/105087614-9abe2180-5a4f-11eb-8ff8-753e3f7c3322.png">


<img width="898" alt="Screen Shot 2021-01-19 at 12 12 44 PM" src="https://user-images.githubusercontent.com/18301288/105087636-a578b680-5a4f-11eb-8ec4-f7d0a67aec53.png">


Addresses [spinnaker/spinnaker#6242](https://github.com/spinnaker/spinnaker/issues/6242)