### PR TITLE
fix(pipeline): Collapse parameters in ancestry

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -321,6 +321,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
   public render() {
     const {
       application,
+      descendantExecutionId,
       execution,
       showAccountLabels,
       showDurations,
@@ -470,7 +471,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
 
           <ParametersAndArtifacts
             execution={execution}
-            expandParamsOnInit={standalone}
+            expandParamsOnInit={standalone && !descendantExecutionId}
             pipelineConfig={pipelineConfig}
           />
 


### PR DESCRIPTION
Just buying some more vertical screen real estate by having parameters collapsed instead of expanded by default on initial render.

This is only for the ancestor executions. For the main execution, it will still be expando by default