### PR TITLE
feat(core/notifications): Save app notifications when modal is submitted

### DIFF
--- a/app/scripts/modules/core/src/notification/modal/EditNotificationModal.tsx
+++ b/app/scripts/modules/core/src/notification/modal/EditNotificationModal.tsx
@@ -12,13 +12,33 @@ export interface IEditNotificationModalProps extends IModalComponentProps {
   level: string;
   notification: INotification;
   stageType: string;
+  editNotification?: (n: INotification) => Promise<INotification>;
 }
 
-export class EditNotificationModal extends React.Component<IEditNotificationModalProps> {
+export interface IEditNotificationModalState {
+  isSubmitting: boolean;
+}
+
+export class EditNotificationModal extends React.Component<IEditNotificationModalProps, IEditNotificationModalState> {
+  constructor(props: IEditNotificationModalProps) {
+    super(props);
+    this.state = {
+      isSubmitting: false,
+    };
+  }
+
   private formikRef = React.createRef<Formik<any>>();
 
   private submit = (values: INotification): void => {
-    this.props.closeModal(values);
+    if (this.props.editNotification) {
+      this.setState({ isSubmitting: true });
+      this.props.editNotification(values).then(() => {
+        this.setState({ isSubmitting: false });
+        this.props.closeModal();
+      });
+    } else {
+      this.props.closeModal(values);
+    }
   };
 
   public static show(props: any): Promise<INotification> {
@@ -60,7 +80,12 @@ export class EditNotificationModal extends React.Component<IEditNotificationModa
               <button className="btn btn-default" onClick={dismissModal} type="button">
                 Cancel
               </button>
-              <SubmitButton isDisabled={!formik.isValid} isFormSubmit={true} submitting={false} label={'Update'} />
+              <SubmitButton
+                isDisabled={!formik.isValid}
+                isFormSubmit={true}
+                submitting={this.state.isSubmitting}
+                label={'Update'}
+              />
             </Modal.Footer>
           </Form>
         )}


### PR DESCRIPTION
**Current Behavior**
1. In application config the user clicks add/edit notification and a modal opens
2. The user makes changes and clicks "Update" in the modal, which updates the pipelin config locally
3. The modal closes
4. The user also has to click "Save" to persist these changes on the BE

Have to click and "Update" and "Save" often leads to confusion. The users will "Update" via teh modal then navigate away from the page before actually persisting the new information. The current user flow makes more sense for the pipeline and stage notifications, so this PR only updates the user flow for application-level notifications.

**New Behavior**
1. In application config the user clicks add/edit notification and a modal opens
2. The user makes changes and clicks "Update" in the modal, which persists the state
3. The modal closes and no other actions are needed
