### PR TITLE
fix(core/projects): Recent projects: only save the link to project dashboard

### DIFF
--- a/app/scripts/modules/core/src/projects/projects.states.ts
+++ b/app/scripts/modules/core/src/projects/projects.states.ts
@@ -74,6 +74,7 @@ module(PROJECTS_STATES_CONFIG, [
         },
         history: {
           type: 'projects',
+          state: 'home.project',
           keyParams: ['project'],
         },
       },


### PR DESCRIPTION
When following a link to the recently used project, we now always link to `home.project` which will redirect to the project dashboard.