### PR TITLE
feat(amazon/loadBalancer): Enable dualstacking in ALBs/NLBs with constraints

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBAdvancedSettings.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBAdvancedSettings.tsx
@@ -1,25 +1,40 @@
 import React from 'react';
 
+import { FormikProps } from 'formik';
 import { FormikFormField, CheckboxInput, NumberInput, HelpField } from '@spinnaker/core';
+import { IAmazonApplicationLoadBalancerUpsertCommand } from 'amazon/domain';
 
-export class ALBAdvancedSettings extends React.Component {
-  public render() {
-    return (
-      <div>
-        <FormikFormField
-          name="idleTimeout"
-          label="Idle Timeout"
-          help={<HelpField id="loadBalancer.advancedSettings.idleTimeout" />}
-          input={(props) => <NumberInput {...props} min={0} />}
-        />
-
-        <FormikFormField
-          name="deletionProtection"
-          label="Protection"
-          help={<HelpField id="loadBalancer.advancedSettings.deletionProtection" />}
-          input={(props) => <CheckboxInput {...props} text="Enable delete protection" />}
-        />
-      </div>
-    );
-  }
+export interface IALBAdvancedSettingsProps {
+  formik: FormikProps<IAmazonApplicationLoadBalancerUpsertCommand>;
 }
+
+export const ALBAdvancedSettings = React.forwardRef<HTMLDivElement, IALBAdvancedSettingsProps>((props, ref) => (
+  <div ref={ref}>
+    <FormikFormField
+      name="idleTimeout"
+      label="Idle Timeout"
+      help={<HelpField id="loadBalancer.advancedSettings.idleTimeout" />}
+      input={(props) => <NumberInput {...props} min={0} />}
+    />
+
+    <FormikFormField
+      name="deletionProtection"
+      label="Protection"
+      help={<HelpField id="loadBalancer.advancedSettings.deletionProtection" />}
+      input={(props) => <CheckboxInput {...props} text="Enable delete protection" />}
+    />
+
+    <FormikFormField
+      name="dualstack"
+      label="Dualstack"
+      help={<HelpField id="loadBalancer.advancedSettings.albIpAddressType" />}
+      input={(inputProps) => (
+        <CheckboxInput
+          {...inputProps}
+          text="Assign Ipv4 and IPv6"
+          disabled={Boolean(props.formik.values?.isInternal)}
+        />
+      )}
+    />
+  </div>
+));

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBAdvancedSettings.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBAdvancedSettings.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
-
-import { FormikProps } from 'formik';
 import { FormikFormField, CheckboxInput, NumberInput, HelpField } from '@spinnaker/core';
-import { IAmazonApplicationLoadBalancerUpsertCommand } from 'amazon/domain';
 
 export interface IALBAdvancedSettingsProps {
-  formik: FormikProps<IAmazonApplicationLoadBalancerUpsertCommand>;
+  isInternal: boolean;
 }
 
 export const ALBAdvancedSettings = React.forwardRef<HTMLDivElement, IALBAdvancedSettingsProps>((props, ref) => (
@@ -14,14 +11,14 @@ export const ALBAdvancedSettings = React.forwardRef<HTMLDivElement, IALBAdvanced
       name="idleTimeout"
       label="Idle Timeout"
       help={<HelpField id="loadBalancer.advancedSettings.idleTimeout" />}
-      input={(props) => <NumberInput {...props} min={0} />}
+      input={(inputProps) => <NumberInput {...inputProps} min={0} />}
     />
 
     <FormikFormField
       name="deletionProtection"
       label="Protection"
       help={<HelpField id="loadBalancer.advancedSettings.deletionProtection" />}
-      input={(props) => <CheckboxInput {...props} text="Enable delete protection" />}
+      input={(inputProps) => <CheckboxInput {...inputProps} text="Enable delete protection" />}
     />
 
     <FormikFormField
@@ -29,11 +26,7 @@ export const ALBAdvancedSettings = React.forwardRef<HTMLDivElement, IALBAdvanced
       label="Dualstack"
       help={<HelpField id="loadBalancer.advancedSettings.albIpAddressType" />}
       input={(inputProps) => (
-        <CheckboxInput
-          {...inputProps}
-          text="Assign Ipv4 and IPv6"
-          disabled={Boolean(props.formik.values?.isInternal)}
-        />
+        <CheckboxInput {...inputProps} text="Assign Ipv4 and IPv6" disabled={Boolean(props.isInternal)} />
       )}
     />
   </div>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
@@ -327,7 +327,7 @@ export class CreateApplicationLoadBalancer extends React.Component<
                 label="Advanced Settings"
                 wizard={wizard}
                 order={nextIdx()}
-                render={({ innerRef }) => <ALBAdvancedSettings ref={innerRef} formik={formik} />}
+                render={({ innerRef }) => <ALBAdvancedSettings ref={innerRef} isInternal={formik.values.isInternal} />}
               />
             </>
           );

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { cloneDeep, get } from 'lodash';
 
-
 import {
   AccountService,
   FirewallLabels,
@@ -160,10 +159,16 @@ export class CreateApplicationLoadBalancer extends React.Component<
     });
   }
 
