### PR TITLE
chore(package): core@0.0.549

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.548",
+  "version": "0.0.549",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## core@0.0.549

205e164eeee964b6ede0f56d840215078760da10 fix(core/ci): Fix endpoint url typo in getJobConfig() (#8904)
e63b2abe48e65d343a369a30b66995be6c23ce03 fix(CiBuild): Allow for empty SCM information when pulling builds (#8890)

PR created via `modules/publish.js`