### PR TITLE
refactor(aws/titus): Convert instance DNS to react

### DIFF
--- a/app/scripts/modules/amazon/src/aws.module.ts
+++ b/app/scripts/modules/amazon/src/aws.module.ts
@@ -72,6 +72,7 @@ import { AWS_EVALUATE_CLOUD_FORMATION_CHANGE_SET_EXECUTION_SERVICE } from './pip
 import { INSTANCE_STATUS_COMPONENT } from './instance/details/instanceStatus.component';
 import { INSTANCE_TAGS_COMPONENT } from './instance/details/instanceTags.component';
 import { INSTANCE_SECURITY_GROUPS_COMPONENT } from './instance/details/instanceSecurityGroups.component';
+import { INSTANCE_DNS_COMPONENT } from './instance/details/instanceDns.component';
 import { AMAZON_INSTANCE_INFORMATION_COMPONENT } from './instance/details/amazonInstanceInformation.component';
 
 // load all templates into the $templateCache
@@ -115,6 +116,7 @@ module(AMAZON_MODULE, [
   INSTANCE_STATUS_COMPONENT,
   INSTANCE_TAGS_COMPONENT,
   INSTANCE_SECURITY_GROUPS_COMPONENT,
+  INSTANCE_DNS_COMPONENT,
   AMAZON_INSTANCE_INFORMATION_COMPONENT,
 ]).config(() => {
   CloudProviderRegistry.registerProvider('aws', {

--- a/app/scripts/modules/amazon/src/instance/details/InstanceDns.tsx
+++ b/app/scripts/modules/amazon/src/instance/details/InstanceDns.tsx
@@ -44,20 +44,27 @@ export const InstanceDns = ({
         value={<LinkWithClipboard text={privateIpAddress} url={`http://${privateIpAddress}:${instancePort}`} />}
       />
     )}
-    {permanentIps && <dt>Permanent IP Address</dt>}
-    <dd>
-      {permanentIps &&
-        permanentIps.map((ip) => <LinkWithClipboard key={ip} text={ip} url={`http://${ip}:${instancePort}`} />)}
-    </dd>
+    {permanentIps?.length && (
+      <LabeledValue
+        label="Permanent IP Address"
+        value={permanentIps.map((ip) => (
+          <LinkWithClipboard key={ip} text={ip} url={`http://${ip}:${instancePort}`} />
+        ))}
+      />
+    )}
     {publicIpAddress && (
       <LabeledValue
         label="Public IP Address"
         value={<LinkWithClipboard text={publicIpAddress} url={`http://${publicIpAddress}:${instancePort}`} />}
       />
     )}
-    {ipv6Addresses && Boolean(ipv6Addresses.length) && <dt>IPv6 Address{ipv6Addresses.length > 1 ? 'es' : ''}</dt>}
-    <dd>
-      {ipv6Addresses && ipv6Addresses.map((ipv6) => <LinkWithClipboard key={ipv6.ip} text={ipv6.ip} url={ipv6.url} />)}
-    </dd>
+    {ipv6Addresses?.length && (
+      <LabeledValue
+        label={`IPv6 Address${ipv6Addresses.length > 1 ? 'es' : ''}`}
+        value={ipv6Addresses.map((ipv6) => (
+          <LinkWithClipboard key={ipv6.ip} text={ipv6.ip} url={ipv6.url} />
+        ))}
+      />
+    )}
   </LabeledValueList>
 );

--- a/app/scripts/modules/amazon/src/instance/details/InstanceDns.tsx
+++ b/app/scripts/modules/amazon/src/instance/details/InstanceDns.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { LabeledValue, LabeledValueList, LinkWithClipboard } from '@spinnaker/core';
+
+interface IIpv6Address {
+  ip: string;
+  url: string;
+}
+
+export interface IInstanceDnsProps {
+  instancePort: string;
+  ipv6Addresses: IIpv6Address[];
+  permanentIps: string[];
+  privateDnsName: string;
+  privateIpAddress: string;
+  publicDnsName: string;
+  publicIpAddress: string;
+}
+
+export const InstanceDns = ({
+  instancePort,
+  ipv6Addresses,
+  permanentIps,
+  privateDnsName,
+  privateIpAddress,
+  publicDnsName,
+  publicIpAddress,
+}: IInstanceDnsProps) => (
+  <LabeledValueList className="horizontal-when-filters-collapsed">
+    {privateDnsName && (
+      <LabeledValue
+        label="Private DNS Name"
+        value={<LinkWithClipboard text={privateDnsName} url={`http://${privateDnsName}:${instancePort}`} />}
+      />
+    )}
+    {publicDnsName && (
+      <LabeledValue
+        label="Public DNS Name"
+        value={<LinkWithClipboard text={publicDnsName} url={`http://${publicDnsName}:${instancePort}`} />}
+      />
+    )}
+    {privateIpAddress && (
+      <LabeledValue
+        label="Private IP Address"
+        value={<LinkWithClipboard text={privateIpAddress} url={`http://${privateIpAddress}:${instancePort}`} />}
+      />
+    )}
+    {permanentIps && <dt>Permanent IP Address</dt>}
+    <dd>
+      {permanentIps &&
+        permanentIps.map((ip) => <LinkWithClipboard key={ip} text={ip} url={`http://${ip}:${instancePort}`} />)}
+    </dd>
+    {publicIpAddress && (
+      <LabeledValue
+        label="Public IP Address"
+        value={<LinkWithClipboard text={publicIpAddress} url={`http://${publicIpAddress}:${instancePort}`} />}
+      />
+    )}
+    {ipv6Addresses && Boolean(ipv6Addresses.length) && <dt>IPv6 Address{ipv6Addresses.length > 1 ? 'es' : ''}</dt>}
+    <dd>
+      {ipv6Addresses && ipv6Addresses.map((ipv6) => <LinkWithClipboard key={ipv6.ip} text={ipv6.ip} url={ipv6.url} />)}
+    </dd>
+  </LabeledValueList>
+);

--- a/app/scripts/modules/amazon/src/instance/details/InstanceStatus.tsx
+++ b/app/scripts/modules/amazon/src/instance/details/InstanceStatus.tsx
@@ -75,11 +75,13 @@ export const InstanceStatus = ({
                 )}
                 {hasLoadBalancer &&
                   metric.type === 'LoadBalancer' &&
-                  (metric.loadBalancers || []).map((lb) => <InstanceLoadBalancerHealth loadBalancer={lb} />)}
+                  (metric.loadBalancers || []).map((lb) => (
+                    <InstanceLoadBalancerHealth key={lb.name} loadBalancer={lb} />
+                  ))}
                 {hasTargetGroup &&
                   metric.type === 'TargetGroup' &&
                   (metric.targetGroups || []).map((tg) => (
-                    <InstanceLoadBalancerHealth loadBalancer={tg} ipAddress={privateIpAddress} />
+                    <InstanceLoadBalancerHealth key={tg.name} loadBalancer={tg} ipAddress={privateIpAddress} />
                   ))}
               </dd>
             </React.Fragment>

--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -201,7 +201,10 @@ module(AMAZON_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
           $scope.instance.targetGroups = targetGroups;
           if ($scope.instance.networkInterfaces) {
             $scope.instance.ipv6Addresses = _.flatMap($scope.instance.networkInterfaces, (i) =>
-              i.ipv6Addresses.map((a) => a.ipv6Address),
+              i.ipv6Addresses.map((a) => ({
+                ip: a.ipv6Address,
+                url: `http://${a.ipv6Address}:${$scope.state.instancePort}`,
+              })),
             );
 
             const permanentNetworkInterfaces = $scope.instance.networkInterfaces.filter(

--- a/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
@@ -27,50 +27,16 @@
     >
     </instance-status>
     <collapsible-section heading="DNS">
-      <dl class="horizontal-when-filters-collapsed">
-        <dt ng-if="instance.privateDnsName">Private DNS Name</dt>
-        <dd ng-if="instance.privateDnsName">
-          <link-with-clipboard
-            url="'http://' + instance.privateDnsName + ':' + state.instancePort"
-            text="instance.privateDnsName"
-          >
-          </link-with-clipboard>
-        </dd>
-        <dt ng-if="instance.publicDnsName">Public DNS Name</dt>
-        <dd ng-if="instance.publicDnsName">
-          <link-with-clipboard
-            url="'http://' + instance.publicDnsName + ':' + state.instancePort"
-            text="instance.publicDnsName"
-          >
-          </link-with-clipboard>
-        </dd>
-        <dt ng-if="instance.privateIpAddress">Private IP Address</dt>
-        <dd ng-if="instance.privateIpAddress">
-          <link-with-clipboard
-            url="'http://' + instance.privateIpAddress + ':' + state.instancePort"
-            text="instance.privateIpAddress"
-          >
-          </link-with-clipboard>
-        </dd>
-        <dt ng-if="instance.permanentIps">Permanent IP Address</dt>
-        <dd ng-if="instance.permanentIps" ng-repeat="ip in instance.permanentIps">
-          <link-with-clipboard url="'http://' + ip + ':' + state.instancePort" text="ip"> </link-with-clipboard>
-        </dd>
-        <dt ng-if="instance.publicIpAddress">Public IP Address</dt>
-        <dd ng-if="instance.publicIpAddress">
-          <link-with-clipboard
-            url="'http://' + instance.publicIpAddress + ':' + state.instancePort"
-            text="instance.publicIpAddress"
-          >
-          </link-with-clipboard>
-        </dd>
-        <dt ng-if="instance.ipv6Addresses.length">
-          IPv6 Address<span ng-if="instance.ipv6Addresses.length > 1">es</span>
-        </dt>
-        <dd ng-if="instance.ipv6Addresses.length" ng-repeat="ip in instance.ipv6Addresses">
-          <link-with-clipboard url="'http://[' + ip + ']:' + state.instancePort" text="ip"> </link-with-clipboard>
-        </dd>
-      </dl>
+      <instance-dns
+        instance-port="state.instancePort"
+        ipv6-addresses="instance.ipv6Addresses"
+        permanent-ips="instance.permanentIps"
+        private-dns-name="instance.privateDnsName"
+        private-ip-address="instance.privateIpAddress"
+        public-dns-name="instance.publicDnsName"
+        public-ip-address="instance.publicIpAddress"
+      >
+      </instance-dns>
     </collapsible-section>
     <instance-security-groups instance="instance"></instance-security-groups>
     <instance-tags tags="instance.tags"></instance-tags>

--- a/app/scripts/modules/amazon/src/instance/details/instanceDns.component.ts
+++ b/app/scripts/modules/amazon/src/instance/details/instanceDns.component.ts
@@ -1,0 +1,20 @@
+import { withErrorBoundary } from '@spinnaker/core';
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { InstanceDns } from './InstanceDns';
+
+export const INSTANCE_DNS_COMPONENT = 'spinnaker.application.instanceDns.component';
+
+module(INSTANCE_DNS_COMPONENT, []).component(
+  'instanceDns',
+  react2angular(withErrorBoundary(InstanceDns, 'instanceDns'), [
+    'instancePort',
+    'ipv6Addresses',
+    'permanentIps',
+    'privateDnsName',
+    'privateIpAddress',
+    'publicDnsName',
+    'publicIpAddress',
+  ]),
+);

--- a/app/scripts/modules/amazon/src/instance/index.ts
+++ b/app/scripts/modules/amazon/src/instance/index.ts
@@ -1,3 +1,4 @@
 export * from './details/utils';
+export * from './details/InstanceDns';
 export * from './details/InstanceInformation';
 export * from './amazon.instance.write.service';

--- a/app/scripts/modules/core/src/instance/details/InstanceLinks.tsx
+++ b/app/scripts/modules/core/src/instance/details/InstanceLinks.tsx
@@ -69,10 +69,10 @@ export const InstanceLinks = ({ address, application, instance, moniker, environ
     <div>
       {linkSections.map((section: LinkSection) =>
         !section.links.length ? null : (
-          <CollapsibleSection heading={section.title}>
+          <CollapsibleSection key={`link-section-${section.title}`} heading={section.title}>
             <ul>
               {section.links.map((link: Link) => (
-                <li>
+                <li key={link.title}>
                   <a href={link.url} target="_blank">
                     {link.title}
                   </a>

--- a/app/scripts/modules/titus/src/instance/details/TitusInstanceDns.tsx
+++ b/app/scripts/modules/titus/src/instance/details/TitusInstanceDns.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {
+  CollapsibleSection,
+  CopyToClipboard,
+  LabeledValue,
+  LabeledValueList,
+  LinkWithClipboard,
+} from '@spinnaker/core';
+
+export interface ITitusInstanceDnsProps {
+  containerIp: string;
+  host: string;
+  instancePort: string;
+  ipv6Address: string;
+}
+
+export const TitusInstanceDns = ({ containerIp, host, instancePort, ipv6Address }: ITitusInstanceDnsProps) => (
+  <CollapsibleSection heading="DNS" defaultExpanded={true}>
+    <LabeledValueList className="dl-horizontal dl-narrow">
+      {containerIp && (
+        <LabeledValue
+          label="Container IP"
+          value={
+            <>
+              {containerIp}
+              <CopyToClipboard text={containerIp} toolTip="Copy container IP to clipboard" />
+            </>
+          }
+        />
+      )}
+      {ipv6Address && (
+        <LabeledValue
+          label="Container IPv6"
+          value={<LinkWithClipboard text={ipv6Address} url={`http://${ipv6Address}:${instancePort}`} />}
+        />
+      )}
+      <LabeledValue label="Host IP" value={host} />
+    </LabeledValueList>
+  </CollapsibleSection>
+);

--- a/app/scripts/modules/titus/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titus/src/instance/details/instanceDetails.html
@@ -27,32 +27,12 @@
       custom-health-url="instance.customHealthUrl"
     >
     </instance-status>
-    <collapsible-section heading="DNS">
-      <dl class="dl-horizontal dl-narrow">
-        <dt ng-if="instance.placement.containerIp">Container IP</dt>
-        <dd ng-if="instance.placement.containerIp">
-          {{instance.placement.containerIp}}
-          <copy-to-clipboard
-            class="copy-to-clipboard"
-            text="instance.placement.containerIp"
-            tool-tip="'Copy container IP clipboard'"
-          >
-          </copy-to-clipboard>
-        </dd>
-        <dt ng-if="instance.ipv6Address">Container IPv6</dt>
-        <dd ng-if="instance.ipv6Address">
-          {{instance.ipv6Address}}
-          <copy-to-clipboard
-            class="copy-to-clipboard"
-            text="'http://[' + instance.ipv6Address + ']:' + state.instancePort"
-            tool-tip="'Copy container IP clipboard'"
-          >
-          </copy-to-clipboard>
-        </dd>
-        <dt>Host IP</dt>
-        <dd>{{instance.placement.host}}</dd>
-      </dl>
-    </collapsible-section>
+    <titus-instance-dns
+      container-ip="instance.placement.containerIp"
+      host="instance.placement.host"
+      instance-port="state.instancePort"
+      ipv6-address="instance.ipv6Address"
+    ></titus-instance-dns>
     <titus-security-groups
       app="application"
       server-group="serverGroup"

--- a/app/scripts/modules/titus/src/instance/details/titusInstanceDns.component.ts
+++ b/app/scripts/modules/titus/src/instance/details/titusInstanceDns.component.ts
@@ -4,7 +4,7 @@ import { react2angular } from 'react2angular';
 
 import { TitusInstanceDns } from './TitusInstanceDns';
 
-export const TITUS_INSTANCE_DNS_COMPONENT = 'spinnaker.application.titusInstanceInformation.component';
+export const TITUS_INSTANCE_DNS_COMPONENT = 'spinnaker.application.titusInstanceDns.component';
 
 module(TITUS_INSTANCE_DNS_COMPONENT, []).component(
   'titusInstanceDns',

--- a/app/scripts/modules/titus/src/instance/details/titusInstanceDns.component.ts
+++ b/app/scripts/modules/titus/src/instance/details/titusInstanceDns.component.ts
@@ -1,0 +1,17 @@
+import { withErrorBoundary } from '@spinnaker/core';
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { TitusInstanceDns } from './TitusInstanceDns';
+
+export const TITUS_INSTANCE_DNS_COMPONENT = 'spinnaker.application.titusInstanceInformation.component';
+
+module(TITUS_INSTANCE_DNS_COMPONENT, []).component(
+  'titusInstanceDns',
+  react2angular(withErrorBoundary(TitusInstanceDns, 'titusInstanceInformation'), [
+    'containerIp',
+    'host',
+    'instancePort',
+    'ipv6Address',
+  ]),
+);

--- a/app/scripts/modules/titus/src/titus.module.ts
+++ b/app/scripts/modules/titus/src/titus.module.ts
@@ -31,6 +31,7 @@ import { TITUS_PIPELINE_STAGES_SHRINKCLUSTER_TITUSSHRINKCLUSTERSTAGE } from './p
 import { TITUS_PIPELINE_STAGES_SCALEDOWNCLUSTER_TITUSSCALEDOWNCLUSTERSTAGE } from './pipeline/stages/scaleDownCluster/titusScaleDownClusterStage';
 
 import { TITUS_INSTANCE_INFORMATION_COMPONENT } from './instance/details/titusInstanceInformation.component';
+import { TITUS_INSTANCE_DNS_COMPONENT } from './instance/details/titusInstanceDns.component';
 
 // load all templates into the $templateCache
 const templates = require.context('./', true, /\.html$/);
@@ -60,6 +61,7 @@ module(TITUS_MODULE, [
   TITUS_SERVERGROUP_DETAILS_CAPACITYDETAILSSECTION,
   TITUS_SERVERGROUP_DETAILS_LAUNCHCONFIGSECTION,
   TITUS_INSTANCE_INFORMATION_COMPONENT,
+  TITUS_INSTANCE_DNS_COMPONENT,
 ]).config(() => {
   CloudProviderRegistry.registerProvider('titus', {
     name: 'Titus',


### PR DESCRIPTION
Converting the DNS section to React. The `react2angular` will be temporary until the containing instance details component is refactored as well.