### PR TITLE
chore: update commit hook to run eslint first, then prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,11 +228,11 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged -p false"
     }
   },
   "lint-staged": {
-    "app/**/*.{js,jsx,ts,tsx,html,css,less}": "prettier --write",
-    "app/**/*.{js,jsx,ts,tsx}": "eslint --fix"
+    "app/**/*.{js,jsx,ts,tsx}": "eslint --fix",
+    "app/**/*.{js,jsx,ts,tsx,html,css,less}": "prettier --write"
   }
 }


### PR DESCRIPTION
This makes the eslint rules run first, then the prettier reformat.  Some eslint rule fixers will leave the source code in a un-pretty format, so let's run prettier AFTER eslint --fix.