### PR TITLE
chore(package): amazon@0.0.288 cloudfoundry@0.0.111 core@0.0.546 titus@0.0.160

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.287",
+  "version": "0.0.288",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.110",
+  "version": "0.0.111",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.545",
+  "version": "0.0.546",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.159",
+  "version": "0.0.160",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.288

1e64d9093d864476616248c60a710f0c407f686a fix(serverGroup): Update capacity text to be more accurate (#8891)
745e1bf5592b768e733f32b6fe6d6852b955c227 refactor(aws/titus): Convert instance DNS to react (#8884)
4c6617492ad0e70e913c1608241cb0c0870e4f4e feat(amazon/loadBalancer): Enable dualstacking in ALBs/NLBs with constraints (#8859)

## cloudfoundry@0.0.111

5713c91c5e6a18cb23b6c2de125f64e418f8fbf1 feat(cloudfoundry): support docker deployments on cloudfoundry (#8864)

## core@0.0.546

745e1bf5592b768e733f32b6fe6d6852b955c227 refactor(aws/titus): Convert instance DNS to react (#8884)
b4584689dd15f66d03fed420fb62a175724b1989 feat(core): Toggle to show or hide many filter tags (#8869)
4c6617492ad0e70e913c1608241cb0c0870e4f4e feat(amazon/loadBalancer): Enable dualstacking in ALBs/NLBs with constraints (#8859)

## titus@0.0.160

745e1bf5592b768e733f32b6fe6d6852b955c227 refactor(aws/titus): Convert instance DNS to react (#8884)

PR created via `modules/publish.js`