### PR TITLE
feat(dev): Added webpack hot reloading

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,10 @@ function configure(env, webpackOpts) {
     }),
   ];
 
+  if (process.env.NODE_ENV !== 'production') {
+    plugins.push(new webpack.HotModuleReplacementPlugin());
+  }
+
   if (DISPLAY_PROGRESS) {
     plugins.push(new webpack.ProgressPlugin({ profile: false }));
   }
@@ -201,6 +205,7 @@ function configure(env, webpackOpts) {
     },
     plugins,
     devServer: {
+      hot: true,
       disableHostCheck: true,
       port: process.env.DECK_PORT || 9000,
       host: process.env.DECK_HOST || 'localhost',


### PR DESCRIPTION
Hot reloading allows us to update styles without refreshing and speeds up the dev process.
This feature is disabled in production.

