### PR TITLE
feat(ecs): improve the Capacity Providers configuration UI

### DIFF
--- a/app/scripts/modules/ecs/src/ecsCluster/IEcsCapacityProviderDetails.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/IEcsCapacityProviderDetails.ts
@@ -1,0 +1,11 @@
+export interface IEcsCapacityProviderDetails {
+  capacityProviders : string[],
+  clusterName : string,
+  defaultCapacityProviderStrategy : IEcsDefaultCapacityProviderStrategyItem[],
+}
+
+export interface IEcsDefaultCapacityProviderStrategyItem {
+  base : number,
+  capacityProvider : string,
+  weight : number
+}

--- a/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
+++ b/app/scripts/modules/ecs/src/ecsCluster/ecsCluster.read.service.ts
@@ -2,10 +2,18 @@ import { module } from 'angular';
 
 import { REST } from '@spinnaker/core';
 import { IEcsClusterDescriptor } from './IEcsCluster';
+import { IEcsCapacityProviderDetails } from "./IEcsCapacityProviderDetails";
 
 export class EcsClusterReader {
   public listClusters(): PromiseLike<IEcsClusterDescriptor[]> {
     return REST('/ecs/ecsClusters').get();
+  }
+
+  public describeClusters(account: string, region: string): PromiseLike<IEcsCapacityProviderDetails[]> {
+    if(account != null && region != null) {
+      return REST('/ecs/ecsClusterDescriptions').path(account).path(region).get();
+    }
+    return {} as PromiseLike<IEcsCapacityProviderDetails[]>;
   }
 }
 

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/capacityProvider/CapacityProvider.tsx
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/capacityProvider/CapacityProvider.tsx
@@ -2,15 +2,23 @@ import React from 'react';
 import { module } from 'angular';
 import { react2angular } from 'react2angular';
 import {IEcsCapacityProviderStrategyItem, IEcsServerGroupCommand} from '../../serverGroupConfiguration.service';
-import { HelpField, withErrorBoundary } from  '@spinnaker/core';
+import { HelpField, withErrorBoundary, TetheredSelect } from  '@spinnaker/core';
+import { Option } from "react-select";
+import  { Alert } from "react-bootstrap";
 
 export interface IEcsCapacityProviderProps {
   command: IEcsServerGroupCommand;
   notifyAngular: (key: string, value: any) => void;
+  configureCommand: (query: string) => PromiseLike<void>;
 }
 
 interface IEcsCapacityProviderState {
   capacityProviderStrategy: IEcsCapacityProviderStrategyItem[],
+  defaultCapacityProviderStrategy: IEcsCapacityProviderStrategyItem[],
+  availableCapacityProviders: string[],
+  ecsClusterName: string,
+  useDefaultCapacityProviders: boolean,
+  capacityProviderLoadedFlag: boolean;
 }
 
 class EcsCapacityProvider extends React.Component<IEcsCapacityProviderProps, IEcsCapacityProviderState>{
@@ -19,9 +27,41 @@ class EcsCapacityProvider extends React.Component<IEcsCapacityProviderProps, IEc
     const cmd = this.props.command;
 
     this.state = {
-      capacityProviderStrategy: cmd.capacityProviderStrategy,
+      availableCapacityProviders: this.getAvailableCapacityProviders(cmd),
+      defaultCapacityProviderStrategy: this.getDefaultCapacityProviderStrategy(cmd),
+      ecsClusterName: cmd.ecsClusterName,
+      useDefaultCapacityProviders: cmd.useDefaultCapacityProviders || cmd.capacityProviderStrategy && cmd.capacityProviderStrategy.length == 0,
+      capacityProviderStrategy: cmd.capacityProviderStrategy && cmd.capacityProviderStrategy.length > 0 ? cmd.capacityProviderStrategy : [],
+      capacityProviderLoadedFlag: false
     };
   }
