### PR TITLE
feat(core): Add a new variable that is interpolated in instance links

### DIFF
--- a/app/scripts/modules/core/src/instance/details/InstanceLinks.tsx
+++ b/app/scripts/modules/core/src/instance/details/InstanceLinks.tsx
@@ -50,6 +50,7 @@ export const InstanceLinks = ({ address, application, instance, moniker, environ
           Object.assign({}, instance, moniker, {
             ipAddress: address,
             environment: environment,
+            embeddableIpAddress: (address || '').split('.').join('-'),
           }),
         );
       }


### PR DESCRIPTION
Sometimes the `ipAdress` needs to be delimited by dashes in links. Adding `embeddableIpAddress` as a way to use this value in links.

ipAddress = 127.0.0.1
embeddableIpAddress = 127-0-0-1
