### PR TITLE
feat(titus): Update logic for auto-assigning IPv6 to containers

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -96,7 +96,9 @@ angular.module(TITUS_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER, []).factor
       const serverGroupName = NameUtils.parseServerGroupName(serverGroup.name);
 
       const isTestEnv = serverGroup.awsAccount === 'test';
-      const isIPv6Set = serverGroup.containerAttributes['titusParameter.agent.assignIPv6Address'] !== undefined;
+      const isIPv6Set =
+        serverGroup.containerAttributes &&
+        serverGroup.containerAttributes['titusParameter.agent.assignIPv6Address'] !== undefined;
 
       // If IPv6 hasn't been explicitly set by the user, auto-assign based on the environment.
       const assignIPv6Address = isIPv6Set

--- a/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -96,12 +96,19 @@ angular.module(TITUS_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER, []).factor
       const serverGroupName = NameUtils.parseServerGroupName(serverGroup.name);
 
       const isTestEnv = serverGroup.awsAccount === 'test';
-      const containerAttributes = isTestEnv
-        ? {
-            ...serverGroup.containerAttributes,
-            'titusParameter.agent.assignIPv6Address': 'true',
-          }
-        : serverGroup.containerAttributes;
+      const isIPv6Set = serverGroup.containerAttributes['titusParameter.agent.assignIPv6Address'] !== undefined;
+
+      // If IPv6 hasn't been explicitly set by the user, auto-assign based on the environment.
+      const assignIPv6Address = isIPv6Set
+        ? serverGroup.containerAttributes['titusParameter.agent.assignIPv6Address']
+        : isTestEnv
+        ? 'true'
+        : 'false';
+
+      const containerAttributes = {
+        ...serverGroup.containerAttributes,
+        'titusParameter.agent.assignIPv6Address': assignIPv6Address,
+      };
 
       const command = {
         application: application.name,

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -88,19 +88,12 @@ export class ServerGroupBasicSettings
     setFieldValue('credentials', account);
 
     const accountDetails = values.backingData.credentialsKeyedByAccount[account];
-    if (accountDetails.environment === 'test') {
-      const newAttr = {
-        ...values.containerAttributes,
-        'titusParameter.agent.assignIPv6Address': 'true',
-      };
-      setFieldValue('containerAttributes', newAttr);
-    }
 
-    if (accountDetails.environment !== 'test' && values.containerAttributes['titusParameter.agent.assignIPv6Address']) {
-      const newAttr = { ...values.containerAttributes };
-      delete newAttr['titusParameter.agent.assignIPv6Address'];
-      setFieldValue('containerAttributes', newAttr);
-    }
+    const newAttr = {
+      ...values.containerAttributes,
+      'titusParameter.agent.assignIPv6Address': accountDetails.environment === 'test' ? 'true' : 'false',
+    };
+    setFieldValue('containerAttributes', newAttr);
   };
 
   private regionUpdated = (region: string): void => {

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.tsx
@@ -65,7 +65,7 @@ function IPv6CheckboxInput(props: IFormInputProps) {
   const mappedProps = useFormInputValueMapper(
     props,
     (val: string) => val === 'true', // formik -> checkbox
-    (_val, e) => (e.target.checked ? 'true' : undefined), // checkbox -> formik
+    (_val, e) => (e.target.checked ? 'true' : 'false'), // checkbox -> formik
   );
   return <CheckboxInput {...mappedProps} />;
 }


### PR DESCRIPTION
**Before:** 
The container attribute `titusParameter.agent.assignIPv6Address`, did not exist if IPv6 wasn't needed.

**After:**
The container attribute will exist and be `false` if the user states that IPv6 isn't needed. 

**Why**
After this PR, if I user has explicitly interacted with IPv6, the value will be `true` or `false`. If they haven't interacted with this config, it will be `null`, and the backend can make some inferences about when to automatically assign an IPv6. 

For now this is based on the `test` environment, but more rules will be added as the rollout progresses. Eventually, this will just default to `true` for everything.
