### PR TITLE
fix(core/forms): MapEditor: make trash icon position: relative to avoid scrollbars

### DIFF
--- a/app/scripts/modules/core/src/forms/mapEditor/MapEditor.less
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapEditor.less
@@ -1,0 +1,13 @@
+.MapEditor {
+  tr.MapPair_error td {
+    border-top: 0;
+    padding-top: 0;
+    margin-top: 0;
+  }
+
+  .MapPair {
+    a.button {
+      position: relative;
+    }
+  }
+}

--- a/app/scripts/modules/core/src/forms/mapEditor/MapEditor.tsx
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapEditor.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { IPipeline } from 'core/domain';
 
 import { IMapPair, MapPair } from './MapPair';
+import './MapEditor.less';
 
 export interface IMapEditorProps {
   addButtonLabel?: string;
@@ -123,7 +124,7 @@ export class MapEditor extends React.Component<IMapEditorProps, IMapEditorState>
     const isParameterized = isString(this.props.model);
 
     return (
-      <div>
+      <div className="MapEditor">
         {label && (
           <div className="sm-label-left">
             <b>{label}</b>

--- a/app/scripts/modules/core/src/forms/mapEditor/MapEditorInput.tsx
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapEditorInput.tsx
@@ -5,6 +5,7 @@ import { IPipeline } from 'core/domain';
 import { createFakeReactSyntheticEvent, IFormInputProps, IValidator, IValidatorResult } from 'core/presentation';
 
 import { IMapPair, MapPair } from './MapPair';
+import './MapEditor.less';
 
 export interface IMapEditorInputProps extends IFormInputProps {
   addButtonLabel?: string;
@@ -118,7 +119,7 @@ export function MapEditorInput({
   };
 
   return (
-    <div>
+    <div className="MapEditor">
       {label && (
         <div className="sm-label-left">
           <b>{label}</b>

--- a/app/scripts/modules/core/src/forms/mapEditor/MapPair.css
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapPair.css
@@ -1,5 +1,0 @@
-table tbody tr.MapPair_error td {
-  border-top: 0;
-  padding-top: 0;
-  margin-top: 0;
-}

--- a/app/scripts/modules/core/src/forms/mapEditor/MapPair.tsx
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapPair.tsx
@@ -5,8 +5,6 @@ import { ValidationMessage } from 'core/presentation';
 import { IPipeline } from '../../domain';
 import { SpelText } from '../../widgets';
 
-import './MapPair.css';
-
 export interface IMapPair {
   key: string;
   value: string;
@@ -27,7 +25,7 @@ export const MapPair = (props: {
 
   return (
     <>
-      <tr>
+      <tr className="MapPair">
         {labelsLeft && (
           <td className="table-label">
             <b>{keyLabel}</b>
@@ -65,7 +63,7 @@ export const MapPair = (props: {
         </td>
         <td>
           <div className="form-control-static">
-            <a className="clickable" onClick={onDelete}>
+            <a className="clickable button" onClick={onDelete}>
               <span className="glyphicon glyphicon-trash" />
               <span className="sr-only">Remove field</span>
             </a>


### PR DESCRIPTION
Before:

![Kapture 2021-03-02 at 17 08 02](https://user-images.githubusercontent.com/2053478/109855002-d7a73780-7bfb-11eb-8c67-943217853b9f.gif)

Note the entire modal is scrolling down all the way to the last `position: absolute` element (which is from the `class="sr-only"` bootstrap screenreader only css class)