### PR TITLE
fix(amazon/serverGroup): Move spelLoadBalancers and spelTargetGroups to viewState

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -123,6 +123,7 @@ describe('Service: awsServerGroupConfiguration', function () {
   describe('configureLoadBalancerOptions', function () {
     beforeEach(function () {
       this.command = {
+        viewState: {},
         backingData: {
           loadBalancers: this.allLoadBalancers,
           filtered: {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -79,6 +79,8 @@ export interface IAmazonServerGroupCommandBackingData extends IServerGroupComman
 
 export interface IAmazonServerGroupCommandViewState extends IServerGroupCommandViewState {
   dirty: IAmazonServerGroupCommandDirty;
+  spelTargetGroups: string[];
+  spelLoadBalancers: string[];
 }
 
 export interface IAmazonServerGroupCommand extends IServerGroupCommand {
@@ -97,8 +99,6 @@ export interface IAmazonServerGroupCommand extends IServerGroupCommand {
   useAmiBlockDeviceMappings: boolean;
   targetGroups: string[];
   setLaunchTemplate?: boolean;
-  spelTargetGroups: string[];
-  spelLoadBalancers: string[];
   unlimitedCpuCredits?: boolean;
   viewState: IAmazonServerGroupCommandViewState;
 
@@ -517,7 +517,7 @@ export class AwsServerGroupConfigurationService {
       if (invalid.length) {
         result.dirty.loadBalancers = invalid;
       }
-      command.spelLoadBalancers = spel || [];
+      command.viewState.spelLoadBalancers = spel || [];
     }
 
     if (currentTargetGroups && command.targetGroups && !currentTargetGroups.includes('${')) {
@@ -526,7 +526,7 @@ export class AwsServerGroupConfigurationService {
       if (invalid.length) {
         result.dirty.targetGroups = invalid;
       }
-      command.spelTargetGroups = spel || [];
+      command.viewState.spelTargetGroups = spel || [];
     }
 
     command.backingData.filtered.loadBalancers = newLoadBalancers;

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
@@ -88,7 +88,7 @@ export class ServerGroupLoadBalancers
     let targetGroupSection = null;
     if (!hideTargetGroups) {
       const targetGroupOptions = (values.backingData.filtered.targetGroups || [])
-        .concat(values.spelTargetGroups || [])
+        .concat(values.viewState.spelTargetGroups || [])
         .map(stringToOption);
 
       targetGroupSection = (
@@ -142,7 +142,7 @@ export class ServerGroupLoadBalancers
     let loadBalancersSection = null;
     if (!hideLoadBalancers) {
       const loadBalancerOptions = (values.backingData.filtered.loadBalancers || [])
-        .concat(values.spelLoadBalancers || [])
+        .concat(values.viewState.spelLoadBalancers || [])
         .map(stringToOption);
 
       const vpcLoadBalancerOptions = (values.backingData.filtered.vpcLoadBalancers || []).map(stringToOption);

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -121,7 +121,6 @@ export interface IServerGroupCommand {
   };
   stack?: string;
   moniker?: IMoniker;
-  spelLoadBalancers: string[];
   strategy: string;
   subnetType: string;
   suspendedProcesses: string[];


### PR DESCRIPTION
When we switch between regions or accounts, the ui validates that the requested load balancers/target groups exist in the new account/region.  If the new region/account doesn't have the load balancer, it's removed from the UI and a message is shown.  However, spel expressions are treated differently and are never removed.  

This change moves the UI state from the command object to the viewState object so these values are not sent to the server