### PR TITLE
chore(md): Enable TS strict null check in MD (only in IDE)

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -97,37 +97,41 @@ export interface IPinned {
   comment?: string;
 }
 
+export interface IManagedArtifactVersionEnvironment {
+  name: string;
+  state: 'current' | 'deploying' | 'approved' | 'pending' | 'previous' | 'vetoed' | 'skipped';
+  pinned?: IPinned;
+  vetoed?: {
+    at: string;
+    by: string;
+    comment?: string;
+  };
+  deployedAt?: string;
+  replacedAt?: string;
+  replacedBy?: string;
+  statefulConstraints?: IStatefulConstraint[];
+  statelessConstraints?: IStatelessConstraint[];
+  compareLink?: string;
+  verifications?: IVerification[];
+}
+
+export interface IManagedArtifactVersionLifecycleStep {
+  // likely more scopes + types later, but hard-coding to avoid premature abstraction for now
+  scope: 'PRE_DEPLOYMENT';
+  type: 'BUILD' | 'BAKE';
+  id: string;
+  status: 'NOT_STARTED' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'ABORTED' | 'UNKNOWN';
+  startedAt?: string;
+  completedAt?: string;
+  link?: string;
+}
+
 export interface IManagedArtifactVersion {
   version: string;
   displayName: string;
   createdAt?: string;
-  environments: Array<{
-    name: string;
-    state: 'current' | 'deploying' | 'approved' | 'pending' | 'previous' | 'vetoed' | 'skipped';
-    pinned?: IPinned;
-    vetoed?: {
-      at: string;
-      by: string;
-      comment?: string;
-    };
-    deployedAt?: string;
-    replacedAt?: string;
-    replacedBy?: string;
-    statefulConstraints?: IStatefulConstraint[];
-    statelessConstraints?: IStatelessConstraint[];
-    compareLink?: string;
-    verifications?: IVerification[];
-  }>;
-  lifecycleSteps?: Array<{
-    // likely more scopes + types later, but hard-coding to avoid premature abstraction for now
-    scope: 'PRE_DEPLOYMENT';
-    type: 'BUILD' | 'BAKE';
-    id: string;
-    status: 'NOT_STARTED' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'ABORTED' | 'UNKNOWN';
-    startedAt?: string;
-    completedAt?: string;
-    link?: string;
-  }>;
+  environments: IManagedArtifactVersionEnvironment[];
+  lifecycleSteps?: IManagedArtifactVersionLifecycleStep[];
   build?: {
     id: number; // deprecated, use number
     number: string;
@@ -160,9 +164,6 @@ export interface IManagedArtifactVersion {
     };
   };
 }
