### PR TITLE
feat(core): export StageSummary props in core module

### DIFF
--- a/app/scripts/modules/core/src/pipeline/details/index.ts
+++ b/app/scripts/modules/core/src/pipeline/details/index.ts
@@ -2,3 +2,4 @@ export * from './executionDetailsSection.service';
 export * from './ExecutionDetailsSectionNav';
 export * from './StageExecutionLogs';
 export * from './StageFailureMessage';
+export * from './StageSummary';


### PR DESCRIPTION
Having the props for the StageSummary component is useful when overriding the component. This should have been done as part of my earlier PR today, but I didn't realize they weren't exported already, so...here they are.