### PR TITLE
chore(package): amazon@0.0.298 azure@0.0.266 core@0.0.563 ecs@0.0.279 titus@0.0.168

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.297",
+  "version": "0.0.298",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/azure/package.json
+++ b/app/scripts/modules/azure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/azure",
   "license": "Apache-2.0",
-  "version": "0.0.265",
+  "version": "0.0.266",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.562",
+  "version": "0.0.563",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.278",
+  "version": "0.0.279",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.167",
+  "version": "0.0.168",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.298

0ff5c18c3fb947800460d32241e8b31d6720c760 test: fix typing errors introduced by stricter types in updated @types/jasmine package
84e4fe6b24592c9bbb65fe45339ccf2a930b2c50 test: switch some imports to `import type` to eliminate certain warnings during karma runs
d58cb46d9559c0c83e7642e0eb79687f9887e586 refactor(amazon/serverGroup): Delete unused metricAlarmChart angularjs component
0861d2dcd07135c45c8e3baf54b0ccdebff9ae6e feat(amazon/serverGroup): Replace angular metric-alarm-chart with react MetricAlarmChart
802cb2eea59c858fc4cb216325b6ae78a0cd9aef feat(amazon/serverGroup): Introduce MetricAlarmChart.tsx using Chart.js

## azure@0.0.266

807830424a51219b7aecf2cf7240039237e5a7af test: fix usage of httpMock

## core@0.0.563

ecbd4e2e96066a00dc85ac2cc7302dcc6f16b7e2 test: remove async/done combination which is now deprecated
0ff5c18c3fb947800460d32241e8b31d6720c760 test: fix typing errors introduced by stricter types in updated @types/jasmine package
ee5bcfc933c6a2ef49c78b0c7ded11e0ecdc1bc8 test: fix uncaught rejection detected by updated jasmine/karma libs
84e4fe6b24592c9bbb65fe45339ccf2a930b2c50 test: switch some imports to `import type` to eliminate certain warnings during karma runs
f8f72b7d53c55f635b2c96490ac1f8c9d565093a chore(ci): replace hex colors with closes css variables (#9060)
6917f5728f656ae39236328e0e152f1167a15cc7 fix(core/pipeline): use cloudprovider from context when generating links (#9061)

## ecs@0.0.279

0ff5c18c3fb947800460d32241e8b31d6720c760 test: fix typing errors introduced by stricter types in updated @types/jasmine package

## titus@0.0.168

0861d2dcd07135c45c8e3baf54b0ccdebff9ae6e feat(amazon/serverGroup): Replace angular metric-alarm-chart with react MetricAlarmChart

PR created via `modules/publish.js`