### PR TITLE
refactor(eslint): Lint rules to prevent presentation import from core

### DIFF
--- a/packages/eslint-plugin/base.config.js
+++ b/packages/eslint-plugin/base.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '@spinnaker/import-from-alias-not-npm': 2,
     '@spinnaker/import-from-npm-not-alias': 2,
     '@spinnaker/import-from-npm-not-relative': 2,
+    '@spinnaker/import-from-presentation-not-core': 2,
     '@spinnaker/import-relative-within-subpackage': 2,
     '@spinnaker/migrate-to-mock-http-client': 2,
     '@spinnaker/ng-no-component-class': 2,

--- a/packages/eslint-plugin/eslint-plugin.js
+++ b/packages/eslint-plugin/eslint-plugin.js
@@ -7,6 +7,7 @@ module.exports = {
     'import-from-alias-not-npm': require('./rules/import-from-alias-not-npm'),
     'import-from-npm-not-alias': require('./rules/import-from-npm-not-alias'),
     'import-from-npm-not-relative': require('./rules/import-from-npm-not-relative'),
+    'import-from-presentation-not-core': require('./rules/import-from-presentation-not-core'),
     'import-relative-within-subpackage': require('./rules/import-relative-within-subpackage'),
     'migrate-to-mock-http-client': require('./rules/migrate-to-mock-http-client'),
     'ng-no-component-class': require('./rules/ng-no-component-class'),

--- a/packages/eslint-plugin/rules/import-from-presentation-not-core.js
+++ b/packages/eslint-plugin/rules/import-from-presentation-not-core.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const migratedPresentationModules = ['Icon', 'IconNames', 'Illustration', 'IllustrationName'];
+
+const removeImportFromCore = (context, importSpecifierNode, fixer) => {
+  const sourceCode = context.getSourceCode();
+  const fixes = [];
+
+  if (importSpecifierNode.parent.specifiers.length === 1) {
+    // The node is the only import specifier in the declaration, so remove the whole import
+    // declaration.
+    fixes.push(fixer.remove(importSpecifierNode.parent));
+  } else {
+    // Remove the import specifier.
+    fixes.push(fixer.remove(importSpecifierNode));
+    const isNextTokenComma = sourceCode.getTokenAfter(importSpecifierNode).value === ',';
+    if (isNextTokenComma) {
+      // Remove the trailing comma in the import specifier as well.
+      fixes.push(fixer.remove(sourceCode.getTokenAfter(importSpecifierNode)));
+    }
+  }
+
+  return fixes;
+};
+
+const addImportToPresentation = (context, importSpecifierNode, fixer) => {
+  const sourceCode = context.getSourceCode();
+  const fixes = [];
+
+  // Use the alias if it is available in the old import specifier.
+  const importSpecifierText =
+    importSpecifierNode.local.name === importSpecifierNode.imported.name
+      ? importSpecifierNode.imported.name
+      : `${importSpecifierNode.imported.name} as ${importSpecifierNode.local.name}`;
+
+  // Check if @spinnaker/presentation is already imported.
+  const spinnakerPresentationImport = sourceCode.ast.body.find(
+    (node) => node.type === 'ImportDeclaration' && node.source.value === '@spinnaker/presentation',
+  );
+
+  if (spinnakerPresentationImport) {
+    // If @spinnaker/presentation is already imported, then append our import specifier to the last
+    // import specifier in this import declaration.
+    const lastSpecifier = spinnakerPresentationImport.specifiers[spinnakerPresentationImport.specifiers.length - 1];
+    fixes.push(fixer.insertTextAfter(lastSpecifier, `, ${importSpecifierText}`));
+  } else {
+    // If @spinnaker/presentation import is not available, then add one as the last import declaration
+    // along with our module's import specifier.
+    const importDeclarations = sourceCode.ast.body.filter((node) => node.type === 'ImportDeclaration');
+    const lastImportDeclaration = importDeclarations[importDeclarations.length - 1];
+
+    fixes.push(
+      fixer.insertTextAfter(lastImportDeclaration, `\nimport {${importSpecifierText}} from '@spinnaker/presentation';`),
+    );
+  }
+
+  return fixes;
+};
+
+const moveImportToPresentation = (context, node, fixer) => [
+  ...removeImportFromCore(context, node, fixer),
+  ...addImportToPresentation(context, node, fixer),
+];
+
+const rule = (context) => {
+  return {
+    ImportSpecifier(node) {
+      if (migratedPresentationModules.includes(node.imported.name) && node.parent.source.value === '@spinnaker/core') {
+        const message = `${node.imported.name} must be imported from @spinnaker/presentation`;
+        const fix = (fixer) => moveImportToPresentation(context, node, fixer);
+        context.report({
+          node,
+          message,
+          fix,
+        });
+      }
+    },
+  };
+};
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: `Enforces import of presentation modules from @spinnaker/presentation`,
+    },
+    fixable: 'code',
+  },
+
+  create: rule,
+};

--- a/packages/eslint-plugin/test/import-from-presentation-not-core.spec.js
+++ b/packages/eslint-plugin/test/import-from-presentation-not-core.spec.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const ruleTester = require('../utils/ruleTester');
+const rule = require('../rules/import-from-presentation-not-core');
+const errorMessage = (moduleName) => `${moduleName} must be imported from @spinnaker/presentation`;
+
+ruleTester.run('import-from-presentation-not-core', rule, {
+  valid: [
+    { code: `import { Icon, Illustration } from '@spinnaker/presentation';` },
+    { code: `import { LabeledValueList } from '@spinnaker/core';` },
+    { code: `import { Application } from '@spinnaker/core';` },
+  ],
+  invalid: [
+    {
+      code: `
+      import { Icon, NotMigratedModule } from '@spinnaker/core';
+      import { Foo } from '@spinnaker/presentation';
+      `,
+      errors: [errorMessage('Icon')],
+      output: `
+      import {  NotMigratedModule } from '@spinnaker/core';
+      import { Foo, Icon } from '@spinnaker/presentation';
+      `,
+    },
+    {
+      code: `
+      import { Icon, NotMigratedModule } from '@spinnaker/core';
+      `,
+      errors: [errorMessage('Icon')],
+      output: `
+      import {  NotMigratedModule } from '@spinnaker/core';\nimport {Icon} from '@spinnaker/presentation';
+      `,
+    },
+    {
+      code: `
+      import React from 'react';
+      import { Icon } from '@spinnaker/core';
+      `,
+      errors: [errorMessage('Icon')],
+      output: `
+      import React from 'react';
+      \nimport {Icon} from '@spinnaker/presentation';
+      `,
+    },
+  ],
+});


### PR DESCRIPTION
If a presentation module is migrated to `@spinnaker/presentation` package, they should not be imported from `@spinnaker/core` anymore.