### PR TITLE
fix(ecs): Determine invalid target groups for the ECS provider

### DIFF
--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -44,7 +44,7 @@ import { ServiceDiscoveryReader } from '../../serviceDiscovery/serviceDiscovery.
 import { IServiceDiscoveryRegistryDescriptor } from '../../serviceDiscovery/IServiceDiscovery';
 
 export interface IEcsServerGroupCommandDirty extends IServerGroupCommandDirty {
-  targetGroup?: string;
+  targetGroups?: string[];
 }
 
 export interface IEcsServerGroupCommandResult extends IServerGroupCommandResult {
@@ -64,6 +64,7 @@ export interface IEcsServerGroupCommandViewState extends IServerGroupCommandView
   contextImages: IEcsDockerImage[];
   pipeline: IPipeline;
   currentStage: IStage;
+  dirty: IEcsServerGroupCommandDirty;
 }
 
 export interface IEcsServerGroupCommandBackingDataFiltered extends IServerGroupCommandBackingDataFiltered {
@@ -507,7 +508,7 @@ export class EcsServerGroupConfigurationService {
     const newLoadBalancers = this.getLoadBalancerNames(command);
     const vpcLoadBalancers = this.getVpcLoadBalancerNames(command);
     const allTargetGroups = this.getTargetGroupNames(command);
-
+    const currentTargetGroups = command.targetGroupMappings.map(tg => tg.targetGroup)
     if (currentLoadBalancers && command.loadBalancers) {
       const valid = command.vpcId ? newLoadBalancers : newLoadBalancers.concat(vpcLoadBalancers);
       const matched = intersection(valid, currentLoadBalancers);
@@ -520,6 +521,16 @@ export class EcsServerGroupConfigurationService {
       }
       if (removedLoadBalancers.length) {
         result.dirty.loadBalancers = removedLoadBalancers;
+      }
+    }
+
+    if (currentTargetGroups) {
+      const matched = intersection(allTargetGroups, currentTargetGroups);
+      const removedTargetGroups = xor(matched, currentTargetGroups);
+      if (removedTargetGroups && removedTargetGroups.length > 0) {
+        command.viewState.dirty.targetGroups = removedTargetGroups;
+      } else if(command.viewState.dirty && command.viewState.dirty.targetGroups) {
+        command.viewState.dirty.targetGroups = [];
       }
     }
 

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/container/Container.tsx
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/container/Container.tsx
@@ -135,6 +135,7 @@ export class Container extends React.Component<IContainerProps, IContainerState>
     targetMapping.targetGroup = newTargetGroup.value;
     this.props.notifyAngular('targetGroupMappings', currentMappings);
     this.setState({ targetGroupMappings: currentMappings });
+    this.updateDirtyTargetGroups();
   };
 
   private updateTargetGroupMappingPort = (index: number, targetPort: number) => {
@@ -152,6 +153,10 @@ export class Container extends React.Component<IContainerProps, IContainerState>
     this.setState({ targetGroupMappings: currentMappings });
   };
 
+  private updateDirtyTargetGroups = () => {
+    this.props.command.viewState.dirty.targetGroups = [];
+  };
+
   public render(): React.ReactElement<Container> {
     const removeTargetGroupMapping = this.removeTargetGroupMapping;
     const updateContainerMappingImage = this.updateContainerMappingImage;
@@ -159,6 +164,7 @@ export class Container extends React.Component<IContainerProps, IContainerState>
     const updateTargetGroupMappingPort = this.updateTargetGroupMappingPort;
     const updateComputeUnits = this.updateComputeUnits;
     const updateReservedMemory = this.updateReservedMemory;
+    const dirtyTagetGroups = this.props.command.viewState.dirty && this.props.command.viewState.dirty.targetGroups ? this.props.command.viewState.dirty.targetGroups : [];
 
     const dockerImageOptions = this.state.dockerImages.map(function (image) {
       let msg = '';
@@ -167,6 +173,28 @@ export class Container extends React.Component<IContainerProps, IContainerState>
       }
       return { label: `${msg} (${image.imageId})`, value: image.imageId };
     });
+
+    const dirtyTargetGroupList = dirtyTagetGroups ? dirtyTagetGroups.map(function (targetGroup, index){
+        return (
+          <li key={index}>{targetGroup}</li>
+        );
+      }) : '';
+
+    const dirtyTargetGroupSection = (
+       <div className="alert alert-warning">
+         <p>
+           <i className="fa fa-exclamation-triangle"></i>
+           The following target groups could not be found in the selected account/region/VPC and were removed:
+         </p>
+         <ul>
+           {dirtyTargetGroupList}
+         </ul>
+         <br/>
+         <p className="text-left">
+           Please select the target group(s) from the dropdown to resolve this error.
+         </p>
+       </div>
+       );
 
     const newTargetGroupMapping = this.state.targetGroupsAvailable.length ? (
       <button
@@ -227,6 +255,7 @@ export class Container extends React.Component<IContainerProps, IContainerState>
 
     return (
       <div className="container-fluid form-horizontal">
+        {dirtyTagetGroups.length > 0 ? ( <div>{dirtyTargetGroupSection}</div>) : ''}
         <div className="form-group">
           <div className="col-md-3 sm-label-right">
             <b>Container Image</b>


### PR DESCRIPTION
This PR fixes the issue [#5248](https://github.com/spinnaker/spinnaker/issues/5248)

For the ECS Provider in deck, an Alert have been added when there is a target group(s) that was previously selected and is no longer available.

Dirty Target Groups
<img width="901" alt="Screen Shot 2021-01-26 at 5 52 43 PM" src="https://user-images.githubusercontent.com/18301288/105931203-9ff70f80-5fff-11eb-9193-c3b3baf56cf1.png">


Working Target Groups
<img width="899" alt="Screen Shot 2021-01-28 at 2 02 41 PM" src="https://user-images.githubusercontent.com/18301288/106204634-24699f80-6172-11eb-884f-d04040091041.png">

 
