### PR TITLE
fix(pipeline): Do not infer user from parent

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/ExecutionUserStatus.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionUserStatus.tsx
@@ -1,39 +1,12 @@
-import { has } from 'lodash';
 import React from 'react';
 
-import { IExecution, IExecutionTriggerStatusComponentProps, IPipelineTrigger, ITrigger } from 'core/domain';
-import { IAuthentication } from 'core/domain/IAuthentication';
+import { IExecutionTriggerStatusComponentProps } from 'core/domain';
 
 export class ExecutionUserStatus extends React.Component<IExecutionTriggerStatusComponentProps> {
   public render() {
     const { authentication, trigger } = this.props;
-    const parentExecution = has(trigger, 'parentExecution') ? (trigger as IPipelineTrigger).parentExecution : null;
-    const authenticatedUser = getAuthenticatedUser(authentication, parentExecution);
-    const triggerUser = getTriggerUser(trigger);
+    const authenticatedUser = authentication.user ?? '[anonymous]';
+    const triggerUser = trigger.user ?? 'unknown user';
     return triggerUser === authenticatedUser ? authenticatedUser : `${triggerUser} (${authenticatedUser})`;
   }
 }
-
-const getTriggerUser = (trigger: ITrigger): string => {
-  if (!trigger.user) {
-    return 'unknown user';
-  }
-  let user: string = trigger.user;
-  if (user === '[anonymous]' && has(trigger, 'parentExecution.trigger.user')) {
-    user = (trigger as IPipelineTrigger).parentExecution.trigger.user;
-  }
-  return user;
-};
-
-const getAuthenticatedUser = (authentication: IAuthentication, parentExecution?: IExecution): string => {
-  const user: string = authentication.user;
-  if (user && user !== '[anonymous]') {
-    return user;
-  } else {
-    if (has(parentExecution, 'authentication.user')) {
-      return parentExecution.authentication.user;
-    } else {
-      return 'unknown user';
-    }
-  }
-};


### PR DESCRIPTION
This is simply not true.

Especially for executions triggered by a pipeline trigger without a runAs user, they are in actuality executing as anonymous, but we incorrectly display them as being run with the same auth as the parent.

Additionally, we should rely on front50/echo/orca to propagate these from parent to child rather than infer them in deck.