### PR TITLE
chore(package): amazon@0.0.294 core@0.0.553 docker@0.0.69

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.293",
+  "version": "0.0.294",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.552",
+  "version": "0.0.553",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/docker",
   "license": "Apache-2.0",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.294

35215bcbfbc7efd25124a2e5623aae5bf9fc939b Merge branch 'master' into disable-ipv6-images
eb4394f8f97bb7958a23c75f3f40cd00111317b6 fix(amazon/serverGroup): Move spelLoadBalancers and spelTargetGroups to viewState (#8957)
84bd0f1f5ae5c6301be067b715284d91eb55c6cc Use native .some instead of lodash
36b7feca2dde7defd6ea1acfb7378044d7c62300 fix(amazon): Do not automatically assign IPv6 for disabled images

## core@0.0.553

3d0ddbd9b97be84d87b8e1439e38383ccb116f93 fix(md): remove beta tag (#8968)
765499fdadec89131359bc089e4a9c090368eb14 fix(pipelines): Add deps to breadcrumbs useMemo (#8967)
4c02d1c5bdc051e20c6a8e5a0f785b82c637822a fix(pr): added explicit log level (#8966)
273966d86d1cefe35378c842a3a334e03f5fd606 fix(core/forms): MapEditor: make trash icon position: relative to avoid scrollbars (#8964)
3f77dc7293455f8c073bb579381d73a91cd23255 feat(md): resource history title - show resource display name (#8963)
b2a6db1c4944811319f2c21cb0d2d5d003aa7912 fix(pr): remove console.log
9a5ee2f5023500db3c9253dce052be181f98efab feat(md): redesigned history page
1faa3163da6f611beb9ed9ae39241e85521af256 fix(core): updated type
378890ba5ba22838b2e8f7207e291371d2f5aa07 feat(md): remove events white list and get info from the backend
e5213a8c79301f1c6891625dd9648e701c2cc204 refactor(md): refactor managed resource history + fix memoization
eb4394f8f97bb7958a23c75f3f40cd00111317b6 fix(amazon/serverGroup): Move spelLoadBalancers and spelTargetGroups to viewState (#8957)

## docker@0.0.69

546e5b3de517f4cfd58ab5bfc0db49cc1a29f1ad fix(docker): DockerImageAndTagSelector.tsx: do not setState when unmounted (#8958)

PR created via `modules/publish.js`