### PR TITLE
pluginsdk enhance

### DIFF
--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -37,6 +37,7 @@
     "rollup-plugin-external-globals": "0.6.1",
     "rollup-plugin-less": "1.1.2",
     "rollup-plugin-postcss": "3.1.8",
+    "rollup-plugin-visualizer": "4.2.2",
     "rxjs": "^5.4.2",
     "shx": "0.3.3",
     "typescript": "^4.0.0",
@@ -89,6 +90,9 @@
       "dev": true
     },
     "rollup-plugin-postcss": {
+      "dev": true
+    },
+    "rollup-plugin-visualizer": {
       "dev": true
     },
     "shx": {

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -14,6 +14,7 @@
   "peerDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",
     "@rollup/plugin-node-resolve": "10.0.0",
+    "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-typescript": "6.1.0",
     "@spinnaker/core": "0.0.554",
     "@spinnaker/eslint-plugin": "1.0.13",
@@ -41,22 +42,59 @@
     "utf-8-validate": "5.0.3"
   },
   "peerDependenciesMeta": {
-    "@rollup/plugin-commonjs": { "dev": true },
-    "@rollup/plugin-node-resolve": { "dev": true },
-    "@rollup/plugin-typescript": { "dev": true },
-    "@spinnaker/eslint-plugin": { "dev": true },
-    "@types/react": { "dev": true },
-    "bufferutil": { "dev": true },
-    "husky": { "dev": true },
-    "npm-run-all": { "dev": true },
-    "prettier": { "dev": true },
-    "pretty-quick": { "dev": true },
-    "rollup": { "dev": true },
-    "rollup-plugin-external-globals": { "dev": true },
-    "rollup-plugin-less": { "dev": true },
-    "rollup-plugin-postcss": { "dev": true },
-    "shx": { "dev": true },
-    "typescript": { "dev": true },
-    "utf-8-validate": { "dev": true }
+    "@rollup/plugin-commonjs": {
+      "dev": true
+    },
+    "@rollup/plugin-json": {
+      "dev": true
+    },
+    "@rollup/plugin-node-resolve": {
+      "dev": true
+    },
+    "@rollup/plugin-typescript": {
+      "dev": true
+    },
+    "@spinnaker/eslint-plugin": {
+      "dev": true
+    },
+    "@types/react": {
+      "dev": true
+    },
+    "bufferutil": {
+      "dev": true
+    },
+    "husky": {
+      "dev": true
+    },
+    "npm-run-all": {
+      "dev": true
+    },
+    "prettier": {
+      "dev": true
+    },
+    "pretty-quick": {
+      "dev": true
+    },
+    "rollup": {
+      "dev": true
+    },
+    "rollup-plugin-external-globals": {
+      "dev": true
+    },
+    "rollup-plugin-less": {
+      "dev": true
+    },
+    "rollup-plugin-postcss": {
+      "dev": true
+    },
+    "shx": {
+      "dev": true
+    },
+    "typescript": {
+      "dev": true
+    },
+    "utf-8-validate": {
+      "dev": true
+    }
   }
 }

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -37,6 +37,7 @@
     "rollup-plugin-external-globals": "0.6.1",
     "rollup-plugin-less": "1.1.2",
     "rollup-plugin-postcss": "3.1.8",
+    "rollup-plugin-terser": "7.0.2",
     "rollup-plugin-visualizer": "4.2.2",
     "rxjs": "^5.4.2",
     "shx": "0.3.3",