-
-export type IManagedArtifactVersionEnvironment = IManagedArtifactSummary['versions'][0]['environments'][0];
-export type IManagedArtifactVersionLifecycleStep = IManagedArtifactSummary['versions'][0]['lifecycleSteps'][0];
 
 export interface IManagedArtifactSummary {
   name: string;

--- a/app/scripts/modules/core/src/managed/AbsoluteTimestamp.tsx
+++ b/app/scripts/modules/core/src/managed/AbsoluteTimestamp.tsx
@@ -13,7 +13,7 @@ const TIMEZONE = SETTINGS.feature.displayTimestampsInUserLocalTime ? undefined :
 
 export const AbsoluteTimestamp = memo(
   ({ timestamp: timestampInOriginalZone, clickToCopy }: IAbsoluteTimestampProps) => {
-    const timestamp = timestampInOriginalZone.setZone(TIMEZONE);
+    const timestamp = TIMEZONE ? timestampInOriginalZone.setZone(TIMEZONE) : timestampInOriginalZone;
 
     const fullTimestamp = timestamp.toFormat('yyyy-MM-dd HH:mm:ss ZZZZ');
     const formattedTimestamp = timestamp.toFormat('MMM d, y HH:mm');

--- a/app/scripts/modules/core/src/managed/Button.tsx
+++ b/app/scripts/modules/core/src/managed/Button.tsx
@@ -17,9 +17,9 @@ export interface IButtonProps {
 export const Button = ({ iconName, appearance = DEFAULT_APPEARANCE, disabled, onClick, children }: IButtonProps) => {
   return (
     <button
-      disabled={disabled ?? null}
+      disabled={disabled}
       className={`flex-container-h center middle text-bold action-button action-button-${appearance}`}
-      onClick={onClick ?? null}
+      onClick={onClick}
     >
       {iconName && (
         <div className="sp-margin-s-right flex-container-h center middle">

--- a/app/scripts/modules/core/src/managed/DeployingIntoManagedClusterWarning.tsx
+++ b/app/scripts/modules/core/src/managed/DeployingIntoManagedClusterWarning.tsx
@@ -17,6 +17,7 @@ export const DeployingIntoManagedClusterWarning = ({ app, formik }: IDeployingIn
   const command = formik.values;
   const pauseResource = React.useCallback(() => {
     const { resourceSummary, backingData } = formik.values;
+    if (!resourceSummary) return;
     toggleResourcePause(resourceSummary, app).then(
       () => {
         backingData.managedResources = app.getDataSource('managedResources')?.data?.resources;

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -88,8 +88,8 @@ export const Environments: React.FC<IEnvironmentsProps> = ({ app }) => {
     [environments, resourcesById],
   );
 
-  const selectedVersion = useMemo<ISelectedArtifactVersion>(
-    () => (params.version ? pick(params, ['reference', 'version']) : null),
+  const selectedVersion = useMemo<ISelectedArtifactVersion | undefined>(
+    () => (params.version ? (pick(params, ['reference', 'version']) as ISelectedArtifactVersion) : undefined),
     [params.reference, params.version],
   );
   const selectedArtifactDetails = useMemo(
@@ -97,7 +97,7 @@ export const Environments: React.FC<IEnvironmentsProps> = ({ app }) => {
     [selectedVersion?.reference, artifacts],
   );
   const selectedVersionDetails = useMemo(
-    () => selectedArtifactDetails?.versions.find(({ version }) => version === selectedVersion.version),
+    () => selectedArtifactDetails?.versions.find(({ version }) => version === selectedVersion?.version),
     [selectedVersion, selectedArtifactDetails],
   );
 
@@ -181,7 +181,9 @@ export const Environments: React.FC<IEnvironmentsProps> = ({ app }) => {
         )}
         {detailPaneTransition.map(
           ({ item, key, props }) =>
-            item.selectedVersion && (
+            item.selectedVersion &&
+            item.selectedArtifactDetails &&
+            item.selectedVersionDetails && (
               <animated.div key={key} className="environments-pane flex-container-v" style={props}>
                 <ArtifactDetail
                   application={app}

--- a/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
@@ -44,9 +44,9 @@ export function EnvironmentsList({
               .map((resource) => {
                 const artifactVersionsByState =
                   resource.artifact &&
-                  artifacts.find(({ reference }) => reference === resource.artifact.reference)?.versions;
+                  artifacts.find(({ reference }) => reference === resource.artifact?.reference)?.versions;
                 const artifactDetails =
-                  resource.artifact && allArtifacts.find(({ reference }) => reference === resource.artifact.reference);
+                  resource.artifact && allArtifacts.find(({ reference }) => reference === resource.artifact?.reference);
                 return (
                   <ManagedResourceObject
                     application={application}

--- a/app/scripts/modules/core/src/managed/ManagedMenuItem.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedMenuItem.tsx
@@ -18,14 +18,15 @@ export const ManagedMenuItem = ({ resource, application, onClick, children }: IM
   if (!resource) {
     return null;
   }
-  const resourceIsPaused = resource.isManaged && resource.managedResourceSummary.isPaused;
+  const resourceIsPaused =
+    resource.isManaged && (!resource.managedResourceSummary || resource.managedResourceSummary.isPaused);
   const appIsPaused = application.isManagementPaused;
   const showInterstitial = resource.isManaged && !resourceIsPaused && !appIsPaused;
   const interstitial: () => PromiseLike<boolean> = () =>
     showInterstitial ? confirmNotManaged(resource, application) : $q.when(true);
   const handleClick: () => void = () =>
     interstitial().then((isNotManaged) => {
-      isNotManaged && onClick();
+      isNotManaged && onClick?.();
     });
 
   return <MenuItem onClick={handleClick}>{children}</MenuItem>;

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -31,8 +31,9 @@ export const getResourceKindForLoadBalancerType = (type: string) => {
   }
 };
 
-const transformManagedResourceDiff = (diff: IManagedResourceEventHistoryResponse[0]['delta']): IManagedResourceDiff =>
-  Object.keys(diff).reduce((transformed, key) => {
+const transformManagedResourceDiff = (diff: IManagedResourceEventHistoryResponse[0]['delta']): IManagedResourceDiff => {
+  if (!diff) return {};
+  return Object.keys(diff).reduce((transformed, key) => {
     const diffNode = diff[key];
     const fieldKeys = flatMap<string, string>(key.split('/').filter(Boolean), (fieldKey) => {
       // Region keys currently come wrapped in {}, which is distracting and not useful. Let's trim those off.
@@ -66,6 +67,7 @@ const transformManagedResourceDiff = (diff: IManagedResourceEventHistoryResponse
     });
     return transformed;
   }, {} as IManagedResourceDiff);
+};
 
 export class ManagedReader {
   private static decorateResources(response: IManagedApplicationSummary) {

--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
@@ -58,8 +58,9 @@ export const ManagedResourceDetailsIndicator = ({
   // events are getting trapped by React bootstrap menu
   const allowNavigation = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
-    if (target && target.hasAttribute('href')) {
-      window.location.href = target.getAttribute('href');
+    const href = target?.getAttribute('href');
+    if (href) {
+      window.location.href = href;
     }
   };
 

--- a/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
@@ -79,9 +79,9 @@ export const ManagedResourceObject = memo(
 
     const linkProps = routeProps.href ? routeProps : displayLinkProps;
 
-    const current =
-      artifactVersionsByState?.current &&
-      artifactDetails?.versions.find(({ version }) => version === artifactVersionsByState?.current);
+    const current = artifactVersionsByState?.current
+      ? artifactDetails?.versions.find(({ version }) => version === artifactVersionsByState?.current)
+      : undefined;
     const deploying =
       artifactVersionsByState?.deploying &&
       artifactDetails?.versions.find(({ version }) => version === artifactVersionsByState?.deploying);
@@ -89,9 +89,9 @@ export const ManagedResourceObject = memo(
     const isCurrentVersionPinned = !!current?.environments.find(({ name }) => name === environment)?.pinned;
     const currentPill = current && (
       <Pill
-        text={`${getArtifactVersionDisplayName(current)}${showReferenceName ? ' ' + artifactDetails.reference : ''}`}
-        bgColor={isCurrentVersionPinned ? 'var(--color-status-warning)' : null}
-        textColor={isCurrentVersionPinned ? 'var(--color-icon-dark)' : null}
+        text={`${getArtifactVersionDisplayName(current)}${showReferenceName ? ' ' + artifactDetails?.reference : ''}`}
+        bgColor={isCurrentVersionPinned ? 'var(--color-status-warning)' : undefined}
+        textColor={isCurrentVersionPinned ? 'var(--color-icon-dark)' : undefined}
       />
     );
     const deployingPill = deploying && (
@@ -99,7 +99,7 @@ export const ManagedResourceObject = memo(
         <Icon appearance="neutral" name="caretRight" size="medium" />
         <AnimatingPill
           text={`${getArtifactVersionDisplayName(deploying)}${
-            showReferenceName ? ' ' + artifactDetails.reference : ''
+            showReferenceName ? ' ' + artifactDetails?.reference : ''
           }`}
           textColor="var(--color-icon-neutral)"
         />
@@ -107,11 +107,12 @@ export const ManagedResourceObject = memo(
     );
 
     const viewConfig = viewConfigurationByStatus[resource.status];
-    const resourceStatus = resource.status !== 'HAPPY' && viewConfig && (
-      <ManagedResourceStatusPopover application={application} placement="left" resourceSummary={resource}>
-        <StatusBubble appearance={viewConfig.appearance} iconName={viewConfig.iconName} size="small" />
-      </ManagedResourceStatusPopover>
-    );
+    const resourceStatus =
+      resource.status !== 'HAPPY' && viewConfig ? (
+        <ManagedResourceStatusPopover application={application} placement="left" resourceSummary={resource}>
+          <StatusBubble appearance={viewConfig.appearance} iconName={viewConfig.iconName} size="small" />
+        </ManagedResourceStatusPopover>
+      ) : undefined;
 
     return (
       <ObjectRow

--- a/app/scripts/modules/core/src/managed/RelativeTimestamp.tsx
+++ b/app/scripts/modules/core/src/managed/RelativeTimestamp.tsx
@@ -20,7 +20,7 @@ export const DurationRender: React.FC<{ startedAt: string; completedAt?: string 
         setRefresh((state) => !state);
       }
     },
-    !completedAt ? 1000 : undefined,
+    !completedAt ? 1000 : 0,
   );
   const startAtDateTime = DateTime.fromISO(startedAt);
   const endTime = !completedAt ? DateTime.utc() : DateTime.fromISO(completedAt);
@@ -29,7 +29,11 @@ export const DurationRender: React.FC<{ startedAt: string; completedAt?: string 
 
 const formatTimestamp = (timestamp: DateTime, distance: Duration) => {
   if (distance.years || distance.months) {
-    if (timestamp.year === DateTime.local().setZone(TIMEZONE).year) {
+    let currentTime = DateTime.local();
+    if (TIMEZONE) {
+      currentTime = currentTime.setZone(TIMEZONE);
+    }
+    if (timestamp.year === currentTime.year) {
       return timestamp.toFormat('MMM d');
     } else {
       return timestamp.toFormat('MMM d, y');
@@ -52,7 +56,7 @@ const getDistanceFromNow = (timestamp: DateTime) =>
 
 export const RelativeTimestamp = memo(
   ({ timestamp: timestampInOriginalZone, clickToCopy }: IRelativeTimestampProps) => {
-    const timestamp = timestampInOriginalZone.setZone(TIMEZONE);
+    const timestamp = TIMEZONE ? timestampInOriginalZone.setZone(TIMEZONE) : timestampInOriginalZone;
     const [formattedTimestamp, setFormattedTimestamp] = useState(
       formatTimestamp(timestamp, getDistanceFromNow(timestamp)),
     );

--- a/app/scripts/modules/core/src/managed/StatusCard.tsx
+++ b/app/scripts/modules/core/src/managed/StatusCard.tsx
@@ -30,9 +30,11 @@ export const StatusCard: React.FC<IStatusCardProps> = ({
   description,
   actions,
 }) => {
-  let timestampAsDateTime: DateTime;
+  let timestampAsDateTime: DateTime | undefined = undefined;
   try {
-    timestampAsDateTime = typeof timestamp === 'string' ? DateTime.fromISO(timestamp) : timestamp;
+    if (timestamp) {
+      timestampAsDateTime = typeof timestamp === 'string' ? DateTime.fromISO(timestamp) : timestamp;
+    }
   } catch (e) {
     console.error(`Failed to parse timestamp ${timestamp}`);
   }
@@ -50,7 +52,7 @@ export const StatusCard: React.FC<IStatusCardProps> = ({
           <StatusBubble iconName={iconName} appearance={appearance} size="small" />
         </div>
         <div className="sp-margin-m-right" style={{ minWidth: 33 }}>
-          {timestamp && <RelativeTimestamp timestamp={timestampAsDateTime} clickToCopy={true} />}
+          {timestampAsDateTime && <RelativeTimestamp timestamp={timestampAsDateTime} clickToCopy={true} />}
         </div>
         <div className="flex-container-v sp-margin-xs-yaxis">
           <div className="text-bold">{title}</div>

--- a/app/scripts/modules/core/src/managed/ToggleManagedResourceForApplication.tsx
+++ b/app/scripts/modules/core/src/managed/ToggleManagedResourceForApplication.tsx
@@ -95,7 +95,7 @@ export const ToggleManagedResourceForApplicationModal = memo(
       call
         .then(() => dataSource.refresh(true).catch(() => null))
         .then(() => {
-          closeModal();
+          closeModal?.();
         })
         .catch((error: Error) => {
           setActionError(error.data);

--- a/app/scripts/modules/core/src/managed/artifactDetail/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/ArtifactDetail.tsx
@@ -82,10 +82,16 @@ export const ArtifactDetail = ({
     ?.filter(({ scope, type }) => scope === 'PRE_DEPLOYMENT' && SUPPORTED_PRE_DEPLOYMENT_TYPES.includes(type))
     .reverse();
 
+  const getPinnedVersion = (environmentName: string) => {
+    const envData = allEnvironments.find(({ name }) => name === environmentName);
+    const artifactData = envData?.artifacts.find(({ reference: referenceToMatch }) => referenceToMatch === reference);
+    return artifactData?.pinnedVersion;
+  };
+
   return (
     <>
       <ArtifactDetailHeader
-        reference={showReferenceNames ? reference : null}
+        reference={showReferenceNames ? reference : undefined}
         version={versionDetails}
         onRequestClose={onRequestClose}
       />
@@ -176,10 +182,6 @@ export const ArtifactDetail = ({
         {environments.map((environment) => {
           const { name: environmentName, state } = environment;
 
-          const { pinnedVersion } = allEnvironments
-            .find(({ name }) => name === environmentName)
-            .artifacts.find(({ reference: referenceToMatch }) => referenceToMatch === reference);
-
           return (
             <EnvironmentRow
               key={environmentName}
@@ -192,7 +194,7 @@ export const ArtifactDetail = ({
                 reference={reference}
                 version={versionDetails}
                 allVersions={allVersions}
-                pinnedVersion={pinnedVersion}
+                pinnedVersion={getPinnedVersion(environmentName)}
                 resourcesByEnvironment={resourcesByEnvironment}
               />
               <div className="resources-section">

--- a/app/scripts/modules/core/src/managed/artifactDetail/ArtifactDetailHeader.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/ArtifactDetailHeader.tsx
@@ -8,7 +8,7 @@ import { IManagedArtifactVersion } from '../../domain';
 import './ArtifactDetailHeader.less';
 
 export interface IArtifactDetailHeaderProps {
-  reference: string;
+  reference?: string;
   version: IManagedArtifactVersion;
   onRequestClose: () => any;
 }

--- a/app/scripts/modules/core/src/managed/artifactDetail/EnvironmentCards.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/EnvironmentCards.tsx
@@ -19,7 +19,7 @@ interface IEnvironmentCardsProps
     'application' | 'reference' | 'version' | 'allVersions' | 'resourcesByEnvironment'
   > {
   environment: IManagedArtifactVersionEnvironment;
-  pinnedVersion: string;
+  pinnedVersion?: string;
 }
 
 export const EnvironmentCards: React.FC<IEnvironmentCardsProps> = ({
@@ -65,7 +65,7 @@ export const EnvironmentCards: React.FC<IEnvironmentCardsProps> = ({
     <PinnedCard
       resourcesByEnvironment={resourcesByEnvironment}
       environmentName={environmentName}
-      pinned={environment.pinned}
+      pinned={pinned}
       reference={reference}
       version={versionDetails}
     />

--- a/app/scripts/modules/core/src/managed/artifactDetail/MarkArtifactAsBadModal.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/MarkArtifactAsBadModal.tsx
@@ -34,7 +34,10 @@ const logEvent = (label: string, application: string, environment?: string, refe
     label: environment ? `${application}:${environment}:${reference}` : application,
   });
 
-type IEnvironmentOptionProps = Option<string> & { disabledReason: string; allResources: IManagedResourceSummary[] };
+type IEnvironmentOptionProps = Required<Option<string>> & {
+  disabledReason: string;
+  allResources: IManagedResourceSummary[];
+};
 
 const EnvironmentOption = memo(({ label, disabled, disabledReason, allResources }: IEnvironmentOptionProps) => {
   const isCritical = useEnvironmentTypeFromResources(allResources);
@@ -78,7 +81,7 @@ export const MarkArtifactAsBadModal = memo(
     closeModal,
   }: IMarkArtifactAsBadModalProps) => {
     const optionRenderer = useCallback(
-      (option: Option<string> & { disabledReason: string }) => (
+      (option: Required<Option<string>> & { disabledReason: string }) => (
         <EnvironmentOption {...option} allResources={resourcesByEnvironment[option.value]} />
       ),
       [resourcesByEnvironment],
@@ -90,13 +93,14 @@ export const MarkArtifactAsBadModal = memo(
       <>
         <ModalHeader>Mark {getArtifactVersionDisplayName(version)} as bad</ModalHeader>
         <SpinFormik<{
-          environment: string;
+          environment?: string;
           comment?: string;
         }>
           initialValues={{
-            environment: version.environments.find(({ pinned, state }) => !pinned && state !== 'vetoed').name,
+            environment: version.environments.find(({ pinned, state }) => !pinned && state !== 'vetoed')?.name,
           }}
-          onSubmit={({ environment, comment }, { setSubmitting, setStatus }) =>
+          onSubmit={({ environment, comment }, { setSubmitting, setStatus }) => {
+            if (!environment || !comment) return;
             ManagedWriter.markArtifactVersionAsBad({
               environment,
               reference,
@@ -106,14 +110,14 @@ export const MarkArtifactAsBadModal = memo(
             })
               .then(() => {
                 logEvent('Version marked bad', application.name, environment, reference);
-                closeModal();
+                closeModal?.();
               })
               .catch((error: { data: { error: string; message: string } }) => {
                 setSubmitting(false);
                 setStatus({ error: error.data });
                 logEvent('Error marking version bad', application.name, environment, reference);
-              })
-          }
+              });
+          }}
           render={({ status, isValid, isSubmitting, submitForm }) => {
             const errorTitle = status?.error?.error;
             const errorMessage = status?.error?.message;
@@ -190,7 +194,7 @@ export const MarkArtifactAsBadModal = memo(
                 <ModalFooter
                   primaryActions={
                     <div className="flex-container-h sp-group-margin-s-xaxis">
-                      <Button onClick={() => dismissModal()}>Cancel</Button>
+                      <Button onClick={() => dismissModal?.()}>Cancel</Button>
                       <Button appearance="primary" disabled={!isValid || isSubmitting} onClick={() => submitForm()}>
                         Mark as bad
                       </Button>

--- a/app/scripts/modules/core/src/managed/artifactDetail/PinnedCard.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/PinnedCard.tsx
@@ -12,7 +12,7 @@ import { useApplicationContext } from '../../presentation/hooks/useApplicationCo
 
 interface PinnedCardProps extends Pick<IArtifactDetailProps, 'resourcesByEnvironment' | 'reference' | 'version'> {
   environmentName: string;
-  pinned?: IPinned;
+  pinned: IPinned;
 }
 
 export const PinnedCard: React.FC<PinnedCardProps> = ({
@@ -23,12 +23,13 @@ export const PinnedCard: React.FC<PinnedCardProps> = ({
   reference,
 }) => {
   const application = useApplicationContext();
+  if (!application) return null;
   return (
     <StatusCard
       iconName="pin"
       appearance="warning"
       background={true}
-      timestamp={pinned?.at ? DateTime.fromISO(pinned.at) : null}
+      timestamp={DateTime.fromISO(pinned.at)}
       title={
         <span className="sp-group-margin-xs-xaxis">
           <span>Pinned</span> <span className="text-regular">—</span>{' '}

--- a/app/scripts/modules/core/src/managed/artifactDetail/PreDeploymentStepCard.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/PreDeploymentStepCard.tsx
@@ -23,6 +23,7 @@ const cardConfigurationByType = {
     title: ({ status, startedAt, completedAt }: IManagedArtifactVersionLifecycleStep) => {
       const startedAtDate = startedAt ? DateTime.fromISO(startedAt) : null;
       const completedAtDate = completedAt ? DateTime.fromISO(completedAt) : null;
+      const timeDiff = startedAtDate && completedAtDate ? timeDiffToString(startedAtDate, completedAtDate) : undefined;
 
       switch (status) {
         case 'NOT_STARTED':
@@ -30,12 +31,13 @@ const cardConfigurationByType = {
         case 'RUNNING':
           return 'Building';
         case 'SUCCEEDED':
-          return `Built in ${timeDiffToString(startedAtDate, completedAtDate)}`;
+          return `Built ${timeDiff ? `in ${timeDiff}` : ''}`;
         case 'FAILED':
-          return `Build failed after ${timeDiffToString(startedAtDate, completedAtDate)}`;
+          return `Build failed ${timeDiff ? `after ${timeDiff}` : ''}`;
         case 'ABORTED':
-          return `Build aborted after ${timeDiffToString(startedAtDate, completedAtDate)}`;
+          return `Build aborted ${timeDiff ? `after ${timeDiff}` : ''}`;
         case 'UNKNOWN':
+        default:
           return 'Unable to find the status of this build';
       }
     },
@@ -45,6 +47,7 @@ const cardConfigurationByType = {
     title: ({ status, startedAt, completedAt }: IManagedArtifactVersionLifecycleStep) => {
       const startedAtDate = startedAt ? DateTime.fromISO(startedAt) : null;
       const completedAtDate = completedAt ? DateTime.fromISO(completedAt) : null;
+      const timeDiff = startedAtDate && completedAtDate ? timeDiffToString(startedAtDate, completedAtDate) : undefined;
 
       switch (status) {
         case 'NOT_STARTED':
@@ -52,12 +55,13 @@ const cardConfigurationByType = {
         case 'RUNNING':
           return 'Baking';
         case 'SUCCEEDED':
-          return `Baked in ${timeDiffToString(startedAtDate, completedAtDate)}`;
+          return `Baked ${timeDiff ? `in ${timeDiff}` : ''}`;
         case 'FAILED':
-          return `Baking failed after ${timeDiffToString(startedAtDate, completedAtDate)}`;
+          return `Baking failed ${timeDiff ? `after ${timeDiff}` : ''}`;
         case 'ABORTED':
-          return `Baking aborted after ${timeDiffToString(startedAtDate, completedAtDate)}`;
+          return `Baking aborted ${timeDiff ? `after ${timeDiff}` : ''}`;
         case 'UNKNOWN':
+        default:
           return 'Unable to find the status of this bake';
       }
     },
@@ -71,13 +75,13 @@ const logEvent = (label: string, application: string, reference: string, type: s
     label: `${application}:${reference}:${type}:${status}`,
   });
 
-const getTimestamp = (startedAt: string, completedAt: string) => {
+const getTimestamp = (startedAt?: string, completedAt?: string) => {
   if (completedAt) {
     return DateTime.fromISO(completedAt);
   } else if (startedAt) {
     return DateTime.fromISO(startedAt);
   } else {
-    return null;
+    return undefined;
   }
 };
 

--- a/app/scripts/modules/core/src/managed/artifactDetail/UnpinArtifactModal.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/UnpinArtifactModal.tsx
@@ -57,7 +57,7 @@ export const UnpinArtifactModal = memo(
   }: IUnpinArtifactModalProps) => {
     const isEnvironmentCritical = useEnvironmentTypeFromResources(resourcesByEnvironment[environment] ?? []);
     const [submitStatus, setSubmitStatus] = useState<IRequestStatus>('NONE');
-    const [error, setError] = useState<{ title: string; message: string }>(null);
+    const [error, setError] = useState<{ title: string; message: string } | undefined>(undefined);
 
     useEffect(() => logEvent('Modal seen', application.name), []);
 
@@ -71,7 +71,7 @@ export const UnpinArtifactModal = memo(
       })
         .then(() => {
           logEvent('Version unpinned', application.name, environment, reference);
-          closeModal();
+          closeModal?.();
         })
         .catch((error: { data: { error: string; message: string } }) => {
           setSubmitStatus('REJECTED');
@@ -125,7 +125,7 @@ export const UnpinArtifactModal = memo(
         <ModalFooter
           primaryActions={
             <div className="flex-container-h sp-group-margin-s-xaxis">
-              <Button onClick={() => dismissModal()}>Cancel</Button>
+              <Button onClick={() => dismissModal?.()}>Cancel</Button>
               <Button appearance="primary" disabled={submitStatus === 'PENDING'} onClick={() => submit()}>
                 Unpin
               </Button>

--- a/app/scripts/modules/core/src/managed/artifactDetail/VersionStateCard.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/VersionStateCard.tsx
@@ -20,9 +20,9 @@ interface CardTitleMetadata {
 interface CardAppearance {
   icon: IconNames;
   appearance: IStatusCardProps['appearance'];
-  timestamp?: (metadata: CardTitleMetadata) => DateTime;
+  timestamp?: (metadata: CardTitleMetadata) => DateTime | undefined;
   title: (metadata: CardTitleMetadata) => string | JSX.Element;
-  description?: (metadata: CardTitleMetadata) => string | JSX.Element;
+  description?: (metadata: CardTitleMetadata) => string | JSX.Element | undefined;
 }
 
 const cardAppearanceByState: { [state: string]: CardAppearance } = {
@@ -45,7 +45,7 @@ const cardAppearanceByState: { [state: string]: CardAppearance } = {
   previous: {
     icon: 'cloudDecommissioned',
     appearance: 'archived',
-    timestamp: ({ replacedAt }: CardTitleMetadata) => (replacedAt ? DateTime.fromISO(replacedAt) : null),
+    timestamp: ({ replacedAt }: CardTitleMetadata) => (replacedAt ? DateTime.fromISO(replacedAt) : undefined),
     title: ({ replacedByVersionName }: CardTitleMetadata) => (
       <span className="sp-group-margin-xs-xaxis">
         <span>Decommissioned</span>{' '}
@@ -76,7 +76,7 @@ const cardAppearanceByState: { [state: string]: CardAppearance } = {
   current: {
     icon: 'cloudDeployed',
     appearance: 'success',
-    timestamp: ({ deployedAt }: CardTitleMetadata) => (deployedAt ? DateTime.fromISO(deployedAt) : null),
+    timestamp: ({ deployedAt }: CardTitleMetadata) => (deployedAt ? DateTime.fromISO(deployedAt) : undefined),
     title: (_: CardTitleMetadata) => <span>Deployed</span>,
   },
   vetoed: {
@@ -84,7 +84,7 @@ const cardAppearanceByState: { [state: string]: CardAppearance } = {
     appearance: 'error',
     timestamp: ({ vetoed }: CardTitleMetadata) =>
       // we have to tolerate some older vetoes (from before June 2020) in the DB that don't have times/user attribution
-      !!vetoed ? DateTime.fromISO(vetoed.at) : null,
+      !!vetoed ? DateTime.fromISO(vetoed.at) : undefined,
     title: ({ vetoed }: CardTitleMetadata) => {
       return (
         <span className="sp-group-margin-xs-xaxis">
@@ -97,7 +97,8 @@ const cardAppearanceByState: { [state: string]: CardAppearance } = {
         </span>
       );
     },
-    description: ({ vetoed }: CardTitleMetadata) => vetoed?.comment && <Markdown message={vetoed.comment} tag="span" />,
+    description: ({ vetoed }: CardTitleMetadata) =>
+      vetoed?.comment ? <Markdown message={vetoed.comment} tag="span" /> : undefined,
   },
 } as const;
 

--- a/app/scripts/modules/core/src/managed/artifactDetail/constraints/constraintRegistry.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/constraints/constraintRegistry.tsx
@@ -61,7 +61,7 @@ export const getConstraintTimestamp = (
   environment: IManagedArtifactVersionEnvironment,
 ) => {
   if (!isConstraintStateful(constraint)) {
-    return null;
+    return undefined;
   }
 
   const { status, startedAt, judgedAt } = constraint as IStatefulConstraint;
@@ -69,21 +69,21 @@ export const getConstraintTimestamp = (
   // PENDING and NOT_EVALUATED constraints stop running once an environment is skipped, however, their status do not change.
   // We need to ignore them
   if (environment.state === 'skipped' && [PENDING, NOT_EVALUATED].includes(status)) {
-    return null;
+    return undefined;
   }
 
   switch (status) {
     case PENDING:
-      return startedAt ? DateTime.fromISO(startedAt) : null;
+      return startedAt ? DateTime.fromISO(startedAt) : undefined;
 
     case PASS:
     case FAIL:
     case OVERRIDE_PASS:
     case OVERRIDE_FAIL:
-      return judgedAt ? DateTime.fromISO(judgedAt) : null;
+      return judgedAt ? DateTime.fromISO(judgedAt) : undefined;
 
     default:
-      return null;
+      return undefined;
   }
 };
 

--- a/app/scripts/modules/core/src/managed/artifactDetail/verifications/VerificationCard.tsx
+++ b/app/scripts/modules/core/src/managed/artifactDetail/verifications/VerificationCard.tsx
@@ -37,7 +37,7 @@ export const VerificationCard: React.FC<VerificationCardProps> = ({ verification
       title={
         <>
           {wasHalted ? 'Verification was halted' : statusToText[status]}
-          {FINISHED_STATES.includes(status) && (
+          {FINISHED_STATES.includes(status) && startedAt && (
             <>
               {' '}
               —{' '}

--- a/app/scripts/modules/core/src/managed/environment/EnvironmentRow.tsx
+++ b/app/scripts/modules/core/src/managed/environment/EnvironmentRow.tsx
@@ -33,12 +33,12 @@ export function EnvironmentRow({ name, resources = [], pinnedVersions, children 
             <EnvironmentBadge name={name} critical={isCritical} />
           </div>
           <div className="flex-container-h flex-grow flex-pull-right">
-            {pinnedVersions?.length > 0 ? (
+            {pinnedVersions && pinnedVersions?.length > 0 ? (
               <StatusBubble
                 iconName="pin"
                 appearance="warning"
                 size="small"
-                quantity={pinnedVersions.length > 1 ? pinnedVersions.length : null}
+                quantity={pinnedVersions.length > 1 ? pinnedVersions.length : undefined}
               />
             ) : null}
           </div>

--- a/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
@@ -5,7 +5,8 @@ import { IMoniker } from 'core/naming';
 
 import { getKindName, getResourceKindForLoadBalancerType } from './ManagedReader';
 
-const isMonikerEqual = (a: IMoniker, b: IMoniker) => a.app === b.app && a.stack === b.stack && a.detail === b.detail;
+const isMonikerEqual = (a?: IMoniker, b?: IMoniker) =>
+  a && b && a.app === b.app && a.stack === b.stack && a.detail === b.detail;
 
 const getResourcesOfKind = (application: Application, kinds: string[]) => {
   const resources: IManagedResourceSummary[] = application.managedResources.data.resources;
@@ -45,6 +46,7 @@ export const addManagedResourceMetadataToLoadBalancers = (application: Applicati
   loadBalancers.forEach((loadBalancer) => {
     const matchingResource = loadBalancerResources.find(
       ({ kind, moniker, locations: { account, regions } }) =>
+        loadBalancer.loadBalancerType &&
         getKindName(kind) === getResourceKindForLoadBalancerType(loadBalancer.loadBalancerType) &&
         isMonikerEqual(moniker, loadBalancer.moniker) &&
         account === loadBalancer.account &&

--- a/app/scripts/modules/core/src/managed/toggleResourceManagement.tsx
+++ b/app/scripts/modules/core/src/managed/toggleResourceManagement.tsx
@@ -38,7 +38,7 @@ const viewConfigurationByStatus: { [status in ManagedResourceStatus]?: IToggleCo
  */
 export const confirmNotManaged = (resource: IManagedResource, application: Application): PromiseLike<boolean> => {
   const { managedResourceSummary, isManaged } = resource;
-  if (!isManaged || managedResourceSummary.isPaused) {
+  if (!isManaged || !managedResourceSummary || managedResourceSummary.isPaused) {
     return $q.when(true);
   }
   const submitMethod = () => {

--- a/app/scripts/modules/core/src/managed/tsconfig.json
+++ b/app/scripts/modules/core/src/managed/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+      "noEmit": true, 
+      "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
I added a `tsconfig.json` file to `managed`. We can't run and enforce it during compilation (unfortunately) as we'll have to fix all of the imports from other folders. However, it allows us to enforce null checking via the IDE. 

It's not perfect, but it's a start. 

Another option is to add the config file to `gitignore`, and use it only for local dev, but I'm not sure it's better. 

@erikmunson can you review this briefly and make sure I didn't do anything stupid?