### PR TITLE
fix(amazon): Do not automatically assign IPv6 for disabled images

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -1,5 +1,4 @@
 import { Field, FormikErrors, FormikProps } from 'formik';
-import { some } from 'lodash';
 import React from 'react';
 
 import {
@@ -92,7 +91,7 @@ export class ServerGroupBasicSettings
     values.imageChanged(values);
 
     if (image && SETTINGS.disabledImages?.length && AWSProviderSettings.serverGroups?.enableIPv6) {
-      const isImageDisabled = some(SETTINGS.disabledImages, (i) => image.imageName.includes(i));
+      const isImageDisabled = SETTINGS.disabledImages.some((i) => image.imageName.includes(i));
       if (isImageDisabled) {
         setFieldValue('associateIPv6Address', false);
       }

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -1,4 +1,5 @@
 import { Field, FormikErrors, FormikProps } from 'formik';
+import { some } from 'lodash';
 import React from 'react';
 
 import {
@@ -15,6 +16,7 @@ import {
   RegionSelectField,
   ServerGroupDetailsField,
   ServerGroupNamePreview,
+  SETTINGS,
   TaskReason,
 } from '@spinnaker/core';
 import { AWSProviderSettings } from 'amazon/aws.settings';
@@ -88,6 +90,13 @@ export class ServerGroupBasicSettings
     setFieldValue('virtualizationType', virtualizationType);
     setFieldValue('amiName', imageName);
     values.imageChanged(values);
+
+    if (image && SETTINGS.disabledImages?.length && AWSProviderSettings.serverGroups?.enableIPv6) {
+      const isImageDisabled = some(SETTINGS.disabledImages, (i) => image.imageName.includes(i));
+      if (isImageDisabled) {
+        setFieldValue('associateIPv6Address', false);
+      }
+    }
   };
 
   private accountUpdated = (account: string): void => {
@@ -201,7 +210,6 @@ export class ServerGroupBasicSettings
 
     const accounts = values.backingData.accounts;
     const readOnlyFields = values.viewState.readOnlyFields || {};
-
     return (
       <div className="container-fluid form-horizontal">
         {values.regionIsDeprecated(values) && (


### PR DESCRIPTION
Some older, partially-deprecated AMIs are having trouble with IPv6. This PR prevents auto-enabling IPv6 if  an image is listed as `disabled` (i.e. almost deprecated).  A user can still manually enable this option in Advanced Settings. 