### PR TITLE
fix(titus): Default container attributes transfer to pipeline deploy …

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -223,6 +223,10 @@ angular.module(TITUS_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER, []).factor
         };
 
         pipelineCluster.strategy = pipelineCluster.strategy || '';
+        pipelineCluster.containerAttributes = {
+          ...command.containerAttributes,
+          ...pipelineCluster.containerAttributes,
+        };
         const extendedCommand = angular.extend({}, command, pipelineCluster, viewOverrides);
         return extendedCommand;
       });


### PR DESCRIPTION

There are some default container attributes that should be passed down to pipeline deploy config in the test environment. They were being overridden by `angular.extend`.