### PR TITLE
pluginsdk: forbid adding check-peer-dependencies as a direct dependency in a plugin

### DIFF
--- a/packages/pluginsdk/scripts/check-plugin/asserters/assertJsonFile.js
+++ b/packages/pluginsdk/scripts/check-plugin/asserters/assertJsonFile.js
@@ -1,15 +1,25 @@
-const { get } = require('lodash');
+const { get, has } = require('lodash');
 
 const assertJsonFile = (report, filename, json) => {
   return function assertJsonFile(field, expectedValue) {
-    const currentValue = get(json, field);
-    const resolution = {
-      description: `Change ${field} in ${filename} from "${currentValue}" to "${expectedValue}"`,
-      command: `npx write-json "${filename}" "${field}" "${expectedValue}"`,
-    };
-    const ok = currentValue === expectedValue;
-    report(`Unexpected value in ${filename}: ${field} should be "${expectedValue}"`, ok, resolution);
+    if (expectedValue === DELETED_FIELD) {
+      const ok = !has(json, field);
+      const resolution = {
+        description: `Delete ${field} in ${filename}`,
+        command: `npx write-json --delete "${filename}" "${field}"`,
+      };
+      report(`Unexpected property in ${filename}: ${field}`, ok, resolution);
+    } else {
+      const currentValue = get(json, field);
+      const resolution = {
+        description: `Change ${field} in ${filename} from "${currentValue}" to "${expectedValue}"`,
+        command: `npx write-json "${filename}" "${field}" "${expectedValue}"`,
+      };
+      const ok = currentValue === expectedValue;
+      report(`Unexpected value in ${filename}: ${field} should be "${expectedValue}"`, ok, resolution);
+    }
   };
 };
 
-module.exports = { assertJsonFile };
+const DELETED_FIELD = {};
+module.exports = { assertJsonFile, DELETED_FIELD };

--- a/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
+++ b/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 const { execSync } = require('child_process');
-const { assertJsonFile } = require('../asserters/assertJsonFile');
+const { assertJsonFile, DELETED_FIELD } = require('../asserters/assertJsonFile');
 const { readJson } = require('../util/readWriteJson');
 
 const PLUGIN_SDK = '@spinnaker/pluginsdk';
@@ -51,6 +51,8 @@ function checkPackageJson(report) {
 
   const checkPackageJsonField = assertJsonFile(report, 'package.json', pkgJson);
 
+  checkPackageJsonField('dependencies.check-peer-dependencies', DELETED_FIELD);
+  checkPackageJsonField('devDependencies.check-peer-dependencies', DELETED_FIELD);
   checkPackageJsonField('scripts.build', 'npm run clean && rollup -c');
   checkPackageJsonField('scripts.clean', 'npx shx rm -rf build');
   checkPackageJsonField('scripts.lint', 'eslint --ext js,jsx,ts,tsx src');

--- a/packages/pluginsdk/scripts/check-plugin/util/readWriteJson.js
+++ b/packages/pluginsdk/scripts/check-plugin/util/readWriteJson.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { set } = require('lodash');
+const { set, unset } = require('lodash');
 const stripJsonComments = require('strip-json-comments');
 
 function readJson(pathname) {
@@ -11,10 +11,16 @@ function writeJson(pathname, json) {
   fs.writeFileSync(pathname, JSON.stringify(json, null, 2));
 }
 
+function deleteJsonField(filename, field) {
+  const json = readJson(filename);
+  unset(json, field);
+  writeJson(filename, json);
+}
+
 function writeJsonField(filename, field, val) {
   const json = readJson(filename);
   set(json, field, val);
   writeJson(filename, json);
 }
 
-module.exports = { readJson, writeJson, writeJsonField };
+module.exports = { readJson, writeJson, writeJsonField, deleteJsonField };

--- a/packages/pluginsdk/scripts/write-json.js
+++ b/packages/pluginsdk/scripts/write-json.js
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
-const { writeJsonField } = require('./check-plugin/util/readWriteJson');
-const [filename, jsonPath, value] = require('yargs').argv._;
+const { writeJsonField, deleteJsonField } = require('./check-plugin/util/readWriteJson');
+
+const yargs = require('yargs').boolean('delete');
+
+const [filename, jsonPath, value] = yargs.argv._;
 
 try {
-  writeJsonField(filename, jsonPath, value);
+  if (yargs.argv.delete) {
+    deleteJsonField(filename, jsonPath);
+  } else {
+    writeJsonField(filename, jsonPath, value);
+  }
 } catch (error) {
   console.error(`Unable to write json path ${jsonPath} in file ${filename}`, error);
   process.exit(-1);


### PR DESCRIPTION
This PR will prompt the user to delete `check-peer-dependencies` from their plugin dependencies via `yarn check-plugin --fix`

I ran into an interesting case today with a plugin repo.  The `check-peer-dependencies` tooling had already been installed as a direct `devDependency` but was stuck at 1.x.  That package is also included as a direct dependency of `@spinnaker/pluginsdk` and is currently at 4.x.  Because of this, the plugin repo was not at the expected versions of  `peerDependencies`.

