### PR TITLE
feat(core): allow custom stage summary as React components

### DIFF
--- a/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
+++ b/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
@@ -1,5 +1,6 @@
 import { IStage } from './IStage';
 import { IExecutionDetailsSectionProps } from 'core/pipeline/config/stages/common';
+import { IStageSummaryProps } from 'core/pipeline/details/StageSummary';
 import { IExecutionContext, IExecutionStageLabelProps, IExecutionStageSummary } from './IExecutionStage';
 import { IStageOrTriggerTypeConfig } from './IStageOrTriggerTypeConfig';
 
@@ -23,6 +24,7 @@ export interface IStageTypeConfig extends IStageOrTriggerTypeConfig {
   executionLabelComponent?: React.ComponentType<IExecutionStageLabelProps>;
   executionStepLabelUrl?: string;
   executionSummaryUrl?: string;
+  executionSummaryComponent?: React.ComponentType<IStageSummaryProps>;
   extraLabelLines?: (stage: IStage) => number;
   markerIcon?: React.ComponentClass<{ stage: IExecutionStageSummary }>;
   nameToCheckInTest?: string;

--- a/app/scripts/modules/core/src/pipeline/details/StageSummary.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/StageSummary.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { get } from 'lodash';
 
 import { Application } from 'core/application';
 import { IExecution, IExecutionStage, IExecutionStageSummary, IStageTypeConfig } from 'core/domain';
@@ -13,28 +12,32 @@ export interface IStageSummaryProps {
   stageSummary: IExecutionStageSummary;
 }
 
-export class StageSummary extends React.Component<IStageSummaryProps> {
-  private getSourceUrl(): string {
-    return get(this.props, 'config.executionSummaryUrl', require('../config/stages/common/executionSummary.html'));
+export function StageSummary(props: IStageSummaryProps) {
+  const { application, execution, stage, stageSummary, config } = props;
+
+  // AngularJS override
+  const sourceUrl = config?.executionSummaryUrl ?? require('../config/stages/common/executionSummary.html');
+  // React override
+  const SummaryComponent = config?.executionSummaryComponent;
+
+  if (SummaryComponent) {
+    return (
+      <div className="stage-summary">
+        <SummaryComponent {...props} />
+      </div>
+    );
   }
 
-  public render(): React.ReactElement<StageSummary> {
-    const sourceUrl = this.getSourceUrl();
-    if (sourceUrl) {
-      const { application, execution, stage, stageSummary } = this.props;
-      const { StageSummaryWrapper } = NgReact;
-      return (
-        <div className="stage-summary">
-          <StageSummaryWrapper
-            application={application}
-            execution={execution}
-            sourceUrl={sourceUrl}
-            stage={stage}
-            stageSummary={stageSummary}
-          />
-        </div>
-      );
-    }
-    return null;
-  }
+  const { StageSummaryWrapper } = NgReact;
+  return (
+    <div className="stage-summary">
+      <StageSummaryWrapper
+        application={application}
+        execution={execution}
+        sourceUrl={sourceUrl}
+        stage={stage}
+        stageSummary={stageSummary}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
Developers can customize the stage summary for a given stage, but only in AngularJS. This provides a way to customize the stage summary with a React component, instead.