### PR TITLE
fix(lint): Handle non-import declaration nodes in import-sort rule

### DIFF
--- a/packages/eslint-plugin/test/import-sort.spec.js
+++ b/packages/eslint-plugin/test/import-sort.spec.js
@@ -43,7 +43,9 @@ import * as Select from 'react-select';
     },
     {
       code: `
-import React, {useState, useCallback} from 'react';
+import React  from 'react';
+
+const {useState, useCallback} = React;
 
 import Bar from "./bar";
 import angular from 'angular';
@@ -63,7 +65,7 @@ import 'bootstrap.less';
       output: `
 import angular from 'angular';
 import 'jquery';
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 // Some comment about react-select
 import * as Select from 'react-select';
 
@@ -74,6 +76,8 @@ import Baz from '../../../test/baz';
 
 import 'bootstrap.less';
 import './styles.less';
+
+const {useState, useCallback} = React;
       `,
       errors: ['Sort the import statements'],
     },


### PR DESCRIPTION
Non-import declaration nodes found between the first and last import statements are currently just removed leading to unexpected behavior. In this commit, such nodes are collected and written back to the end of the import declarations.