### PR TITLE
fix(core): allow stage validation to use both validators and validateFn

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/validation/PipelineConfigValidator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/PipelineConfigValidator.ts
@@ -136,14 +136,16 @@ export class PipelineConfigValidator {
             );
           }
         });
-      } else if (config && config.validateFn) {
+      }
+      if (config && config.validateFn) {
         validations.push(
           $q<FormikErrors<IStage>>((resolve, reject) =>
             Promise.resolve(config.validateFn(stage, { pipeline })).then(resolve, reject),
           ).then((errors: FormikErrors<IStage>) => {
             const array: string[] = PipelineConfigValidator.flattenValues(errors);
-            if (array && array.length > 0) {
-              stageValidations.set(stage, array);
+            if (array?.length) {
+              const existingValidations = stageValidations.get(stage) ?? [];
+              stageValidations.set(stage, existingValidations.concat(array));
             }
           }),
         );


### PR DESCRIPTION
Imagine a stage that uses Formik to perform field-level validation, but also wants to validate the presence of an upstream stage, e.g. a stage that provides an image, via a `stageBeforeTypeValidator`.

It's not easy (or seems clean) to include stage-level validation in the formik validator code, but the PipelineConfigValidator only takes one or the other of `validators` and `validateFn`.

This just lets a stage do both.