### PR TITLE
chore(lint): Remove lint rule for prettier

### DIFF
--- a/packages/eslint-plugin/base.config.js
+++ b/packages/eslint-plugin/base.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: { sourceType: 'module' },
-  plugins: ['@typescript-eslint', '@spinnaker/eslint-plugin', 'react-hooks', 'prettier'],
+  plugins: ['@typescript-eslint', '@spinnaker/eslint-plugin', 'react-hooks'],
   extends: ['eslint:recommended', 'prettier', 'prettier/@typescript-eslint', 'plugin:@typescript-eslint/recommended'],
   rules: {
     '@spinnaker/import-sort': 2,
@@ -32,7 +32,6 @@ module.exports = {
     'prefer-spread': 'off',
     // turn back on if https://github.com/eslint/eslint/issues/11899 fixes false positives
     'require-atomic-updates': 'off',
-    'prettier/prettier': 'error',
     'react-hooks/rules-of-hooks': 'error',
     // turn back on after addressing all violations
     // 'react-hooks/exhaustive-deps': 'warn',

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/eslint-plugin",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "eslint-plugin.js",
   "license": "Apache-2.0",
   "scripts": {
@@ -14,7 +14,6 @@
     "@types/eslint": "^7.2.5",
     "@types/estree": "^0.0.45",
     "@types/lodash": "^4.14.165",
-    "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3"
   },
   "peerDependencies": {

--- a/packages/eslint-plugin/yarn.lock
+++ b/packages/eslint-plugin/yarn.lock
@@ -1408,13 +1408,6 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-prettier@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
-  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -1541,11 +1534,6 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -2954,13 +2942,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
IDEs run eslint eagerly and seeing prettier lint errors pop-up aggressively results in a poor dev experience. So removing the prettier linter here.