+  private setIpAddressType(command: IAmazonApplicationLoadBalancerUpsertCommand): void {
+    command.ipAddressType = command.dualstack ? 'dualstack' : 'ipv4';
+    delete command.dualstack;
+  }
+
   private formatCommand(command: IAmazonApplicationLoadBalancerUpsertCommand): void {
     this.setAvailabilityZones(command);
     this.manageTargetGroupNames(command);
     this.manageRules(command);
+    this.setIpAddressType(command);
   }
 
   protected onApplicationRefresh(values: IAmazonApplicationLoadBalancerUpsertCommand): void {
@@ -229,6 +234,7 @@ export class CreateApplicationLoadBalancer extends React.Component<
     if (forPipelineConfig) {
       // don't submit to backend for creation. Just return the loadBalancerCommand object
       this.formatListeners(loadBalancerCommandFormatted).then(() => {
+        this.setIpAddressType(loadBalancerCommandFormatted);
         closeModal && closeModal(loadBalancerCommandFormatted);
       });
     } else {
@@ -321,7 +327,7 @@ export class CreateApplicationLoadBalancer extends React.Component<
                 label="Advanced Settings"
                 wizard={wizard}
                 order={nextIdx()}
-                render={({ innerRef }) => <ALBAdvancedSettings ref={innerRef} />}
+                render={({ innerRef }) => <ALBAdvancedSettings ref={innerRef} formik={formik} />}
               />
             </>
           );

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/CreateNetworkLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/CreateNetworkLoadBalancer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cloneDeep, get } from 'lodash';
+import { cloneDeep, every, get } from 'lodash';
 import { FormikErrors } from 'formik';
 
 import {
@@ -287,7 +287,12 @@ export class CreateNetworkLoadBalancer extends React.Component<
               label="Advanced Settings"
               wizard={wizard}
               order={nextIdx()}
-              render={({ innerRef }) => <NLBAdvancedSettings ref={innerRef} formik={formik} />}
+              render={({ innerRef }) => (
+                <NLBAdvancedSettings
+                  ref={innerRef}
+                  showDualstack={!formik.values.isInternal && every(formik.values.targetGroups, { targetType: 'ip' })}
+                />
+              )}
             />
           </>
         )}

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/CreateNetworkLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/CreateNetworkLoadBalancer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { cloneDeep, get } from 'lodash';
 import { FormikErrors } from 'formik';
 
