### PR TITLE
feat(core/ExecutionMarket): Extends component to customize status color by output status code

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
@@ -83,7 +83,7 @@ export class ExecutionMarker extends React.Component<IExecutionMarkerProps, IExe
 
   private getStageOutputStatusCode = (): number => {
     const { stage } = this.props;
-    return stage.masterStage.outputs.status && stage.masterStage.outputs.status.code;
+    return stage.masterStage.outputs.status?.code;
   };
 
   private getClassNameByStatusCode = (code: number): string => {

--- a/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
@@ -81,9 +81,24 @@ export class ExecutionMarker extends React.Component<IExecutionMarkerProps, IExe
     });
   };
 
+  private getStageOutputStatusCode = (): number => {
+    const { stage } = this.props;
+    return stage.masterStage.outputs.status && stage.masterStage.outputs.status.code;
+  };
+
+  private getClassNameByStatusCode = (code: number): string => {
+    switch (code) {
+      case 2:
+        return 'success-with-diff';
+      default:
+        return '';
+    }
+  };
+
   public render() {
     const { stage, application, execution, active, previousStageActive, width } = this.props;
     const stageType = (stage.activeStageType || stage.type).toLowerCase(); // support groups
+    const stageOutputStatusCode = this.getStageOutputStatusCode();
     const markerClassName = [
       stage.type !== 'group' ? 'clickable' : '',
       'stage',
@@ -94,6 +109,7 @@ export class ExecutionMarker extends React.Component<IExecutionMarkerProps, IExe
       previousStageActive ? 'after-active' : '',
       stage.isRunning ? 'glowing' : '',
       stage.requiresAttention ? 'requires-attention' : '',
+      this.getClassNameByStatusCode(stageOutputStatusCode),
     ].join(' ');
 
     const TooltipComponent = stage.useCustomTooltip ? stage.labelComponent : ExecutionBarLabel;

--- a/app/scripts/modules/core/src/pipeline/executions/execution/executionMarker.less
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/executionMarker.less
@@ -1,4 +1,5 @@
 @import (reference) '~core/presentation/less/imports/commonImports.less';
+@color-success: #8aad6a;
 
 .execution-marker.stage {
   margin-top: 0;
@@ -34,6 +35,15 @@
   }
   &.requires-attention {
     background-color: var(--color-alert);
+  }
+  &.success-with-diff {
+    background: repeating-linear-gradient(
+      45deg,
+      var(--color-success),
+      var(--color-success) 10px,
+      lighten(@color-success, 10%) 10px,
+      lighten(@color-success, 10%) 20px
+    );
   }
   i {
     color: var(--color-white);


### PR DESCRIPTION
## What does this PR do?
This PR extends the functionality of the `ExecutionMarker` component to add different css classes based on a stage output status code.

The following example shows the UI changing the execution marker based on the status code 2 which means the stage succeeded but there was a diff.

This should be useful for users who run several pipelines at once so they can identify the status of a finished job with just a glance.

## Demo
<img width="1680" alt="Screen Shot 2021-03-02 at 15 30 39" src="https://user-images.githubusercontent.com/77355419/109718088-800dbb00-7b6c-11eb-9b1c-7241ac5c1dd2.png">

