### PR TITLE
fix(md): remove depends-on icon from the artifacts list

### DIFF
--- a/app/scripts/modules/core/src/managed/artifactsList/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/artifactsList/ArtifactsList.tsx
@@ -155,10 +155,11 @@ export const ArtifactRow = ({ isSelected, clickHandler, version: versionInfo, re
   );
 };
 
+const ignoredConstraintTypes: Array<IConstraint['type']> = ['depends-on'];
+
 type ArtifactStatusList = IStatusBubbleStackProps['statuses'];
 function getArtifactStatuses({ environments, lifecycleSteps }: IManagedArtifactVersion): ArtifactStatusList {
   const statuses: ArtifactStatusList = [];
-  // TODO: ask Erik why we are doing this
 
   // NOTE: The order in which entries are added to `statuses` is important. The highest priority
   // item must be inserted first.
@@ -188,7 +189,7 @@ function getArtifactStatuses({ environments, lifecycleSteps }: IManagedArtifactV
 
     environment.constraints?.forEach((constraint: IConstraint) => {
       const icon = constraintsManager.getIcon(constraint);
-      if (constraint.status === 'PENDING') {
+      if (constraint.status === 'PENDING' && !ignoredConstraintTypes.includes(constraint.type)) {
         pendingConstraintIcons.add(icon);
       } else if (constraint.status === 'FAIL' || constraint.status === 'OVERRIDE_FAIL') {
         failedConstraintIcons.add(icon);


### PR DESCRIPTION
The PR removes the depends-on icon from the artifact versions list (the example below is showing MJ). I'm not a fan of remove only this constraint, as it creates inconsistency in user expectations but we will deal with it later. 

![image](https://user-images.githubusercontent.com/17147717/112418847-7f89bf80-8ce7-11eb-8056-5b08e4ead6ad.png)
