### PR TITLE
fix(core): add vertical padding on page owner nav link

### DIFF
--- a/app/scripts/modules/core/src/application/nav/ApplicationNavigation.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationNavigation.tsx
@@ -75,8 +75,11 @@ export const ApplicationNavigation = ({ app }: IApplicationNavigationProps) => {
           <NavSection key={`section-${i}`} dataSources={section} app={app} />
         ))}
       {SETTINGS.feature.pagerDuty && app.attributes.pdApiKey && (
-        <div className="nav-section clickable">
-          <div className="page-category flex-container-h middle text-semibold" onClick={pageApplicationOwner}>
+        <div className="nav-section sp-padding-s-yaxis">
+          <div
+            className="page-category flex-container-h middle text-semibold sp-padding-s-yaxis clickable"
+            onClick={pageApplicationOwner}
+          >
             <div className="nav-row-item sp-margin-s-right">
               {!isExpanded ? (
                 <Tooltip value="Page App Owner" placement="right">


### PR DESCRIPTION
**Before**
<img width="238" alt="Screen Shot 2021-01-28 at 9 16 46 PM" src="https://user-images.githubusercontent.com/73450/106234816-454fe600-61ae-11eb-8c65-30b62183331c.png">

**After**
<img width="239" alt="Screen Shot 2021-01-28 at 9 16 31 PM" src="https://user-images.githubusercontent.com/73450/106234826-484ad680-61ae-11eb-8c50-4027f0ce117a.png">