+
+  public componentDidMount() {
+    this.props.configureCommand('1').then(() => {
+      const cmd = this.props.command;
+      const useDefaultCapacityProviders = this.state.useDefaultCapacityProviders;
+      this.setState({
+        availableCapacityProviders: this.getAvailableCapacityProviders(cmd),
+        defaultCapacityProviderStrategy: this.getDefaultCapacityProviderStrategy(cmd),
+        capacityProviderStrategy: this.getCapacityProviderStrategy(useDefaultCapacityProviders, cmd),
+        capacityProviderLoadedFlag: true,
+      });
+      this.props.notifyAngular('useDefaultCapacityProviders', this.state.useDefaultCapacityProviders);
+      this.props.notifyAngular('capacityProviderStrategy', this.state.capacityProviderStrategy);
+    });
+  }
+
+  private getAvailableCapacityProviders = (cmd: IEcsServerGroupCommand) => {
+    return cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.availableCapacityProviders ? cmd.backingData.filtered.availableCapacityProviders : [];
+  };
+
+  private getDefaultCapacityProviderStrategy = (cmd: IEcsServerGroupCommand) => {
+    return cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.defaultCapacityProviderStrategy ? cmd.backingData.filtered.defaultCapacityProviderStrategy : [];
+  };
+
+  private getCapacityProviderStrategy = (useDefaultCapacityProviders: boolean, cmd : IEcsServerGroupCommand) => {
+    return useDefaultCapacityProviders && cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.defaultCapacityProviderStrategy ? cmd.backingData.filtered.defaultCapacityProviderStrategy : this.state.capacityProviderStrategy;
+  };
 
   private addCapacityProviderStrategy = () => {
     const capacityProviderStrategy = this.state.capacityProviderStrategy;
@@ -61,6 +101,14 @@ class EcsCapacityProvider extends React.Component<IEcsCapacityProviderProps, IEc
     this.setState({ capacityProviderStrategy: capacityProviderStrategy });
   };
 
