### PR TITLE
Always link to /applications/appname from the recent applications list

### DIFF
--- a/app/scripts/modules/core/src/application/application.state.provider.ts
+++ b/app/scripts/modules/core/src/application/application.state.provider.ts
@@ -122,6 +122,7 @@ export class ApplicationStateProvider implements IServiceProvider {
         },
         history: {
           type: 'applications',
+          state: 'home.applications.application',
           keyParams: ['application'],
         },
       },

--- a/app/scripts/modules/core/src/history/recentHistory.service.ts
+++ b/app/scripts/modules/core/src/history/recentHistory.service.ts
@@ -136,9 +136,11 @@ module(RECENT_HISTORY_SERVICE, []).run([
   '$rootScope',
   ($rootScope: ng.IRootScopeService) => {
     $rootScope.$on('$stateChangeSuccess', (_event: IAngularEvent, toState: Ng1StateDeclaration, toParams: any) => {
-      if (toState.data && toState.data.history) {
+      const history = toState.data?.history;
+      if (history) {
         const params = omit(toParams || {}, ['debug', 'vis', 'trace']);
-        RecentHistoryService.addItem(toState.data.history.type, toState.name, params, toState.data.history.keyParams);
+        const state = history.state || toState.name;
+        RecentHistoryService.addItem(history.type, state, params, history.keyParams);
       }
     });
   },


### PR DESCRIPTION
Before, the recent applications list would link you to the deepest link in that view.  Now it links to the default route, i.e., http://spinnaker/#/applications/appname

Also refactored RecentlyViewedItems.tsx to a functional component cause I was in there