### PR TITLE
Validate Titus Environment Variables

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.less
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.less
@@ -1,0 +1,5 @@
+.ServerGroupParameters {
+  .StandardFieldLayout_Label {
+    min-width: 160px;
+  }
+}

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/TitusMapLayout.less
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/TitusMapLayout.less
@@ -1,0 +1,3 @@
+.TitusMapLayout_Contents * {
+  flex: auto
+}

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/TitusMapLayout.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/TitusMapLayout.tsx
@@ -1,0 +1,28 @@
+import { isUndefined } from 'lodash';
+import React from 'react';
+
+import { IFormInputValidation, ValidationMessage } from '@spinnaker/core';
+import { ILayoutProps } from '@spinnaker/core';
+import './TitusMapLayout.less';
+
+export function TitusMapLayout(props: ILayoutProps) {
+  const { label, help, input, actions, validation = {} as IFormInputValidation } = props;
+  const { hidden, messageNode, category } = validation;
+  const showLabel = !isUndefined(label) || !isUndefined(help);
+
+  return (
+    <div className="TitusMapLayout flex-container-v">
+      {showLabel && (
+        <h4>
+          {label} {help}
+        </h4>
+      )}
+
+      <div className="flex-container-h baseline margin-between-lg TitusMapLayout_Contents">
+        {input} {actions}
+      </div>
+
+      {!hidden && <ValidationMessage message={messageNode} type={category} />}
+    </div>
+  );
+}


### PR DESCRIPTION
Two commits: 

1) Migrate to Spinnaker Forms
2) Migrate validation to ValidateForm and validate Environment Variables.

 
<img width="899" alt="Screen Shot 2021-03-16 at 4 32 13 PM" src="https://user-images.githubusercontent.com/2053478/111406884-22529600-8677-11eb-900d-93b6aa3f25a1.png">


<img width="897" alt="Screen Shot 2021-03-16 at 4 49 49 PM" src="https://user-images.githubusercontent.com/2053478/111407255-a9a00980-8677-11eb-82e6-7b37e0f293d6.png">




Some notes re: the Forms migration:

- I wired up a `TitusMapLayout` to mimic the existing layout of the titus deploy stage with the form input label as a header above the `MapEditor`
- Extracted some [FormInputs](https://github.com/spinnaker/deck/blob/abbce18f6221146d13889df3e3edc5f0c96b6c4e/app/scripts/modules/core/src/presentation/forms/README.md#inputs) to their own components
  - ServiceJobProcesses: this is a checklist, but the known list of options is augmented with the values in the existing stage JSON
  - IPv6Checkbox: `'true'`/`undefined` values when checked/unchecked
  - IamInstanceProfile: Shows the account and "apply default" button