+  private updateCapacityProviderType = (targetCapacityProviderType: boolean) => {
+    this.setState({useDefaultCapacityProviders : targetCapacityProviderType});
+    this.props.notifyAngular("useDefaultCapacityProviders", targetCapacityProviderType);
+
+    const capacityProviderStrategy = targetCapacityProviderType && this.state.defaultCapacityProviderStrategy.length > 0 ? this.state.defaultCapacityProviderStrategy : [];
+    this.setState({ capacityProviderStrategy : capacityProviderStrategy });
+    this.props.notifyAngular('capacityProviderStrategy',  capacityProviderStrategy);
+  };
 
   render(): React.ReactElement<EcsCapacityProvider> {
 
@@ -69,33 +117,57 @@ class EcsCapacityProvider extends React.Component<IEcsCapacityProviderProps, IEc
     const updateCapacityProviderWeight = this.updateCapacityProviderWeight;
     const addCapacityProviderStrategy = this.addCapacityProviderStrategy;
     const removeCapacityProviderStrategy = this.removeCapacityProviderStrategy;
+    const updateCapacityProviderType = this.updateCapacityProviderType;
+    const capacityProviderStrategy = this.state.capacityProviderStrategy;
+    const useDefaultCapacityProviders = this.state.useDefaultCapacityProviders;
+    const capacityProviderLoadedFlag = this.state.capacityProviderLoadedFlag;
 
-    const capacityProviderInputs = this.state.capacityProviderStrategy.map(function (mapping, index) {
+
+    const capacityProviderNames = this.state.availableCapacityProviders &&  this.state.availableCapacityProviders.length > 0 ?  this.state.availableCapacityProviders.map((capacityProviderNames) => {
+      return { label: `${capacityProviderNames}`, value: capacityProviderNames };
+    }) : [];
+
+    const capacityProviderInputs = capacityProviderStrategy.length > 0 ? capacityProviderStrategy.map(function (mapping, index) {
       return (
         <tr key={index}>
+          {useDefaultCapacityProviders ? (
+            <td>
+              <input
+                data-test-id={"ServerGroup.defaultCapacityProvider.name." + index}
+                type="string"
+                className="form-control input-sm no-spel"
+                required={true}
+                value={mapping.capacityProvider}
+                disabled={true}
+              />
+            </td>
+          ) : (
+            <td data-test-id={"ServerGroup.customCapacityProvider.name." + index}>
+              <TetheredSelect
+                placeholder="Select capacity provider"
+                options={capacityProviderNames}
+                value={mapping.capacityProvider}
+                onChange={(e: Option) => {
+                  updateCapacityProviderName(index, e.label as string)
+                }}
+                clearable={false}
+              />
+            </td>
+          )}
           <td>
             <input
-              data-test-id={"capacityProvider.name." +  index }
-              type="string"
-              className="form-control input-sm no-spel"
-              required={true}
-              value={mapping.capacityProvider}
-              onChange={(e) => updateCapacityProviderName(index, e.target.value)}
-            />
-          </td>
-          <td>
-            <input
-              data-test-id={"capacityProvider.base." + index }
+              data-test-id={"ServerGroup.capacityProvider.base." + index}
+              disabled= {useDefaultCapacityProviders}
               type="number"
               className="form-control input-sm no-spel"
-              required={true}
               value={mapping.base}
               onChange={(e) => updateCapacityProviderBase(index, e.target.valueAsNumber)}
             />
           </td>
           <td>
             <input
-              data-test-id={"capacityProvider.weight." +  index }
+              data-test-id={"ServerGroup.capacityProvider.weight." + index}
+              disabled= {useDefaultCapacityProviders}
               type="number"
               className="form-control input-sm no-spel"
               required={true}
@@ -103,50 +175,89 @@ class EcsCapacityProvider extends React.Component<IEcsCapacityProviderProps, IEc
               onChange={(e) => updateCapacityProviderWeight(index, e.target.valueAsNumber)}
             />
           </td>
-          <td>
+          {!useDefaultCapacityProviders ? ( <td>
             <div className="form-control-static">
               <a className="btn-link sm-label" onClick={() => removeCapacityProviderStrategy(index)}>
                 <span className="glyphicon glyphicon-trash" />
                 <span className="sr-only">Remove</span>
               </a>
             </div>
-          </td>
+          </td> ) : ''}
         </tr>
       );
-    });
+    }) : useDefaultCapacityProviders && this.state.capacityProviderStrategy.length == 0 ?  (
+      <tr><div className="sm-label-left" style={{width: "200%"}}>
+          <Alert color="warning"> The cluster does not have a default capacity provider strategy defined. Set a default capacity provider strategy or use a custom strategy.</Alert>
+      </div></tr> )
+      : '';
 
-    const newCapacityProviderStrategy = (
-      <button className="btn btn-block btn-sm add-new" onClick={addCapacityProviderStrategy} data-test-id="ServerGroup.addCapacityProvider">
+    const newCapacityProviderStrategy =   this.state.ecsClusterName && this.props.command.credentials && this.props.command.region && !useDefaultCapacityProviders && capacityProviderNames.length > 0 ? (
+      <button data-test-id="ServerGroup.addCapacityProvider" className="btn btn-block btn-sm add-new" onClick={addCapacityProviderStrategy}>
         <span className="glyphicon glyphicon-plus-sign" />
         Add New Capacity Provider
-    </button>
-    )
-
+      </button>
+    ) : !useDefaultCapacityProviders && capacityProviderLoadedFlag && capacityProviderNames.length == 0 ? (
+      <div className="sm-label-left" style={{width: "200%"}}>
+        <Alert color="warning"> The cluster does not have capacity providers defined. </Alert>
+      </div>
+    ) : '';
 
     return (
       <div>
-      <div className="sm-label-left">
-        <b>Capacity Provider Strategy</b>
-        <HelpField id="ecs.capacityProviderStrategy" />
+        <div className="sm-label-left">
+          <b>Capacity Provider Strategy</b><HelpField id="ecs.capacityProviderStrategy" /> <br/>
+          <span>({this.state.ecsClusterName})</span>
+        </div>
+        <div className="radio">
+          <label>
+            <input
+              data-test-id="ServerGroup.capacityProviders.default"
+              type="radio"
+              checked={useDefaultCapacityProviders}
+              onClick={() => updateCapacityProviderType(true)}
+              id="computeOptionsLaunchType1"
+            />
+            Use cluster default
+          </label>
+        </div>
+        <div className="radio">
+          <label>
+            <input
+              data-test-id="ServerGroup.capacityProviders.custom"
+              type="radio"
+              checked= {!useDefaultCapacityProviders}
+              onClick={() => updateCapacityProviderType(false)}
+              id="computeOptionsCapacityProviders2"
+            />
+            Use custom (Advanced)
+          </label>
+        </div>
+        {capacityProviderLoadedFlag ? (
+          <table className="table table-condensed packed tags">
+            <thead>
+            <tr>
+              <th style={{ width: '50%' }}>Provider name<HelpField id="ecs.capacityProviderName" /></th>
+              <th style={{ width: '25%' }}>Base<HelpField id="ecs.capacityProviderBase" /></th>
+              <th style={{ width: '25%' }}>Weight<HelpField id="ecs.capacityProviderWeight" /></th>
+            </tr>
+            </thead>
+            <tbody>{capacityProviderInputs}</tbody>
+            <tfoot>
+            <tr>
+              <td colSpan={4}>{newCapacityProviderStrategy}</td>
+            </tr>
+            </tfoot>
+          </table>) : (
+          <div className="load medium">
+            <div className="message">Loading capacity providers...</div>
+            <div className="bars">
+              <div className="bar"></div>
+              <div className="bar"></div>
+              <div className="bar"></div>
+            </div>
+          </div>
+        )}
       </div>
-        <table className="table table-condensed packed tags">
-          <thead>
-          <th style={{ width: '50%' }}> Provider name <HelpField id="ecs.capacityProviderName" /></th>
-          <th style={{ width: '25%' }}> Base <HelpField id="ecs.capacityProviderBase" /></th>
-          <th style={{ width: '25%' }}>Weight <HelpField id="ecs.capacityProviderWeight" /></th>
-          </thead>
-          <tbody>
-          {capacityProviderInputs}
-          </tbody>
-          <tfoot>
-          <tr>
-            <td colSpan={4}>{newCapacityProviderStrategy}</td>
-          </tr>
-          </tfoot>
-        </table>
-
-      </div>
-
     );
   }
 }
