### PR TITLE
feat(core/presentation): add `mode="CREATABLE"` to the ReactSelectInput

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/inputs/ReactSelectInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/ReactSelectInput.tsx
@@ -78,9 +78,11 @@ export function ReactSelectInput<T = string>(props: IReactSelectInputProps<T>) {
   const className = orEmptyString(inputClassName);
   const { category } = useValidationData(validation.messageNode, validation.touched);
   const style = category === 'error' ? reactSelectValidationErrorStyle : {};
+  const fieldValue = props.multi ? (isNil(value) ? [] : value) : orEmptyString(value);
+
   const fieldProps = {
     name,
-    value: orEmptyString(value),
+    value: fieldValue,
     onBlur: reactSelectOnBlurAdapter(name, value, onBlur),
     onChange: reactSelectOnChangeAdapter(name, onChange),
   };

--- a/app/scripts/modules/core/src/presentation/forms/inputs/ReactSelectInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/ReactSelectInput.tsx
@@ -1,6 +1,6 @@
 import { isNil } from 'lodash';
 import React from 'react';
-import Select, { Option, OptionValues, ReactSelectProps } from 'react-select';
+import Select, { Option, OptionValues, ReactSelectProps, Creatable } from 'react-select';
 import VirtualizedSelect from 'react-virtualized-select';
 
 import { noop } from 'core/utils';
@@ -15,7 +15,7 @@ export interface IReactSelectInputProps<T = OptionValues>
   extends IFormInputProps,
     OmitControlledInputPropsFrom<ReactSelectProps<T>> {
   stringOptions?: string[];
-  mode?: 'TETHERED' | 'VIRTUALIZED' | 'PLAIN';
+  mode?: 'TETHERED' | 'VIRTUALIZED' | 'PLAIN' | 'CREATABLE';
 }
 
 // TODO: use standard css classes (from style guide?)
@@ -92,6 +92,8 @@ export function ReactSelectInput<T = string>(props: IReactSelectInputProps<T>) {
       <TetheredSelect {...commonProps} options={options} />
     ) : mode === 'VIRTUALIZED' ? (
       <VirtualizedSelect {...commonProps} options={options} optionRenderer={null} />
+    ) : mode === 'CREATABLE' ? (
+      <CreatableSelect {...commonProps} options={options} />
     ) : (
       <Select {...commonProps} options={options} />
     );
@@ -103,4 +105,18 @@ export function ReactSelectInput<T = string>(props: IReactSelectInputProps<T>) {
   } else {
     return <SelectElement options={optionOptions} />;
   }
+}
+
+function CreatableSelect(props: IReactSelectInputProps<any>) {
+  // React select 1.x requires the options array to contain any created values
+  const options = React.useMemo(() => {
+    const options = props.options ?? [];
+    const optionsValues = options.map((o) => o.value);
+    const createdOptions = ((props.value as string[]) ?? [])
+      .filter((val) => !optionsValues.includes(val))
+      .map((opt) => ({ label: opt, value: opt }));
+    return options.concat(createdOptions);
+  }, [props.options, props.value]);
+
+  return <Creatable {...props} options={options} />;
 }


### PR DESCRIPTION
This PR allows the ReactSelectInput to use the `react-select` 1.x `Creatable` component which allows you to type an arbitrary value and hit Enter, even if it's not an existing option in the list.
