### PR TITLE
fix(core): handle errors on confirmation modal submission

### DIFF
--- a/app/scripts/modules/core/src/confirmationModal/ConfirmModal.tsx
+++ b/app/scripts/modules/core/src/confirmationModal/ConfirmModal.tsx
@@ -64,7 +64,7 @@ export const ConfirmModal = (props: IConfirmModalProps) => {
         });
       });
     } else if (submitJustWithReason) {
-      submitMethod({ reason }).then(closeModal);
+      submitMethod({ reason }).then(closeModal, showError);
     } else {
       if (submitMethod) {
         submitMethod().then(closeModal, showError);


### PR DESCRIPTION
It's not clear why we are not catching any errors if the `submitJustWithReason` flag is set but I am pretty sure it was an oversight when this was converted to React (it was being caught in the AngularJS version) and I am the one who converted it about a year ago so I can't really blame anyone else.