### PR TITLE
fix(pipelines): Add deps to breadcrumbs useMemo

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionBreadcrumbs.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionBreadcrumbs.tsx
@@ -16,7 +16,7 @@ export const ExecutionBreadcrumbs = ({ execution }: IExecutionBreadcrumbsProps) 
       .getAllParentExecutions(execution)
       .filter((x) => x !== execution)
       .reverse();
-  }, []);
+  }, [execution]);
 
   const label = parentExecutions.length === 1 ? 'Parent Execution' : 'Parent Executions';
 


### PR DESCRIPTION
The `parentExecutions` was `useMemo`'d with an empty deps array `[]` which means it is never invalidated.

This meant that when navigating from child to child to child, the parentExecutions never got recomputed and certain parts of the lineage would be missing.