### PR TITLE
fix(core): Revert notifications saving changes

### DIFF
--- a/app/scripts/modules/core/src/notification/NotificationsList.tsx
+++ b/app/scripts/modules/core/src/notification/NotificationsList.tsx
@@ -1,15 +1,14 @@
+import React from 'react';
+import { Observable, Subject } from 'rxjs';
 import classNames from 'classnames';
 import { capitalize, filter, flatten, get, isEmpty } from 'lodash';
-import React from 'react';
 
 import { Application } from 'core/application';
 import { INotification, INotificationTypeConfig } from 'core/domain';
-import { useData } from 'core/presentation';
 import { Registry } from 'core/registry';
-
-import { AppNotificationsService, IAppNotifications } from './AppNotificationsService';
-import { EditNotificationModal } from './modal/EditNotificationModal';
+import { AppNotificationsService } from './AppNotificationsService';
 import { NotificationTransformer } from './notification.transformer';
+import { EditNotificationModal } from './modal/EditNotificationModal';
 
 export interface INotificationsListProps {
   application?: Application;
@@ -21,197 +20,228 @@ export interface INotificationsListProps {
   updateNotifications: (notifications: INotification[]) => void;
 }
 
-export const NotificationsList = ({
-  application,
-  level,
-  notifications,
-  stageType,
-  sendNotifications,
-  handleSendNotificationsChanged,
-  updateNotifications,
-}: INotificationsListProps) => {
-  const [isDirty, setIsDirty] = React.useState<boolean>(false);
-  const [indexEdited, setIndexEdited] = React.useState<number>(null);
+export interface INotificationsListState {
+  isNotificationsDirty: boolean;
+  supportedNotificationTypes: string[];
+}
 
-  const supportedNotificationTypes = React.useMemo(
-    () => Registry.pipeline.getNotificationTypes().map((type: INotificationTypeConfig) => type.key),
-    [],
-  );
-  const { result: appNotifications, refresh: refreshAppNotifications } = useData(
-    () => AppNotificationsService.getNotificationsForApplication(application.name),
-    {} as IAppNotifications,
-    [application.name],
-  );
+export class NotificationsList extends React.Component<INotificationsListProps, INotificationsListState> {
+  private destroy$ = new Subject();
 
-  const transfromNotifications = () => {
-    /** Transforms the notifications to a table friendly format */
-    const results = filter(
-      flatten(
-        supportedNotificationTypes.map((type) => {
-          return get(appNotifications, type) || [];
-        }),
-      ),
-      (allow) => allow !== undefined && allow.level === 'application',
-    );
-    updateNotifications(results);
-    setIsDirty(false);
-  };
-
-  const editNotification = (newNotification: INotification) => {
-    let notificationsToSave = notifications || [];
-    if (indexEdited || indexEdited === 0) {
-      notificationsToSave[indexEdited] = newNotification;
-    } else {
-      notificationsToSave = notificationsToSave.concat(newNotification);
-    }
-    setIsDirty(true);
-    setIndexEdited(null);
-
-    return saveNotifications(notificationsToSave);
-  };
-
-  const addNotification = () => openEditModal();
-
-  const removeNotification = (index: number) => {
-    const newNotifications = [...notifications];
-    newNotifications.splice(index, 1);
-    updateNotifications(newNotifications);
-    setIsDirty(true);
-  };
-
-  const saveNotifications = (newNotifications: INotification[]) => {
-    const toSaveNotifications: IAppNotifications = {
-      application: application.name,
+  constructor(props: INotificationsListProps) {
+    super(props);
+    this.state = {
+      isNotificationsDirty: false,
+      supportedNotificationTypes: Registry.pipeline
+        .getNotificationTypes()
+        .map((type: INotificationTypeConfig) => type.key),
     };
+  }
 
-    newNotifications.forEach((n) => {
-      if (isEmpty(get(toSaveNotifications, n.type))) {
-        toSaveNotifications[n.type] = [];
-      }
-      (toSaveNotifications[n.type] as INotification[]).push(n);
-    });
+  public componentDidMount() {
+    if (this.props.level === 'application') {
+      this.revertNotificationChanges();
+    }
+  }
 
-    return AppNotificationsService.saveNotificationsForApplication(application.name, toSaveNotifications).then(() =>
-      refreshAppNotifications(),
-    );
+  public componentWillUnmount() {
+    this.destroy$.next();
+  }
+
+  private addNotification = () => {
+    this.editNotification();
   };
 
-  const openEditModal = (notification?: INotification, index?: number) => {
-    setIndexEdited(index);
+  private editNotification = (notification?: INotification, index?: number) => {
+    const { level, notifications, stageType, updateNotifications } = this.props;
     EditNotificationModal.show({
       notification: notification || { level, when: [] },
       level: level,
       stageType,
-      editNotification,
+    })
+      .then((newNotification) => {
+        const notificationsCopy = notifications || [];
+        if (!notification) {
+          updateNotifications(notificationsCopy.concat(newNotification));
+        } else {
+          const update = [...notificationsCopy];
+          update[index] = newNotification;
+          updateNotifications(update);
+        }
+        this.setState({ isNotificationsDirty: true });
+      })
+      .catch(() => {});
+  };
+
+  private removeNotification = (index: number) => {
+    const notifications = [...this.props.notifications];
+    notifications.splice(index, 1);
+    this.props.updateNotifications(notifications);
+    this.setState({
+      isNotificationsDirty: true,
     });
   };
 
-  React.useEffect(() => {
-    if (level === 'application') {
-      transfromNotifications();
-    }
-  }, []);
+  private revertNotificationChanges = () => {
+    /*
+      we currently store application level notifications in front50 as a map indexed by type
+      {
+           "application": "ayuda",
+           "email": [ { ... } ]
+      }
+      the code below unwraps it into a table friendly format and the saveNotifications code will
+      write it back into the right format.
 
-  React.useEffect(() => {
-    transfromNotifications();
-  }, [appNotifications]);
+      We will change the format in front50 when we rewrite notifications to use CQL so this transformation
+      is no longer needed
+   */
+    const { application, updateNotifications } = this.props;
+    const { supportedNotificationTypes } = this.state;
+    Observable.fromPromise(AppNotificationsService.getNotificationsForApplication(application.name))
+      .takeUntil(this.destroy$)
+      .subscribe((notifications) => {
+        const results = filter(
+          flatten(
+            supportedNotificationTypes.map((type) => {
+              return get(notifications, type) || [];
+            }),
+          ),
+          (allow) => allow !== undefined && allow.level === 'application',
+        );
+        updateNotifications(results);
+      });
+    this.setState({ isNotificationsDirty: false });
+  };
 
-  return (
-    <>
-      {level === 'stage' && stageType !== 'manualJudgment' && (
-        <div className="form-group">
-          <div className="col-md-9 col-md-offset-1">
-            <div className="checkbox">
-              <label>
-                <input type="checkbox" onChange={handleSendNotificationsChanged} checked={sendNotifications} />
-                <strong>Send notifications for this stage</strong>
-              </label>
+  private saveNotifications = () => {
+    const { application, notifications } = this.props;
+    const toSaveNotifications: any = {
+      application: application.name,
+    };
+
+    notifications.forEach((n) => {
+      if (isEmpty(get(toSaveNotifications, n.type))) {
+        toSaveNotifications[n.type] = [];
+      }
+      toSaveNotifications[n.type].push(n);
+    });
+
+    Observable.fromPromise(
+      AppNotificationsService.saveNotificationsForApplication(application.name, toSaveNotifications),
+    )
+      .takeUntil(this.destroy$)
+      .subscribe(() => {
+        this.revertNotificationChanges();
+      });
+  };
+
+  public render() {
+    const { level, handleSendNotificationsChanged, notifications, sendNotifications, stageType } = this.props;
+    const { isNotificationsDirty } = this.state;
+    return (
+      <>
+        {level === 'stage' && stageType !== 'manualJudgment' && (
+          <div className="form-group">
+            <div className="col-md-9 col-md-offset-1">
+              <div className="checkbox">
+                <label>
+                  <input type="checkbox" onChange={handleSendNotificationsChanged} checked={sendNotifications} />
+                  <strong>Send notifications for this stage</strong>
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      )}
-      {(level !== 'stage' || sendNotifications) && (
-        <div className="row">
-          <div className={'col-md-12'}>
-            <table className="table table-condensed">
-              {notifications && notifications.length > 0 && (
-                <thead>
+        )}
+        {(level !== 'stage' || sendNotifications) && (
+          <div className="row">
+            <div className={'col-md-12'}>
+              <table className="table table-condensed">
+                {notifications && notifications.length > 0 && (
+                  <thead>
+                    <tr>
+                      <th>Type</th>
+                      <th>Details</th>
+                      <th>Notify When</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                )}
+                <tbody>
+                  {notifications &&
+                    notifications.map((n, i) => {
+                      return (
+                        <tr key={i} className={classNames({ 'templated-pipeline-item': n.inherited })}>
+                          <td>{capitalize(n.type)}</td>
+                          <td>{NotificationTransformer.getNotificationDetails(n)}</td>
+                          <td>
+                            {n.when &&
+                              n.when.map((w, k) => (
+                                <div key={k}>
+                                  {NotificationTransformer.getNotificationWhenDisplayName(w, level, stageType)}
+                                </div>
+                              ))}
+                          </td>
+                          <td>
+                            {!n.inherited && (
+                              <>
+                                <button className="btn btn-xs btn-link" onClick={() => this.editNotification(n, i)}>
+                                  Edit
+                                </button>
+                                <button
+                                  className="btn btn-xs btn-link pad-left"
+                                  onClick={() => this.removeNotification(i)}
+                                >
+                                  Remove
+                                </button>
+                              </>
+                            )}
+                            {n.inherited && <span className="btn btn-xs pad-left">Inherited from template</span>}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                </tbody>
+                <tfoot>
                   <tr>
-                    <th>Type</th>
-                    <th>Details</th>
-                    <th>Notify When</th>
-                    <th>Actions</th>
+                    <td colSpan={7}>
+                      <button className="btn btn-block add-new" onClick={() => this.addNotification()}>
+                        <span className="glyphicon glyphicon-plus-sign" /> Add Notification Preference
+                      </button>
+                    </td>
                   </tr>
-                </thead>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+        )}
+        {level === 'application' && (
+          <div className="row main-footer">
+            <div className="col-md-3">
+              {isNotificationsDirty && (
+                <button
+                  className="btn btn-default"
+                  onClick={() => this.revertNotificationChanges()}
+                  style={{ visibility: 'visible' }}
+                >
+                  <span className="glyphicon glyphicon-flash" /> Revert
+                </button>
               )}
-              <tbody>
-                {notifications &&
-                  notifications.map((n, i) => {
-                    return (
-                      <tr key={i} className={classNames({ 'templated-pipeline-item': n.inherited })}>
-                        <td>{capitalize(n.type)}</td>
-                        <td>{NotificationTransformer.getNotificationDetails(n)}</td>
-                        <td>
-                          {n.when &&
-                            n.when.map((w, k) => (
-                              <div key={k}>
-                                {NotificationTransformer.getNotificationWhenDisplayName(w, level, stageType)}
-                              </div>
-                            ))}
-                        </td>
-                        <td>
-                          {!n.inherited && (
-                            <>
-                              <button className="btn btn-xs btn-link" onClick={() => openEditModal(n, i)}>
-                                Edit
-                              </button>
-                              <button className="btn btn-xs btn-link pad-left" onClick={() => removeNotification(i)}>
-                                Remove
-                              </button>
-                            </>
-                          )}
-                          {n.inherited && <span className="btn btn-xs pad-left">Inherited from template</span>}
-                        </td>
-                      </tr>
-                    );
-                  })}
-              </tbody>
-              <tfoot>
-                <tr>
-                  <td colSpan={7}>
-                    <button className="btn btn-block add-new" onClick={() => addNotification()}>
-                      <span className="glyphicon glyphicon-plus-sign" /> Add Notification Preference
-                    </button>
-                  </td>
-                </tr>
-              </tfoot>
-            </table>
+            </div>
+            <div className="col-md-9 text-right">
+              {isNotificationsDirty && (
+                <button className="btn btn-primary" onClick={() => this.saveNotifications()}>
+                  <span className="far fa-check-circle" /> Save Changes
+                </button>
+              )}
+              {isNotificationsDirty === false && (
+                <span className="btn btn-link disabled">
+                  <span className="far fa-check-circle" /> In sync with server
+                </span>
+              )}
+            </div>
           </div>
-        </div>
-      )}
-      {level === 'application' && (
-        <div className="row main-footer">
-          <div className="col-md-3">
-            {isDirty && (
-              <button className="btn btn-default" onClick={transfromNotifications} style={{ visibility: 'visible' }}>
-                <span className="glyphicon glyphicon-flash" /> Revert
-              </button>
-            )}
-          </div>
-          <div className="col-md-9 text-right">
-            {isDirty && (
-              <button className="btn btn-primary" onClick={() => saveNotifications(notifications)}>
-                <span className="far fa-check-circle" /> Save Changes
-              </button>
-            )}
-            {!isDirty && (
-              <span className="btn btn-link disabled">
-                <span className="far fa-check-circle" /> In sync with server
-              </span>
-            )}
-          </div>
-        </div>
-      )}
-    </>
-  );
-};
+        )}
+      </>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/notification/NotificationsList.tsx
+++ b/app/scripts/modules/core/src/notification/NotificationsList.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import { Observable, Subject } from 'rxjs';
 import classNames from 'classnames';
 import { capitalize, filter, flatten, get, isEmpty } from 'lodash';
+import React from 'react';
+import { Observable, Subject } from 'rxjs';
 
 import { Application } from 'core/application';
 import { INotification, INotificationTypeConfig } from 'core/domain';
 import { Registry } from 'core/registry';
+
 import { AppNotificationsService } from './AppNotificationsService';
-import { NotificationTransformer } from './notification.transformer';
 import { EditNotificationModal } from './modal/EditNotificationModal';
+import { NotificationTransformer } from './notification.transformer';
 
 export interface INotificationsListProps {
   application?: Application;

--- a/app/scripts/modules/core/src/notification/modal/EditNotificationModal.tsx
+++ b/app/scripts/modules/core/src/notification/modal/EditNotificationModal.tsx
@@ -12,29 +12,13 @@ export interface IEditNotificationModalProps extends IModalComponentProps {
   level: string;
   notification: INotification;
   stageType: string;
-  editNotification: (n: INotification) => Promise<INotification[]>;
 }
 
-export interface IEditNotificationModalState {
-  isSubmitting: boolean;
-}
-
-export class EditNotificationModal extends React.Component<IEditNotificationModalProps, IEditNotificationModalState> {
-  constructor(props: IEditNotificationModalProps) {
-    super(props);
-    this.state = {
-      isSubmitting: false,
-    };
-  }
-
+export class EditNotificationModal extends React.Component<IEditNotificationModalProps> {
   private formikRef = React.createRef<Formik<any>>();
 
   private submit = (values: INotification): void => {
-    this.setState({ isSubmitting: true });
-    this.props.editNotification(values).then(() => {
-      this.setState({ isSubmitting: false });
-      this.props.closeModal();
-    });
+    this.props.closeModal(values);
   };
 
   public static show(props: any): Promise<INotification> {
@@ -76,12 +60,7 @@ export class EditNotificationModal extends React.Component<IEditNotificationModa
               <button className="btn btn-default" onClick={dismissModal} type="button">
                 Cancel
               </button>
-              <SubmitButton
-                isDisabled={!formik.isValid}
-                isFormSubmit={true}
-                submitting={false}
-                label={'Save Changes'}
-              />
+              <SubmitButton isDisabled={!formik.isValid} isFormSubmit={true} submitting={false} label={'Update'} />
             </Modal.Footer>
           </Form>
         )}


### PR DESCRIPTION
These updates are not compatible with the pipeline notifications. App level notifications and pipeline level notifications are persisted differently. The path of promise chaining to avoid a dual-save for applications, was not consistent with updating the pipeline notification then later saving the entire pipeline config. 

I will revisit this later. It probably requires a different set of methods for each notification level. 