@@ -154,5 +265,8 @@ class EcsCapacityProvider extends React.Component<IEcsCapacityProviderProps, IEc
 export const ECS_CAPACITY_PROVIDER_REACT = 'spinnaker.ecs.serverGroup.configure.wizard.capacityProvider.react';
 module(ECS_CAPACITY_PROVIDER_REACT, []).component(
   'ecsCapacityProviderReact',
-  react2angular(withErrorBoundary(EcsCapacityProvider, 'ecsCapacityProviderReact'), ['command', 'notifyAngular']),
+  react2angular(withErrorBoundary(EcsCapacityProvider, 'ecsCapacityProviderReact'), [
+    'command',
+    'notifyAngular',
+    'configureCommand',]),
 );

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/capacityProvider/capacityProvider.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/capacityProvider/capacityProvider.html
@@ -4,6 +4,7 @@
       <ecs-capacity-provider-react
         command="command"
         notify-angular="notifyAngular"
+        configure-command="configureCommand"
       ></ecs-capacity-provider-react>
     </div>
   </div>

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
@@ -34,7 +34,8 @@
 
   <div class="form-group" ng-if="$ctrl.capacityProviderState.useCapacityProviders">
     <ecs-capacity-provider-react command="$ctrl.command"
-                             notify-angular="$ctrl.notifyAngular"/>
+                                 notify-angular="$ctrl.notifyAngular"
+                                 configure-command="$ctrl.configureCommand"/>
   </div>
 
   <div class="form-group" ng-if="!$ctrl.capacityProviderState.useCapacityProviders" style="padding-top: 10px">

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.js
@@ -12,7 +12,8 @@ module(ECS_SERVERGROUP_CONFIGURE_WIZARD_HORIZONTALSCALING_HORIZONTALSCALING_COMP
       command: '=',
       application: '=',
       capacityProviderState: '=',
-      notifyAngular: '='
+      notifyAngular: '=',
+      configureCommand: '=',
     },
     templateUrl: require('./horizontalScaling.component.html'),
   },

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.html
@@ -6,6 +6,7 @@
         application="application"
         capacity-provider-state="capacityProviderState"
         notify-angular="notifyAngular"