@@ -90,6 +91,9 @@
       "dev": true
     },
     "rollup-plugin-postcss": {
+      "dev": true
+    },
+    "rollup-plugin-terser": {
       "dev": true
     },
     "rollup-plugin-visualizer": {

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk-peerdeps",
   "description": "Provides package dependencies to plugin developers",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "Apache-2.0",
   "scripts": {
     "temp": "./convert-peerdeps.js --from-peerdeps --input package.json --output package.temp.json",
@@ -13,15 +13,15 @@
   "files": [],
   "peerDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",
-    "@rollup/plugin-node-resolve": "10.0.0",
     "@rollup/plugin-json": "4.1.0",
+    "@rollup/plugin-node-resolve": "10.0.0",
     "@rollup/plugin-replace": "2.4.2",
     "@rollup/plugin-typescript": "6.1.0",
     "@rollup/plugin-url": "6.0.0",
-    "@spinnaker/core": "0.0.554",
+    "@spinnaker/core": "0.0.563",
     "@spinnaker/eslint-plugin": "1.0.13",
     "@spinnaker/pluginsdk": "*",
-    "@spinnaker/presentation": "0.0.2",
+    "@spinnaker/presentation": "0.0.4",
     "@types/react": "~16.8.0",
     "@uirouter/core": "6.0.4",
     "@uirouter/react": "1.0.2",
@@ -46,71 +46,27 @@
     "utf-8-validate": "5.0.3"
   },
   "peerDependenciesMeta": {
-    "@rollup/plugin-commonjs": {
-      "dev": true
-    },
-    "@rollup/plugin-json": {
-      "dev": true
-    },
-    "@rollup/plugin-node-resolve": {
-      "dev": true
-    },
-    "@rollup/plugin-replace": {
-      "dev": true
-    },
-    "@rollup/plugin-typescript": {
-      "dev": true
-    },
-    "@rollup/plugin-url": {
-      "dev": true
-    },
-    "@spinnaker/eslint-plugin": {
-      "dev": true
-    },
-    "@types/react": {
-      "dev": true
-    },
-    "bufferutil": {
-      "dev": true
-    },
-    "husky": {
-      "dev": true
-    },
-    "npm-run-all": {
-      "dev": true
-    },
-    "prettier": {
-      "dev": true
-    },
-    "pretty-quick": {
-      "dev": true
-    },
-    "rollup": {
-      "dev": true
-    },
-    "rollup-plugin-external-globals": {
-      "dev": true
-    },
-    "rollup-plugin-less": {
-      "dev": true
-    },
-    "rollup-plugin-postcss": {
-      "dev": true
-    },
-    "rollup-plugin-terser": {
-      "dev": true
-    },
-    "rollup-plugin-visualizer": {
-      "dev": true
-    },
-    "shx": {
-      "dev": true
-    },
-    "typescript": {
-      "dev": true
-    },
-    "utf-8-validate": {
-      "dev": true
-    }
+    "@rollup/plugin-commonjs": { "dev": true },
+    "@rollup/plugin-node-resolve": { "dev": true },
+    "@rollup/plugin-json": { "dev": true },
+    "@rollup/plugin-replace": { "dev": true },
+    "@rollup/plugin-typescript": { "dev": true },
+    "@rollup/plugin-url": { "dev": true },
+    "@spinnaker/eslint-plugin": { "dev": true },
+    "@types/react": { "dev": true },
+    "bufferutil": { "dev": true },
+    "husky": { "dev": true },
+    "npm-run-all": { "dev": true },
+    "prettier": { "dev": true },
+    "pretty-quick": { "dev": true },
+    "rollup": { "dev": true },
+    "rollup-plugin-external-globals": { "dev": true },
+    "rollup-plugin-less": { "dev": true },
+    "rollup-plugin-postcss": { "dev": true },
+    "rollup-plugin-terser": { "dev": true },
+    "rollup-plugin-visualizer": { "dev": true },
+    "shx": { "dev": true },
+    "typescript": { "dev": true },
+    "utf-8-validate": { "dev": true }
   }
 }

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -17,6 +17,7 @@
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-replace": "2.4.2",
     "@rollup/plugin-typescript": "6.1.0",
+    "@rollup/plugin-url": "6.0.0",
     "@spinnaker/core": "0.0.554",
     "@spinnaker/eslint-plugin": "1.0.13",
     "@spinnaker/pluginsdk": "*",
