### PR TITLE
feat(titus): Finish migrating instance details to react

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonHealth.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonHealth.ts
@@ -11,4 +11,5 @@ export interface IAmazonTargetGroupHealth extends ILoadBalancerHealth {
   // Augmented to backend data in applyHealthCheckInfoToTargetGroups()
   healthCheckProtocol?: string;
   healthCheckPath?: string;
+  instanceId?: string;
 }

--- a/app/scripts/modules/core/src/instance/details/index.ts
+++ b/app/scripts/modules/core/src/instance/details/index.ts
@@ -5,3 +5,4 @@ export * from './InstanceDetailsHeader';
 export * from './InstanceDetailsPane';
 export * from './InstanceInsights';
 export * from './InstanceLinks';
+export * from './console/ConsoleOutputLink';

--- a/app/scripts/modules/titus/src/index.ts
+++ b/app/scripts/modules/titus/src/index.ts
@@ -4,3 +4,4 @@ export * from './reactShims';
 export * from './serverGroup/details';
 export * from './titus.settings';
 export * from './domain';
+export * from './instance/details';

--- a/app/scripts/modules/titus/src/instance/details/TitusInstanceDetails.tsx
+++ b/app/scripts/modules/titus/src/instance/details/TitusInstanceDetails.tsx
@@ -1,0 +1,202 @@
+import * as React from 'react';
+
+import { IAmazonHealth, InstanceStatus } from '@spinnaker/amazon';
+import { AccountService, Action, Application, CollapsibleSection, ConsoleOutputLink, IAccountDetails, IInstanceDetailsProps, IMoniker, InstanceActions, InstanceDetailsHeader, InstanceDetailsPane, InstanceInsights, InstanceLinks, InstanceReader, IOverridableProps, overridableComponent, RecentHistoryService, SETTINGS, Spinner, useData } from '@spinnaker/core';
+
+import { TitusInstanceDns } from './TitusInstanceDns';
+import { TitusInstanceInformation } from './TitusInstanceInformation';
+import { ITitusInstance, ITitusServerGroup, ITitusServerGroupView } from '../../domain';
+import { TitusSecurityGroupsDetailsSection } from '../../serverGroup/details/TitusSecurityGroups';
+import { buildTaskActions, extractHealthMetrics } from './titusInstanceDetailsUtils';
+
+export interface ITitusInstanceDetailsProps extends IInstanceDetailsProps {
+  instance: { instanceId: string };
+}
+
+export interface ITitusInstanceDetailsContentProps {
+  account: IAccountDetails;
+  actions: Action[];
+  app: Application;
+  baseIpAddress: string;
+  environment: string;
+  healthMetrics: IAmazonHealth[];
+  instance: ITitusInstance;
+  instanceId: string;
+  instancePort: string;
+  loading: boolean;
+  moniker: IMoniker;
+  serverGroup: ITitusServerGroup;
+  region: string;
+}
+
+const TitusInstanceDetailsContent = ({
+  account,
+  actions,
+  app,
+  baseIpAddress,
+  environment,
+  healthMetrics,
+  instance,
+  instanceId,
+  instancePort,
+  loading,
+  moniker,
+  serverGroup,
+  region,
+}: ITitusInstanceDetailsContentProps) => {
+  const defaultSshLink = `ssh -t ${account?.bastionHost} 'titus-ssh -region ${region} ${instanceId}'`;
+  const regionDetails = (account.regions || []).find((r) => r.name === region);
+
+  return (
+    <div className="details-panel">
+      <div className="header">
+        <InstanceDetailsHeader
+          healthState={instance.healthState}
+          instanceId={instanceId}
+          loading={loading}
+          sshLink={defaultSshLink}
+          standalone={app.isStandalone}
+        />
+        <div className="actions">
+          <InstanceActions actions={actions} />
+          {Boolean(instance?.insightActions?.length) && (
+            <InstanceInsights analytics={true} insights={instance.insightActions} instance={instance} />
+          )}
+        </div>
+      </div>
+      <div className="content">
+        <TitusInstanceInformation instance={instance} titusUiEndpoint={regionDetails?.endpoint} />
+        <InstanceStatus
+          healthMetrics={healthMetrics}
+          healthState={instance.healthState}
+          metricTypes={['TargetGroup']}
+          privateIpAddress={instance.privateIpAddress}
+        />
+        <TitusInstanceDns
+          containerIp={instance.placement?.containerIp}
+          host={instance.placement?.host}
+          instancePort={instancePort}
+          ipv6Address={instance.ipv6Address}
+        />
+        <div className="collapsible-section">
+          <TitusSecurityGroupsDetailsSection app={app} serverGroup={serverGroup as ITitusServerGroupView} />
+        </div>
+        <CollapsibleSection heading="Console Output">
+          <ConsoleOutputLink instance={instance} />
+        </CollapsibleSection>
+        <InstanceLinks
+          address={baseIpAddress}
+          application={app}
+          instance={instance}
+          environment={environment}
+          moniker={moniker}
+        />
+      </div>
+    </div>
+  );
+};
+
+const OverridableTitusInstanceDetailsContent = overridableComponent<
+  ITitusInstanceDetailsContentProps & IOverridableProps,
+  typeof TitusInstanceDetailsContent
+>(TitusInstanceDetailsContent, 'titus.instance.details.content');
+
+export const TitusInstanceDetails = ({ app, environment, instance, moniker }: ITitusInstanceDetailsProps) => {
+  const { instanceId } = instance;
+  const serverGroup = app.serverGroups.data.find((sg: ITitusServerGroup) =>
+    sg.instances.some((possibleMatch) => possibleMatch.id === instanceId),
+  );
+  const { account, region } = serverGroup;
+
+  const retrieveInstance = () => {
+    RecentHistoryService.addExtraDataToLatest('instances', {
+      account,
+      region,
+      serverGroup: serverGroup.name,
+    });
+
+    return Promise.all([
+      InstanceReader.getInstanceDetails(account, region, instanceId).then((instance) => ({
+        ...instance,
+        account,
+        region,
+      })),
+      AccountService.getAccountDetails(account),
+    ]);
+  };
+
+  const {
+    result: [currentInstance, currentAccount],
+    status,
+  } = useData(
+    () => {
+      if (app.isStandalone) {
+        return retrieveInstance();
+      } else {
+        return app.serverGroups.ready().then(retrieveInstance);
+      }
+    },
+    [{} as ITitusInstance, {} as IAccountDetails],
+    [instanceId, serverGroup],
+  );
+
+  const taskActions = buildTaskActions(currentInstance, app);
+  const healthMetrics = extractHealthMetrics(
+    currentInstance.health as IAmazonHealth[],
+    app.loadBalancers.data,
+    currentAccount.awsAccount,
+  );
+
+  const isLoading = status === 'PENDING';
+  const instancePort = app.attributes?.instancePort || SETTINGS.defaultInstancePort || '80';
+  const baseIpAddress = currentInstance.placement?.containerIp || currentInstance?.placement?.host;
+
+  if (isLoading) {
+    return (
+      <InstanceDetailsPane>
+        <div className="horizontal center middle">
+          <Spinner size="small" />
+        </div>
+      </InstanceDetailsPane>
+    );
+  }
+
+  if (!currentInstance?.id) {
+    return (
+      <div className="details-panel">
+        <div className="header">
+          <InstanceDetailsPane>
+            <div className="header-text horizontal middle">
+              <h3 className="horizontal middle space-between flex-1">{instance.instanceId}</h3>
+            </div>
+          </InstanceDetailsPane>
+        </div>
+        <div className="content">
+          <div className="content-section">
+            <div className="content-body text-center">
+              <h3>Instance not found.</h3>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <OverridableTitusInstanceDetailsContent
+      account={currentAccount}
+      actions={taskActions}
+      app={app}
+      baseIpAddress={baseIpAddress}
+      environment={environment}
+      healthMetrics={healthMetrics}
+      instance={currentInstance as ITitusInstance}
+      instanceId={instance.instanceId}
+      instancePort={instancePort}
+      moniker={moniker}
+      loading={isLoading}
+      serverGroup={serverGroup}
+      region={region}
+    />
+  );
+};

--- a/app/scripts/modules/titus/src/instance/details/index.ts
+++ b/app/scripts/modules/titus/src/instance/details/index.ts
@@ -1,0 +1,4 @@
+export * from './TitusInstanceDetails';
+export * from './titusInstanceDetailsUtils';
+export * from './TitusInstanceDns';
+export * from './TitusInstanceInformation';

--- a/app/scripts/modules/titus/src/instance/details/titusInstanceDetailsUtils.spec.ts
+++ b/app/scripts/modules/titus/src/instance/details/titusInstanceDetailsUtils.spec.ts
@@ -1,0 +1,124 @@
+import {
+  IAmazonApplicationLoadBalancer,
+  IAmazonHealth,
+  IAmazonTargetGroupHealth,
+  ITargetGroup,
+} from '@spinnaker/amazon';
+import { Application } from '@spinnaker/core';
+import { mockHealth, mockInstance, mockLoadBalancer, mockLoadBalancerHealth } from '@spinnaker/mocks';
+import {
+  applyTargetGroupInfoToHealthMetric,
+  buildTaskActions,
+  extractHealthMetrics,
+} from './titusInstanceDetailsUtils';
+
+const targetGroup1 = {
+  account: 'test',
+  name: 'tg1',
+  healthCheckPort: '8080',
+  healthCheckProtocol: 'https',
+  healthCheckPath: '/healthcheck',
+};
+const targetGroup2 = {
+  ...targetGroup1,
+  name: 'tg2',
+  port: '7001',
+  healthCheckPort: 'traffic-port',
+};
+
+const metricTg1 = {
+  instanceId: '100.000.000.00',
+  name: 'tg1',
+  targetGroupName: 'tg1',
+  healthState: 'Up',
+  state: 'healthy',
+};
+
+const metricTg2 = {
+  ...metricTg1,
+  name: 'test-tg',
+  targetGroupName: 'test-tg',
+};
+
+const metricTg3 = {
+  ...metricTg1,
+  name: 'tg2',
+  targetGroupName: 'tg2',
+};
+
+const tgHealth = {
+  state: 'Up',
+  targetGroups: [metricTg1, metricTg2],
+  type: 'TargetGroup',
+};
+
+describe('applyTargetGroupInfoToHealthMetric', () => {
+  const metricGroups = [metricTg1, metricTg2, metricTg3] as IAmazonTargetGroupHealth[];
+  const targetGroups = [targetGroup1, targetGroup2] as ITargetGroup[];
+
+  it('should apply healthcheck info to health metrics', () => {
+    const [result1, result2, result3] = applyTargetGroupInfoToHealthMetric(metricGroups, targetGroups, 'test');
+
+    // Uses given healthcheck port
+    expect(result1.healthCheckPath).toEqual(':8080/healthcheck');
+    expect(result1.healthCheckProtocol).toEqual('https');
+
+    // Target group is not found
+    expect(result2.healthCheckPath).toBeUndefined();
+    expect(result2.healthCheckProtocol).toBeUndefined();
+
+    // Uses traffic port
+    expect(result3.healthCheckPath).toEqual(':7001/healthcheck');
+    expect(result3.healthCheckProtocol).toEqual('https');
+  });
+});
+
+describe('extractHealthMetrics', () => {
+  it('should extract unknown health states', () => {
+    const lb = { ...mockLoadBalancer, targetGroups: [targetGroup1] } as IAmazonApplicationLoadBalancer;
+    const health1 = [mockHealth, mockLoadBalancerHealth, { ...mockHealth, state: 'Unknown' }] as IAmazonHealth[];
+    const health2 = [mockHealth, mockLoadBalancerHealth] as IAmazonHealth[];
+
+    const result1 = extractHealthMetrics(health1, [lb], 'test');
+    expect(result1.length).toEqual(2);
+
+    const result2 = extractHealthMetrics(health2, [lb], 'test');
+    expect(result2.length).toEqual(2);
+  });
+
+  it('should supplement TargetGroup health info', () => {
+    const lb = { ...mockLoadBalancer, targetGroups: [targetGroup1, targetGroup2] } as IAmazonApplicationLoadBalancer;
+
+    const health = [mockHealth, tgHealth] as IAmazonHealth[];
+
+    const result = extractHealthMetrics(health, [lb], 'test');
+    expect(result.length).toEqual(2);
+
+    const tgs = result[1].targetGroups;
+    expect(tgs[0].healthCheckPath).toEqual(':8080/healthcheck');
+  });
+});
+
+describe('buildTaskActions', () => {
+  it('should render required actions', () => {
+    // Instance has Discovery health
+    const actions1 = buildTaskActions(mockInstance, {} as Application);
+    expect(actions1.length).toEqual(3);
+    expect(actions1[2].label).toEqual('Disable in Discovery');
+
+    const actions2 = buildTaskActions(
+      { ...mockInstance, health: [{ ...mockHealth, state: 'OutOfService' }] },
+      {} as Application,
+    );
+    expect(actions2.length).toEqual(3);
+    expect(actions2[2].label).toEqual('Enable in Discovery');
+
+    // Instance does not have Discovery health
+    const actions3 = buildTaskActions({ ...mockInstance, health: [tgHealth as IAmazonHealth] }, {} as Application);
+    expect(actions3.length).toEqual(2);
+
+    // Instance has no health
+    const actions4 = buildTaskActions({ ...mockInstance, health: [] }, {} as Application);
+    expect(actions4.length).toEqual(2);
+  });
+});

--- a/app/scripts/modules/titus/src/instance/details/titusInstanceDetailsUtils.ts
+++ b/app/scripts/modules/titus/src/instance/details/titusInstanceDetailsUtils.ts
@@ -1,0 +1,186 @@
+import {
+  getAllTargetGroups,
+  IAmazonApplicationLoadBalancer,
+  IAmazonHealth,
+  IAmazonNetworkLoadBalancer,
+  IAmazonTargetGroupHealth,
+  ITargetGroup,
+} from '@spinnaker/amazon';
+import {
+  Action,
+  Application,
+  ConfirmationModalService,
+  IInstance,
+  IJob,
+  InstanceWriter,
+  ReactInjector,
+} from '@spinnaker/core';
+
+const applyTargetGroupInfoToHealthMetric = (
+  metricGroups: IAmazonTargetGroupHealth[],
+  targetGroups: ITargetGroup[],
+  account: string,
+) => {
+  return metricGroups.map((tg) => {
+    const group = targetGroups.find(
+      (g) => (g.name === tg.name || g.name === tg.targetGroupName) && g.account === account,
+    );
+    const useTrafficPort = group?.healthCheckPort === 'traffic-port' || !group?.healthCheckPort;
+    return {
+      ...tg,
+      name: group?.name,
+      healthCheckPath: `:${useTrafficPort ? group?.port : group.healthCheckPort}${group?.healthCheckPath || ''}`,
+      healthCheckProtocol: group?.healthCheckProtocol?.toLowerCase(),
+    };
+  });
+};
+
+export const extractHealthMetrics = (
+  health: IAmazonHealth[],
+  loadBalancers: IAmazonApplicationLoadBalancer[] | IAmazonNetworkLoadBalancer[],
+  account: string,
+): IAmazonHealth[] => {
+  const displayableMetrics = (health || []).filter((m) => m.state !== 'Unknown');
+  const allTargetGroups = getAllTargetGroups(loadBalancers);
+
+  return displayableMetrics.map((metric) => {
+    if (metric.type === 'TargetGroup') {
+      const augmentedGroups = applyTargetGroupInfoToHealthMetric(metric.targetGroups, allTargetGroups, account);
+      return { ...metric, targetGroups: augmentedGroups } as IAmazonHealth;
+    }
+
+    return metric;
+  });
+};
+
+const terminateInstance = (instance: IInstance, app: Application) => {
+  return () => {
+    const taskMonitorConfig = {
+      application: app,
+      title: `Terminating ${instance.id}`,
+      onTaskComplete: () => {
+        if (ReactInjector.$state.includes('**.instanceDetails', { id: instance.id })) {
+          ReactInjector.$state.go('^');
+        }
+      },
+    };
+
+    const submitMethod = () => {
+      const params: IJob = { cloudProvider: 'titus' };
+      if (instance.serverGroup) {
+        params.serverGroupName = instance.serverGroup;
+      }
+      return InstanceWriter.terminateInstance(instance, app, params);
+    };
+
+    ConfirmationModalService.confirm({
+      header: `Really terminate ${instance.id}?`,
+      buttonText: `Terminate ${instance.id}`,
+      account: instance.account,
+      taskMonitorConfig,
+      submitMethod,
+    });
+  };
+};
+
+const terminateInstanceAndShrinkServerGroup = (instance: IInstance, app: Application) => {
+  return () => {
+    const taskMonitorConfig = {
+      application: app,
+      title: `Terminating ${instance.id} and shrinking server group`,
+      onTaskComplete: () => {
+        if (ReactInjector.$state.includes('**.instanceDetails', { instanceId: instance.id })) {
+          ReactInjector.$state.go('^');
+        }
+      },
+    };
+
+    const submitMethod = () => {
+      return InstanceWriter.terminateInstancesAndShrinkServerGroups(
+        [
+          {
+            cloudProvider: instance.cloudProvider,
+            instanceIds: [instance.id],
+            account: instance.account,
+            region: instance.region,
+            serverGroup: instance.serverGroup,
+            instances: [instance],
+          },
+        ],
+        app,
+      );
+    };
+
+    ConfirmationModalService.confirm({
+      header: `Really terminate ${instance.id} and shrink ${instance.serverGroup}?`,
+      buttonText: `Terminate ${instance.id} and shrink ${instance.serverGroup}`,
+      account: instance.account,
+      taskMonitorConfig,
+      submitMethod,
+    });
+  };
+};
+
+const enableInstanceInDiscovery = (instance: IInstance, app: Application) => {
+  return () => {
+    const taskMonitorConfig = {
+      application: app,
+      title: `Enabling ${instance.id} in discovery`,
+    };
+
+    const submitMethod = () => InstanceWriter.enableInstanceInDiscovery(instance, app);
+
+    ConfirmationModalService.confirm({
+      header: `Really enable ${instance.id} in discovery?`,
+      buttonText: `Enable ${instance.id}`,
+      account: instance.account,
+      taskMonitorConfig,
+      submitMethod,
+    });
+  };
+};
+
+const disableInstanceInDiscovery = (instance: IInstance, app: Application) => {
+  return () => {
+    const taskMonitorConfig = {
+      application: app,
+      title: `Disabling ${instance.id} in discovery`,
+    };
+
+    const submitMethod = () => InstanceWriter.disableInstanceInDiscovery(instance, app);
+
+    ConfirmationModalService.confirm({
+      header: `Really disable ${instance.id} in discovery?`,
+      buttonText: `Disable ${instance.id}`,
+      account: instance.account,
+      taskMonitorConfig,
+      submitMethod,
+    });
+  };
+};
+
+export const buildTaskActions = (instance: IInstance, app: Application): Action[] => {
+  const taskActions = [
+    { label: 'Terminate', triggerAction: terminateInstance(instance, app) },
+    { label: 'Terminate and Shrink Server Group', triggerAction: terminateInstanceAndShrinkServerGroup(instance, app) },
+  ];
+
+  const discoveryHealth = (instance.health || []).filter((h) => h.type === 'Discovery');
+
+  if (discoveryHealth.length && discoveryHealth[0].state === 'OutOfService') {
+    taskActions.push({
+      label: 'Enable In Discovery',
+      triggerAction: enableInstanceInDiscovery(instance, app),
+    });
+  }
+
+  const hasHealthState = (discoveryHealth || []).some((h) => h.state === 'Up' || h.state === 'Down');
+  if (hasHealthState) {
+    taskActions.push({
+      label: 'Disable in Discovery',
+      triggerAction: disableInstanceInDiscovery(instance, app),
+    });
+  }
+
+  return taskActions;
+};

--- a/app/scripts/modules/titus/src/instance/details/titusInstanceDetailsUtils.ts
+++ b/app/scripts/modules/titus/src/instance/details/titusInstanceDetailsUtils.ts
@@ -16,7 +16,7 @@ import {
   ReactInjector,
 } from '@spinnaker/core';
 
-const applyTargetGroupInfoToHealthMetric = (
+export const applyTargetGroupInfoToHealthMetric = (
   metricGroups: IAmazonTargetGroupHealth[],
   targetGroups: ITargetGroup[],
   account: string,
@@ -29,7 +29,9 @@ const applyTargetGroupInfoToHealthMetric = (
     return {
       ...tg,
       name: group?.name,
-      healthCheckPath: `:${useTrafficPort ? group?.port : group.healthCheckPort}${group?.healthCheckPath || ''}`,
+      healthCheckPath: group
+        ? `:${useTrafficPort ? group?.port : group.healthCheckPort}${group?.healthCheckPath || ''}`
+        : undefined,
       healthCheckProtocol: group?.healthCheckProtocol?.toLowerCase(),
     };
   });
@@ -169,7 +171,7 @@ export const buildTaskActions = (instance: IInstance, app: Application): Action[
 
   if (discoveryHealth.length && discoveryHealth[0].state === 'OutOfService') {
     taskActions.push({
-      label: 'Enable In Discovery',
+      label: 'Enable in Discovery',
       triggerAction: enableInstanceInDiscovery(instance, app),
     });
   }

--- a/app/scripts/modules/titus/src/titus.module.ts
+++ b/app/scripts/modules/titus/src/titus.module.ts
@@ -91,8 +91,6 @@ module(TITUS_MODULE, [
       useProvider: 'aws',
     },
     instance: {
-      detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
-      detailsController: 'titusInstanceDetailsCtrl',
       details: TitusInstanceDetails,
     },
   });

--- a/app/scripts/modules/titus/src/titus.module.ts
+++ b/app/scripts/modules/titus/src/titus.module.ts
@@ -4,6 +4,7 @@ import { AmazonLoadBalancersTag } from '@spinnaker/amazon';
 import { CloudProviderRegistry, DeploymentStrategyRegistry } from '@spinnaker/core';
 
 import './help/titus.help';
+import { TitusInstanceDetails } from './instance/details/TitusInstanceDetails';
 import { TITUS_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER } from './instance/details/instance.details.controller';
 import { TITUS_INSTANCE_DNS_COMPONENT } from './instance/details/titusInstanceDns.component';
 import { TITUS_INSTANCE_INFORMATION_COMPONENT } from './instance/details/titusInstanceInformation.component';
@@ -92,6 +93,7 @@ module(TITUS_MODULE, [
     instance: {
       detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
       detailsController: 'titusInstanceDetailsCtrl',
+      details: TitusInstanceDetails,
     },
   });
 });


### PR DESCRIPTION
This PR completes the Titus instance details react migration. What this PR includes:
- **`TitusInstanceDetails`** - This component captures all common behavior. It fetches, transforms and passes all needed information to the presentational `TitusInstanceDetailsContent` component.  It will also show any error or loading states.
- **`OverridableTitusInstanceDetailsContent`** - This is mainly a presentational component composed of different instance details sections. It is meant to be overridden and augmented with custom behavior or collapsible sections. 
- **`utils`** to help generate common instance information.
  - `extractHealthMetrics` - Gets all displayable metrics, and augments health metrics with additional data
  - `buildTaskActions` - Returns an array of actions based on the health state of the instance
  
What this does not include:
- Deleting angular files. There are still some dependencies that will be removed shortly. At that point, I will create another PR that deletes those files.  
