### PR TITLE
fix(amazon): Instance DNS hrefs when Instance Port is not defined

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/InstanceDns.tsx
+++ b/app/scripts/modules/amazon/src/instance/details/InstanceDns.tsx
@@ -24,47 +24,50 @@ export const InstanceDns = ({
   privateIpAddress,
   publicDnsName,
   publicIpAddress,
-}: IInstanceDnsProps) => (
-  <LabeledValueList className="horizontal-when-filters-collapsed">
-    {privateDnsName && (
-      <LabeledValue
-        label="Private DNS Name"
-        value={<LinkWithClipboard text={privateDnsName} url={`http://${privateDnsName}:${instancePort}`} />}
-      />
-    )}
-    {publicDnsName && (
-      <LabeledValue
-        label="Public DNS Name"
-        value={<LinkWithClipboard text={publicDnsName} url={`http://${publicDnsName}:${instancePort}`} />}
-      />
-    )}
-    {privateIpAddress && (
-      <LabeledValue
-        label="Private IP Address"
-        value={<LinkWithClipboard text={privateIpAddress} url={`http://${privateIpAddress}:${instancePort}`} />}
-      />
-    )}
-    {Boolean(permanentIps?.length) && (
-      <LabeledValue
-        label="Permanent IP Address"
-        value={permanentIps.map((ip) => (
-          <LinkWithClipboard key={ip} text={ip} url={`http://${ip}:${instancePort}`} />
-        ))}
-      />
-    )}
-    {publicIpAddress && (
-      <LabeledValue
-        label="Public IP Address"
-        value={<LinkWithClipboard text={publicIpAddress} url={`http://${publicIpAddress}:${instancePort}`} />}
-      />
-    )}
-    {Boolean(ipv6Addresses?.length) && (
-      <LabeledValue
-        label={`IPv6 Address${ipv6Addresses.length > 1 ? 'es' : ''}`}
-        value={ipv6Addresses.map((ipv6) => (
-          <LinkWithClipboard key={ipv6.ip} text={ipv6.ip} url={ipv6.url} />
-        ))}
-      />
-    )}
-  </LabeledValueList>
-);
+}: IInstanceDnsProps) => {
+  const portSuffix = instancePort ? `:${instancePort}` : '';
+  return (
+    <LabeledValueList className="horizontal-when-filters-collapsed">
+      {privateDnsName && (
+        <LabeledValue
+          label="Private DNS Name"
+          value={<LinkWithClipboard text={privateDnsName} url={`http://${privateDnsName}${portSuffix}`} />}
+        />
+      )}
+      {publicDnsName && (
+        <LabeledValue
+          label="Public DNS Name"
+          value={<LinkWithClipboard text={publicDnsName} url={`http://${publicDnsName}${portSuffix}`} />}
+        />
+      )}
+      {privateIpAddress && (
+        <LabeledValue
+          label="Private IP Address"
+          value={<LinkWithClipboard text={privateIpAddress} url={`http://${privateIpAddress}${portSuffix}`} />}
+        />
+      )}
+      {Boolean(permanentIps?.length) && (
+        <LabeledValue
+          label="Permanent IP Address"
+          value={permanentIps.map((ip) => (
+            <LinkWithClipboard key={ip} text={ip} url={`http://${ip}${portSuffix}`} />
+          ))}
+        />
+      )}
+      {publicIpAddress && (
+        <LabeledValue
+          label="Public IP Address"
+          value={<LinkWithClipboard text={publicIpAddress} url={`http://${publicIpAddress}${portSuffix}`} />}
+        />
+      )}
+      {Boolean(ipv6Addresses?.length) && (
+        <LabeledValue
+          label={`IPv6 Address${ipv6Addresses.length > 1 ? 'es' : ''}`}
+          value={ipv6Addresses.map((ipv6) => (
+            <LinkWithClipboard key={ipv6.ip} text={ipv6.ip} url={ipv6.url} />
+          ))}
+        />
+      )}
+    </LabeledValueList>
+  );
+};


### PR DESCRIPTION
When the instance port is not defined, the href looks like this: `http://{ip}:undefined`. This PR fixes that.