+        configure-command="configureCommand"
       ></ecs-server-group-horizontal-scaling>
     </div>
   </div>

--- a/test/functional/cypress/fixtures/ecs/shared/ecsClusters.json
+++ b/test/functional/cypress/fixtures/ecs/shared/ecsClusters.json
@@ -4,5 +4,17 @@
     "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/spinnaker-deployment-cluster",
     "name": "spinnaker-deployment-cluster",
     "region": "us-west-2"
+  },
+  {
+    "account": "ecs-my-aws-devel-acct",
+    "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/TestCluster",
+    "name": "TestCluster",
+    "region": "us-west-2"
+  },
+  {
+    "account": "ecs-my-aws-devel-acct",
+    "arn": "arn:aws:ecs:us-west-2:123456789012:cluster/example-app-test-Cluster-NSnYsTXmCfV2",
+    "name": "example-app-test-Cluster-NSnYsTXmCfV2",
+    "region": "us-west-2"
   }
 ]

--- a/test/functional/cypress/fixtures/ecs/shared/ecsDescribeClusters.json
+++ b/test/functional/cypress/fixtures/ecs/shared/ecsDescribeClusters.json
@@ -1,0 +1,29 @@
+[
+  {
+    "capacityProviders": [],
+    "clusterName": "spinnaker-deployment-cluster",
+    "defaultCapacityProviderStrategy": []
+  },
+  {
+    "capacityProviders": [
+      "FARGATE_SPOT",
+      "FARGATE"
+    ],
+    "clusterName": "example-app-test-Cluster-NSnYsTXmCfV2",
+    "defaultCapacityProviderStrategy": [
+      {
+        "base": 0,
+        "capacityProvider": "FARGATE_SPOT",
+        "weight": 1
+      }
+    ]
+  },
+  {
+    "capacityProviders": [
+      "FARGATE_SPOT",
+      "FARGATE"
+    ],
+    "clusterName": "TestCluster",
+    "defaultCapacityProviderStrategy": []
+  }
+]


### PR DESCRIPTION
This PR adds a new enhanced version of UI to support Capacity Providers.

Currently, Capacity Provider UI section provides input fields to enter details about Capacity Provider Strategy for the server group.
But new UI will have a drop down list for selecting a Capacity Provider. Plus now users can add default Capacity providers without typing in the details of default Capacity Provider by just clicking on the use cluster default option. Please refer the following screenshots for the more details.

When set custom capacity provider startegy

<img width="903" alt="Screen Shot 2021-01-19 at 12 12 27 PM" src="https://user-images.githubusercontent.com/18301288/105087614-9abe2180-5a4f-11eb-8ff8-753e3f7c3322.png">

When set default capacity provider startegy

<img width="898" alt="Screen Shot 2021-01-19 at 12 12 44 PM" src="https://user-images.githubusercontent.com/18301288/105087636-a578b680-5a4f-11eb-8ec4-f7d0a67aec53.png">

When default capacity provider is not available on the cluster

![Defaul not available](https://user-images.githubusercontent.com/18301288/106228850-15e6ac80-61a1-11eb-9d49-ee117e84675e.png)

When Custom capacity providers are not available on the cluster

![Custom CP not available](https://user-images.githubusercontent.com/18301288/106228856-17b07000-61a1-11eb-8390-50ecfbab1567.png)



Addresses [spinnaker/spinnaker#6242](https://github.com/spinnaker/spinnaker/issues/6242)

Continuation of PR [#8810](https://github.com/spinnaker/deck/pull/8810) and [8858](https://github.com/spinnaker/deck/pull/8858). Implemented review comments from #8810 and [#8858](https://github.com/spinnaker/deck/pull/8858) PR as well. 