### PR TITLE
feat(core/serverGroups): Intelligently enable/disable server groups in multiselect

### DIFF
--- a/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.js
+++ b/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.js
@@ -88,6 +88,7 @@ angular
       };
 
       this.disableServerGroups = () => {
+        this.serverGroups = this.serverGroups.filter((group) => !group.disabled);
         confirm('disableServerGroup', {
           presentContinuous: 'Disabling',
           simplePresent: 'Disable',
@@ -96,6 +97,7 @@ angular
       };
 
       this.enableServerGroups = () => {
+        this.serverGroups = this.serverGroups.filter((group) => group.disabled);
         confirm('enableServerGroup', {
           presentContinuous: 'Enabling',
           simplePresent: 'Enable',
@@ -103,9 +105,9 @@ angular
         });
       };
 
-      this.canDisable = () => this.serverGroups.every((group) => !group.disabled);
+      this.canDisable = () => this.serverGroups.some((group) => !group.disabled);
 
-      this.canEnable = () => this.serverGroups.every((group) => group.disabled);
+      this.canEnable = () => this.serverGroups.some((group) => group.disabled);
 
       /***
        * View instantiation/synchronization

--- a/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.spec.js
+++ b/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.spec.js
@@ -105,26 +105,26 @@ describe('Controller: MultipleServerGroups', function () {
   });
 
   describe('actions', function () {
-    it('can disable when all groups are enabled', function () {
+    it('can disable when some groups are enabled, but not all', function () {
       ClusterState.multiselectModel.toggleServerGroup(this.serverGroupA);
       ClusterState.multiselectModel.toggleServerGroup(this.serverGroupB);
       this.createController([this.serverGroupA, this.serverGroupB]);
-      expect(controller.canDisable()).toBe(false);
-
-      this.serverGroupB.isDisabled = false;
-      this.application.serverGroups.dataUpdated();
       expect(controller.canDisable()).toBe(true);
-    });
-
-    it('can enable when all groups are disabled', function () {
-      ClusterState.multiselectModel.toggleServerGroup(this.serverGroupA);
-      ClusterState.multiselectModel.toggleServerGroup(this.serverGroupB);
-      this.createController([this.serverGroupA, this.serverGroupB]);
-      expect(controller.canEnable()).toBe(false);
 
       this.serverGroupA.isDisabled = true;
       this.application.serverGroups.dataUpdated();
+      expect(controller.canDisable()).toBe(false);
+    });
+
+    it('can enable when some groups are disabled, but not all', function () {
+      ClusterState.multiselectModel.toggleServerGroup(this.serverGroupA);
+      ClusterState.multiselectModel.toggleServerGroup(this.serverGroupB);
+      this.createController([this.serverGroupA, this.serverGroupB]);
       expect(controller.canEnable()).toBe(true);
+
+      this.serverGroupB.isDisabled = false;
+      this.application.serverGroups.dataUpdated();
+      expect(controller.canEnable()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
We got feedback that when selecting many server groups to enable/disable and accidentally choosing one that is opposite of the desired state, you cannot perform the action you want. It takes too much time to scroll through and de-select the invalid server groups. The suggestion was to make this more intelligent (i.e. if we know the user is disabling a group of server groups only allow the selected _and_ enabled server groups to be disabled).

Before:
- User cannot choose to bulk enable/disable all selected server groups if they are all already disabled/enabled. This option is hidden from server group actions

After:
- User can choose enable/disable in server group actions if some of the selected server groups match the desired state
- Invalid server groups are automatically filtered out before the tasks are submitted (this is reflected in the preivew)