### PR TITLE
chore(core): strict null checking

### DIFF
--- a/app/scripts/modules/core/tsconfig.json
+++ b/app/scripts/modules/core/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "lib",
     "rootDir": "./src",
     "typeRoots": ["../../../../node_modules/@types"],
+    "strictNullChecks": true,
     "paths": {
       "@spinnaker/core": ["."],
       "core/*": ["*"],

--- a/packages/presentation/tsconfig.json
+++ b/packages/presentation/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true
+    "strict": true,
+    "strictNullChecks": false
   }
 }


### PR DESCRIPTION
Enabling strict null checking globally introduces a lot of error, however, we can gradually enforce it everywhere