@@ -58,6 +59,9 @@
       "dev": true
     },
     "@rollup/plugin-typescript": {
+      "dev": true
+    },
+    "@rollup/plugin-url": {
       "dev": true
     },
     "@spinnaker/eslint-plugin": {

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -15,6 +15,7 @@
     "@rollup/plugin-commonjs": "16.0.0",
     "@rollup/plugin-node-resolve": "10.0.0",
     "@rollup/plugin-json": "4.1.0",
+    "@rollup/plugin-replace": "2.4.2",
     "@rollup/plugin-typescript": "6.1.0",
     "@spinnaker/core": "0.0.554",
     "@spinnaker/eslint-plugin": "1.0.13",
@@ -49,6 +50,9 @@
       "dev": true
     },
     "@rollup/plugin-node-resolve": {
+      "dev": true
+    },
+    "@rollup/plugin-replace": {
       "dev": true
     },
     "@rollup/plugin-typescript": {

--- a/packages/pluginsdk/package.json
+++ b/packages/pluginsdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk",
   "description": "Provides blessed opinions (rollup, code format, lint) and packages (react, etc) to plugin developers",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/pluginsdk/package.json
+++ b/packages/pluginsdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk",
   "description": "Provides blessed opinions (rollup, code format, lint) and packages (react, etc) to plugin developers",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/pluginsdk/pluginconfig/rollup.config.js
+++ b/packages/pluginsdk/pluginconfig/rollup.config.js
@@ -5,12 +5,18 @@ const externalGlobals = require('rollup-plugin-external-globals');
 const json = require('@rollup/plugin-json');
 const postCss = require('rollup-plugin-postcss');
 const replace = require('@rollup/plugin-replace');
+const { terser } = require('rollup-plugin-terser');
 const typescript = require('@rollup/plugin-typescript');
 const visualizer = require('rollup-plugin-visualizer');
 
 const ROLLUP_STATS = !!process.env.ROLLUP_STATS;
 const ROLLUP_WATCH = !!process.env.ROLLUP_WATCH;
-const NODE_ENV = JSON.stringify(process.env.NODE_ENV || 'development');
+const NODE_ENV = JSON.stringify(process.env.NODE_ENV || '"development"');
+const ENV_MINIFY = process.env.ROLLUP_MINIFY;
+const ROLLUP_MINIFY = ENV_MINIFY === 'true' || (NODE_ENV === '"production"' && ENV_MINIFY !== 'false');
+
+// eslint-disable-next-line no-console
+console.log({ ROLLUP_STATS, ROLLUP_WATCH, ROLLUP_MINIFY, NODE_ENV });
 
 const plugins = [
   nodeResolve(),
@@ -27,6 +33,10 @@ const plugins = [
   // import from .css, .less, and inject into the document <head></head>
   postCss(),
 ];
+
+if (ROLLUP_MINIFY) {
+  plugins.push(terser());
+}
 
 if (ROLLUP_STATS) {
   plugins.push(visualizer({ sourcemap: true }));

--- a/packages/pluginsdk/pluginconfig/rollup.config.js
+++ b/packages/pluginsdk/pluginconfig/rollup.config.js
@@ -1,8 +1,10 @@
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
+
 const commonjs = require('@rollup/plugin-commonjs');
-const typescript = require('@rollup/plugin-typescript');
-const postCss = require('rollup-plugin-postcss');
 const externalGlobals = require('rollup-plugin-external-globals');
+const json = require('@rollup/plugin-json');
+const postCss = require('rollup-plugin-postcss');
+const typescript = require('@rollup/plugin-typescript');
 
 const ROLLUP_WATCH = !!process.env.ROLLUP_WATCH;
 
@@ -11,6 +13,7 @@ module.exports = {
   plugins: [
     nodeResolve(),
     commonjs(),
+    json(),
     typescript({
       // In watch mode, always emit javascript even with errors (otherwise rollup will terminate)
       noEmitOnError: !ROLLUP_WATCH,

--- a/packages/pluginsdk/pluginconfig/rollup.config.js
+++ b/packages/pluginsdk/pluginconfig/rollup.config.js
@@ -28,7 +28,10 @@ const plugins = [
     fileName: '[dirname][hash][extname]',
   }),
   // Replace literal string 'process.env.NODE_ENV' with the current NODE_ENV
-  replace({ 'process.env.NODE_ENV': NODE_ENV }),
+  replace({
+    preventAssignment: true,
+    values: { 'process.env.NODE_ENV': NODE_ENV },
+  }),
   typescript({
     // In watch mode, always emit javascript even with errors (otherwise rollup will terminate)
     noEmitOnError: !ROLLUP_WATCH,

--- a/packages/pluginsdk/pluginconfig/rollup.config.js
+++ b/packages/pluginsdk/pluginconfig/rollup.config.js
@@ -12,7 +12,7 @@ const visualizer = require('rollup-plugin-visualizer');
 
 const ROLLUP_STATS = !!process.env.ROLLUP_STATS;
 const ROLLUP_WATCH = !!process.env.ROLLUP_WATCH;
-const NODE_ENV = JSON.stringify(process.env.NODE_ENV || '"development"');
+const NODE_ENV = JSON.stringify(process.env.NODE_ENV || 'development');
 const ENV_MINIFY = process.env.ROLLUP_MINIFY;
 const ROLLUP_MINIFY = ENV_MINIFY === 'true' || (NODE_ENV === '"production"' && ENV_MINIFY !== 'false');
 

--- a/packages/pluginsdk/pluginconfig/rollup.config.js
+++ b/packages/pluginsdk/pluginconfig/rollup.config.js
@@ -7,6 +7,7 @@ const postCss = require('rollup-plugin-postcss');
 const replace = require('@rollup/plugin-replace');
 const { terser } = require('rollup-plugin-terser');
 const typescript = require('@rollup/plugin-typescript');
+const url = require('@rollup/plugin-url');
 const visualizer = require('rollup-plugin-visualizer');
 
 const ROLLUP_STATS = !!process.env.ROLLUP_STATS;
@@ -22,6 +23,10 @@ const plugins = [
   nodeResolve(),
   commonjs(),
   json(),
+  url({
+    include: ['**/*.html', '**/*.svg', '**/*.png', '**/*.jp(e)?g', '**/*.gif', '**/*.webp'],
+    fileName: '[dirname][hash][extname]',
+  }),
   // Replace literal string 'process.env.NODE_ENV' with the current NODE_ENV
   replace({ 'process.env.NODE_ENV': NODE_ENV }),
   typescript({

--- a/packages/pluginsdk/pluginconfig/rollup.config.js
+++ b/packages/pluginsdk/pluginconfig/rollup.config.js
@@ -44,7 +44,23 @@ function spinnakerSharedLibraries() {
     return `${prefix}.${sanitizedLibraryName}`;
   }
 
+  // This allows us to share libraries with plugin dependencies that would otherwise be double bundled
+  // @rollup/plugin-commonjs rewrites library names in commonjs imported code
+  // This block finds known permutations and replaces them with the shared global variable
   return libraries.reduce((globalsMap, libraryName) => {
-    return { ...globalsMap, [libraryName]: getGlobalVariable(libraryName) };
+    const globalVar = getGlobalVariable(libraryName);
+    const libName2 = libraryName + '?commonjs-proxy';
+    const libName3 = libraryName + '?commonjs-require';
+    const libName4 = '\u0000' + libraryName + '?commonjs-proxy';
+    const libName5 = '\u0000' + libraryName + '?commonjs-require';
+
+    return {
+      ...globalsMap,
+      [libraryName]: globalVar,
+      [libName2]: globalVar,
+      [libName3]: globalVar,
+      [libName4]: globalVar,
+      [libName5]: globalVar,
+    };
   }, {});
 }

--- a/packages/pluginsdk/pluginconfig/rollup.config.js
+++ b/packages/pluginsdk/pluginconfig/rollup.config.js
@@ -4,9 +4,11 @@ const commonjs = require('@rollup/plugin-commonjs');
 const externalGlobals = require('rollup-plugin-external-globals');
 const json = require('@rollup/plugin-json');
 const postCss = require('rollup-plugin-postcss');
+const replace = require('@rollup/plugin-replace');
 const typescript = require('@rollup/plugin-typescript');
 
 const ROLLUP_WATCH = !!process.env.ROLLUP_WATCH;
+const NODE_ENV = JSON.stringify(process.env.NODE_ENV || 'development') 
 
 module.exports = {
   input: 'src/index.ts',
@@ -14,6 +16,8 @@ module.exports = {
     nodeResolve(),
     commonjs(),
     json(),
+    // Replace literal string 'process.env.NODE_ENV' with the current NODE_ENV
+    replace({ 'process.env.NODE_ENV': NODE_ENV }),
     typescript({
       // In watch mode, always emit javascript even with errors (otherwise rollup will terminate)
       noEmitOnError: !ROLLUP_WATCH,

--- a/packages/pluginsdk/scaffold/package.json
+++ b/packages/pluginsdk/scaffold/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "npx shx rm -rf build",
     "develop": "npm run clean && run-p watch proxy",
-    "build": "npm run clean && rollup -c",
+    "build": "npm run clean && NODE_ENV=production rollup -c",
     "lint": "eslint --ext js,jsx,ts,tsx src",
     "postinstall": "check-plugin && check-peer-dependencies || true",
     "prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,html,css,less,json}'",

--- a/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
+++ b/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
@@ -51,7 +51,7 @@ function checkPackageJson(report) {
 
   const checkPackageJsonField = assertJsonFile(report, 'package.json', pkgJson);
 
-  checkPackageJsonField('scripts.build', 'npm run clean && rollup -c');
+  checkPackageJsonField('scripts.build', 'npm run clean && NODE_ENV=production rollup -c');
   checkPackageJsonField('scripts.clean', 'npx shx rm -rf build');
   checkPackageJsonField('scripts.lint', 'eslint --ext js,jsx,ts,tsx src');
   checkPackageJsonField('scripts.develop', 'npm run clean && run-p watch proxy');


### PR DESCRIPTION
Lots of new build tooling features in this release of pluginsdk

- feat(pluginsdk): support sharing libraries (i.e., react) with commonjs plugin dependencies
- feat(pluginsdk): support importing JSON files via rollup
- feat(pluginsdk): add support for replacing literal process.env.NODE_ENV with the current environment variable value
- feat(pluginsdk): Emit bundle size stats when ROLLUP_STATS environment variable is set
- feat(pluginsdk): Minify the plugin bundles when NODE_ENV is 'production' or ROLLUP_MINIFY is 'true'
- feat(pluginsdk): support importing content from html/svg/png/jpg/gif
- chore(pluginsdk-peerdeps): release 0.0.11
- chore(pluginsdk): release 0.0.25