-
 import {
   AccountService,
   ILoadBalancerModalProps,
@@ -196,6 +195,9 @@ export class CreateNetworkLoadBalancer extends React.Component<
 
     const descriptor = isNew ? 'Create' : 'Update';
     const loadBalancerCommandFormatted = cloneDeep(values);
+    loadBalancerCommandFormatted.ipAddressType = loadBalancerCommandFormatted.dualstack ? 'dualstack' : 'ipv4';
+    delete loadBalancerCommandFormatted.dualstack;
+
     if (forPipelineConfig) {
       // don't submit to backend for creation. Just return the loadBalancerCommand object
       this.formatListeners(loadBalancerCommandFormatted).then(() => {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBAdvancedSettings.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBAdvancedSettings.tsx
@@ -1,44 +1,33 @@
 import React from 'react';
-import { FormikProps } from 'formik';
-import { every } from 'lodash';
-
 import { HelpField, FormikFormField, CheckboxInput } from '@spinnaker/core';
 
-import { IAmazonNetworkLoadBalancerUpsertCommand } from 'amazon/domain';
-
 export interface INLBAdvancedSettingsProps {
-  formik: FormikProps<IAmazonNetworkLoadBalancerUpsertCommand>;
+  showDualstack: boolean;
 }
 
-export const NLBAdvancedSettings = React.forwardRef<HTMLDivElement, INLBAdvancedSettingsProps>((props, ref) => {
-  const { formik } = props;
-  /** NLBs can only be dualstacked if they are external and all targets are IPs. This will remain true until NLBs support security groups. */
-  const allIpTargets = every(formik.values.targetGroups, { targetType: 'ip' });
-  const showDualstack = !formik.values.isInternal && allIpTargets;
-  return (
-    <div ref={ref}>
-      <FormikFormField
-        name="deletionProtection"
-        label="Protection"
-        help={<HelpField id="loadBalancer.advancedSettings.deletionProtection" />}
-        input={(props) => <CheckboxInput {...props} text="Enable deletion protection" />}
-      />
+export const NLBAdvancedSettings = React.forwardRef<HTMLDivElement, INLBAdvancedSettingsProps>((props, ref) => (
+  <div ref={ref}>
+    <FormikFormField
+      name="deletionProtection"
+      label="Protection"
+      help={<HelpField id="loadBalancer.advancedSettings.deletionProtection" />}
+      input={(inputProps) => <CheckboxInput {...inputProps} text="Enable deletion protection" />}
+    />
 
-      <FormikFormField
-        name="loadBalancingCrossZone"
-        label="Cross-Zone Load Balancing"
-        help={<HelpField id="loadBalancer.advancedSettings.loadBalancingCrossZone" />}
-        input={(props) => <CheckboxInput {...props} text="Enable deletion protection" />}
-      />
+    <FormikFormField
+      name="loadBalancingCrossZone"
+      label="Cross-Zone Load Balancing"
+      help={<HelpField id="loadBalancer.advancedSettings.loadBalancingCrossZone" />}
+      input={(inputProps) => <CheckboxInput {...inputProps} text="Enable deletion protection" />}
+    />
 
-      {showDualstack && (
-        <FormikFormField
-          name="dualstack"
-          label="Dualstack"
-          help={<HelpField id="loadBalancer.advancedSettings.nlbIpAddressType" />}
-          input={(inputProps) => <CheckboxInput {...inputProps} text="Assign Ipv4 and IPv6" />}
-        />
-      )}
-    </div>
-  );
-});
+    {props.showDualstack && (
+      <FormikFormField
+        name="dualstack"
+        label="Dualstack"
+        help={<HelpField id="loadBalancer.advancedSettings.nlbIpAddressType" />}
+        input={(inputProps) => <CheckboxInput {...inputProps} text="Assign Ipv4 and IPv6" />}
+      />
+    )}
+  </div>
+));

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBAdvancedSettings.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBAdvancedSettings.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Field, FormikProps } from 'formik';
+import { FormikProps } from 'formik';
+import { every } from 'lodash';
 
-import { HelpField } from '@spinnaker/core';
+import { HelpField, FormikFormField, CheckboxInput } from '@spinnaker/core';
 
 import { IAmazonNetworkLoadBalancerUpsertCommand } from 'amazon/domain';
 
@@ -9,30 +10,35 @@ export interface INLBAdvancedSettingsProps {
   formik: FormikProps<IAmazonNetworkLoadBalancerUpsertCommand>;
 }
 
-export class NLBAdvancedSettings extends React.Component<INLBAdvancedSettingsProps> {
-  public render() {
-    const { values } = this.props.formik;
-    return (
-      <div className="form-group">
-        <div className="col-md-3 sm-label-right">
-          <b>Protection</b> <HelpField id="loadBalancer.advancedSettings.deletionProtection" />
-        </div>
-        <div className="col-md-7 checkbox">
-          <label>
-            <Field type="checkbox" name="deletionProtection" checked={values.deletionProtection} />
-            Enable deletion protection
-          </label>
-        </div>
-        <div className="col-md-3 sm-label-right">
-          <b>Cross-Zone Load Balancing</b> <HelpField id="loadBalancer.advancedSettings.loadBalancingCrossZone" />
-        </div>
-        <div className="col-md-7 checkbox">
-          <label>
-            <Field type="checkbox" name="loadBalancingCrossZone" checked={values.loadBalancingCrossZone} />
-            Cross-Zone Load Balancing
-          </label>
-        </div>
-      </div>
-    );
-  }
-}
+export const NLBAdvancedSettings = React.forwardRef<HTMLDivElement, INLBAdvancedSettingsProps>((props, ref) => {
+  const { formik } = props;
+  /** NLBs can only be dualstacked if they are external and all targets are IPs. This will remain true until NLBs support security groups. */
+  const allIpTargets = every(formik.values.targetGroups, { targetType: 'ip' });
+  const showDualstack = !formik.values.isInternal && allIpTargets;
+  return (
+    <div ref={ref}>
+      <FormikFormField
+        name="deletionProtection"
+        label="Protection"
+        help={<HelpField id="loadBalancer.advancedSettings.deletionProtection" />}
+        input={(props) => <CheckboxInput {...props} text="Enable deletion protection" />}
+      />
+
+      <FormikFormField
+        name="loadBalancingCrossZone"
+        label="Cross-Zone Load Balancing"
+        help={<HelpField id="loadBalancer.advancedSettings.loadBalancingCrossZone" />}
+        input={(props) => <CheckboxInput {...props} text="Enable deletion protection" />}
+      />
+
+      {showDualstack && (
+        <FormikFormField
+          name="dualstack"
+          label="Dualstack"
+          help={<HelpField id="loadBalancer.advancedSettings.nlbIpAddressType" />}
+          input={(inputProps) => <CheckboxInput {...inputProps} text="Assign Ipv4 and IPv6" />}
+        />
+      )}
+    </div>
+  );
+});

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -280,6 +280,8 @@ export class AwsLoadBalancerTransformer {
       vpcId: undefined,
       idleTimeout: loadBalancer.idleTimeout || 60,
       deletionProtection: loadBalancer.deletionProtection || false,
+      ipAddressType: loadBalancer.ipAddressType || 'ipv4',
+      dualstack: loadBalancer.ipAddressType === 'dualstack',
     };
 
     if (loadBalancer.elb) {
@@ -392,6 +394,8 @@ export class AwsLoadBalancerTransformer {
       vpcId: undefined,
       deletionProtection: loadBalancer.deletionProtection,
       loadBalancingCrossZone: loadBalancer.loadBalancingCrossZone,
+      ipAddressType: loadBalancer.ipAddressType || 'ipv4',
+      dualstack: loadBalancer.ipAddressType === 'dualstack',
     };
 
     if (loadBalancer.elb) {
@@ -528,6 +532,8 @@ export class AwsLoadBalancerTransformer {
       stack: '',
       detail: '',
       loadBalancerType: 'application',
+      ipAddressType: 'ipv4',
+      dualstack: false,
       isInternal: false,
       cloudProvider: 'aws',
       credentials: defaultCredentials,
@@ -591,6 +597,8 @@ export class AwsLoadBalancerTransformer {
       detail: '',
       loadBalancerType: 'network',
       isInternal: false,
+      ipAddressType: 'ipv4',
+      dualstack: false,
       cloudProvider: 'aws',
       credentials: defaultCredentials,
       region: defaultRegion,

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -213,6 +213,10 @@ const helpContents: { [key: string]: string } = {
     '<p>Configures the number of unhealthy observations before deservicing an instance from the ELB.</p><p>Default: <b>2</b></p>',
   'loadBalancer.advancedSettings.loadBalancingCrossZone':
     '<p>Cross-zone load balancing distributes traffic evenly across all targets in the Availability Zones enabled for the load balancer.</p><p> Default: <b>True</b></p>',
+  'loadBalancer.advancedSettings.albIpAddressType':
+    '<p>Assigns both a v4 and v6 IP address to the load balancer. This option is only valid for an external load balancer. If left unchecked, this value will default to <b>"ipv4"</b>.</p>',
+  'loadBalancer.advancedSettings.nlbIpAddressType':
+    '<p>Assigns both a v4 and v6 IP address to the load balancer. This option is only valid for NLBs which are external and only have Ip targets (not instance targets). If left unchecked, this value will default to <b>"ipv4"</b>.</p>',
   'pipeline.config.resizeAsg.action': `
       <p>Configures the resize action for the target server group.
       <ul>
@@ -357,7 +361,7 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.trigger.runAsUser':
     "The current user must have access to the specified service account, and the service account must have access to the current application. Otherwise, you'll receive an 'Access is denied' error.",
   'pipeline.config.trigger.authorizedUser':
-      "The current user must have the permission to approve the manual judgment stage. Otherwise, you'll not be able continue to the next pipeline stage.",
+    "The current user must have the permission to approve the manual judgment stage. Otherwise, you'll not be able continue to the next pipeline stage.",
   'pipeline.config.script.repoUrl':
     '<p>Path to the repo hosting the scripts in Stash. (e.g. <samp>CDL/mimir-scripts</samp>). Leave empty to use the default.</p>',
   'pipeline.config.script.repoBranch':


### PR DESCRIPTION
ALBs and NLBs can have an `ipAddressType` of `ipv4` or `dualstack` if:
- The ALB is external
- The NLB is external, but all targets are of type `ip`.

This option is now an advanced setting the server group configuration. If nothing is selected it will default to `ipv4` (which is the current behavior). 

This also refactors the ALB/NLB advanced settings to functional components. 


