### PR TITLE
fix(core): Export ConsoleOutputLink

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/InstanceStatus.tsx
+++ b/app/scripts/modules/amazon/src/instance/details/InstanceStatus.tsx
@@ -76,12 +76,12 @@ export const InstanceStatus = ({
                 {hasLoadBalancer &&
                   metric.type === 'LoadBalancer' &&
                   (metric.loadBalancers || []).map((lb) => (
-                    <InstanceLoadBalancerHealth key={lb.name} loadBalancer={lb} />
+                    <InstanceLoadBalancerHealth key={`lb-${lb.name}`} loadBalancer={lb} />
                   ))}
                 {hasTargetGroup &&
                   metric.type === 'TargetGroup' &&
                   (metric.targetGroups || []).map((tg) => (
-                    <InstanceLoadBalancerHealth key={tg.name} loadBalancer={tg} ipAddress={privateIpAddress} />
+                    <InstanceLoadBalancerHealth key={`tg-${tg.name}`} loadBalancer={tg} ipAddress={privateIpAddress} />
                   ))}
               </dd>
             </React.Fragment>

--- a/app/scripts/modules/core/src/instance/details/index.ts
+++ b/app/scripts/modules/core/src/instance/details/index.ts
@@ -1,3 +1,4 @@
+export * from './console/ConsoleOutputLink';
 export * from './InstanceActions';
 export * from './InstanceDetails';
 export * from './InstanceDetailsHeader';


### PR DESCRIPTION
- export `ConsoleOutputLink`
- make key on `InstanceLoadBalancerHealth` unique to avoid console warnings (warning appears when target group and load balancer have similar names)
