### PR TITLE
feat(core): Allow function components to be overridden

### DIFF
--- a/app/scripts/modules/core/src/bootstrap/SpinnakerContainer.tsx
+++ b/app/scripts/modules/core/src/bootstrap/SpinnakerContainer.tsx
@@ -1,4 +1,5 @@
 import { UIView } from '@uirouter/react';
+import { UIRouterContextComponent } from '@uirouter/react-hybrid';
 import * as React from 'react';
 import { RecoilRoot } from 'recoil';
 
@@ -25,7 +26,9 @@ export const SpinnakerContainer = ({ authenticating, routing }: ISpinnakerContai
         )}
         <div className="navbar-inverse grid-header">
           <CustomBanner />
-          <SpinnakerHeader />
+          <UIRouterContextComponent>
+            <SpinnakerHeader />
+          </UIRouterContextComponent>
         </div>
         <div className="spinnaker-content grid-contents">{!authenticating && <UIView name="main" />}</div>
       </div>

--- a/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
+++ b/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
@@ -1,5 +1,4 @@
 import { useCurrentStateAndParams, useSrefActive } from '@uirouter/react';
-import { UIRouterContext } from '@uirouter/react-hybrid';
 import React from 'react';
 import { useRecoilState } from 'recoil';
 
@@ -7,25 +6,11 @@ import { Icon } from '@spinnaker/presentation';
 import { verticalNavExpandedAtom } from 'core/application/nav/navAtoms';
 import { CollapsibleSectionStateCache } from 'core/cache';
 import { HelpMenu } from 'core/help/HelpMenu';
-import { Overridable } from 'core/overrideRegistry';
+import { overridableComponent } from 'core/overrideRegistry';
 import { NgReact } from 'core/reactShims';
 import { GlobalSearch } from 'core/search/global/GlobalSearch';
 
 import './SpinnakerHeader.css';
-
-@UIRouterContext
-@Overridable('spinnakerHeader')
-export class SpinnakerHeader extends React.Component<{}, {}> {
-  public render(): React.ReactElement<SpinnakerHeader> {
-    return <SpinnakerHeaderContent />;
-  }
-}
-
-/**
- * This needs to be a functional component to use an external module's hook.
- * Currently, @Overrides only works on a class component.
- * This is temproary until we can refactor the override component to work for functional components.
- */
 
 export const SpinnakerHeaderContent = () => {
   const { state: currentState } = useCurrentStateAndParams();
@@ -94,3 +79,5 @@ export const SpinnakerHeaderContent = () => {
     </nav>
   );
 };
+
+export const SpinnakerHeader = overridableComponent(SpinnakerHeaderContent, 'spinnakerHeader');

--- a/app/scripts/modules/core/src/overrideRegistry/Overridable.tsx
+++ b/app/scripts/modules/core/src/overrideRegistry/Overridable.tsx
@@ -50,7 +50,7 @@ export function Overridable(key: string) {
  *
  * export const MyOverridableCmp = overridableComponent(MyCmp);
  */
-export function overridableComponent<P extends IOverridableProps, T extends React.ComponentClass<P>>(
+export function overridableComponent<P extends IOverridableProps, T extends React.ComponentType<P>>(
   OriginalComponent: T,
   key: string,
 ): T {

--- a/app/scripts/modules/core/src/overrideRegistry/Overrides.tsx
+++ b/app/scripts/modules/core/src/overrideRegistry/Overrides.tsx
@@ -18,7 +18,7 @@ export class RegistrationQueue {
     this.flush();
   }
 
-  public register(component: React.ComponentClass, key: string, cloudProvider?: string) {
+  public register(component: React.ComponentType, key: string, cloudProvider?: string) {
     this.queue.push(() => {
       if (!cloudProvider) {
         this.overrideRegistry.overrideComponent(key, component);
@@ -61,3 +61,14 @@ export function Overrides(key: string, cloudProvider?: string) {
     overrideRegistrationQueue.register(targetComponent, key, cloudProvider);
   };
 }
+
+/**
+ * This should be applied to a React Function Component, since they cannot utilize decorators.
+ * The component class will be used instead of the OverridableComponent with the same key.
+ *
+ * If an (optional) cloudProvider is specified, the component override takes effect only for that cloud provider.
+ * If not, this is the same as using the override registry to override the component.
+ */
+export const overridesComponent = (targetComponent: React.ComponentType, key: string, cloudProvider?: string) => {
+  overrideRegistrationQueue.register(targetComponent, key, cloudProvider);
+};

--- a/app/scripts/modules/core/src/overrideRegistry/Overrides.tsx
+++ b/app/scripts/modules/core/src/overrideRegistry/Overrides.tsx
@@ -63,6 +63,8 @@ export function Overrides(key: string, cloudProvider?: string) {
 }
 
 /**
+ * Registers a component as a replacement for some other component.
+ *
  * This should be applied to a React Function Component, since they cannot utilize decorators.
  * The component class will be used instead of the OverridableComponent with the same key.
  *

--- a/app/scripts/modules/core/src/overrideRegistry/override.registry.ts
+++ b/app/scripts/modules/core/src/overrideRegistry/override.registry.ts
@@ -5,14 +5,14 @@ import { overrideRegistrationQueue } from './Overrides';
 
 export class OverrideRegistry {
   private templateOverrides: Map<string, string> = new Map();
-  private componentOverrides: Map<string, React.ComponentClass> = new Map();
+  private componentOverrides: Map<string, React.ComponentType> = new Map();
   private controllerOverrides: Map<string, string> = new Map();
 
   public overrideTemplate(key: string, val: string) {
     this.templateOverrides.set(key, val);
   }
 
-  public overrideComponent(key: string, val: React.ComponentClass) {
+  public overrideComponent(key: string, val: React.ComponentType) {
     this.componentOverrides.set(key, val);
   }
 


### PR DESCRIPTION
React function components cannot use decorators, so the dev experience hasn't been ideal using `@Overridable` as we try and move toward function components. (the `OverridableComponent` renders a wrapper class component, which renders a functioning function component). 

This ended up being mostly a Typescript update, but now we can utilize the existing `overrideableComponent` function to produce an HOC, which is a better pattern for function components. 

What is in this PR:
- type updates
- A new function `overridesComponent` that is equivalent to the `@Overrides` decorator, but can be used for function components
- An example of utilizing `overrideableComponent` to create an HOC