### PR TITLE
chore: make sort-imports rule a warning, rather than an error

### DIFF
--- a/packages/eslint-plugin/base.config.js
+++ b/packages/eslint-plugin/base.config.js
@@ -4,7 +4,7 @@ module.exports = {
   plugins: ['@typescript-eslint', '@spinnaker/eslint-plugin', 'react-hooks', 'prettier'],
   extends: ['eslint:recommended', 'prettier', 'prettier/@typescript-eslint', 'plugin:@typescript-eslint/recommended'],
   rules: {
-    '@spinnaker/import-sort': 2,
+    '@spinnaker/import-sort': 1,
     '@spinnaker/api-deprecation': 2,
     '@spinnaker/api-no-slashes': 2,
     '@spinnaker/api-no-unused-chaining': 2,


### PR DESCRIPTION
1) When doing local development, it's annoying that webpack-dev-server doesn't reload if there are any eslint errors. 
2) Marking this rule as a warning seems reasonable anyway
