### PR TITLE
chore(pluginsdk): fix scaffold tmpl for newer spinnaker versions

### DIFF
--- a/packages/pluginsdk/scaffold/src/WidgetizeStage.tsx
+++ b/packages/pluginsdk/scaffold/src/WidgetizeStage.tsx
@@ -51,11 +51,6 @@ function WidgetizeStageForm(props: IFormikStageConfigInjectedProps) {
   );
 }
 
-// Soon-to-be-deprecated API to supply the stage label
-export namespace WidgetizeStageConfig {
-  export const title = 'Widgetize';
-}
-
 /** Example validation */
 export function validate(stageConfig: IStage) {
   const validator = new FormValidator(stageConfig);
@@ -75,6 +70,8 @@ export function validate(stageConfig: IStage) {
 
 export const widgetizeStage: IStageTypeConfig = {
   key: 'widgetize',
+  label: 'Widgetize',
+  description: 'Widgetize the froobulator.',
   component: WidgetizeStageConfig,
   executionDetailsSections: [ExecutionDetailsTasks],
   validateFn: validate,


### PR DESCRIPTION
On newer versions of Spinnaker the `Widgetize` stage that is provided by the scaffold command no longer works OOB. I've added the required fields on the stage itself and verified this works in 1.24.

I also noticed that `check-plugin` and `check-peer-deps` aren't running successfully on first scaffold, but they do when you have `check-plugin` fix unmet deps after initial scaffold. I won't fix that in this PR, but may in an upcoming PR.