### PR TITLE
fix(titus/serverGroup): Remove empty key/pairs from job attributes

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -108,6 +108,11 @@ angular
           delete labels['source'];
           delete labels['spinnakerAccount'];
 
+          // Server groups with no instances have an empty key/value pair that causes validation issues in the clone modal
+          if (labels[''] === '') {
+            delete labels[''];
+          }
+
           Object.keys(labels).forEach((key) => {
             if (key.startsWith('titus.')) {
               delete labels[key];

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -108,10 +108,7 @@ angular
           delete labels['source'];
           delete labels['spinnakerAccount'];
 
-          // Server groups with no instances have an empty key/value pair that causes validation issues in the clone modal
-          if (labels[''] === '') {
-            delete labels[''];
-          }
+          delete labels[''];
 
           Object.keys(labels).forEach((key) => {
             if (key.startsWith('titus.')) {


### PR DESCRIPTION
Server groups with no instances have an empty key/pair `{ "": "" }`. This causes validation issues in the UI when a user wants to clone an empty server group. 

To fix, the empty key/pair is deleted where the other labels are deleted. 

<img width="1461" alt="Screen Shot 2021-04-23 at 11 24 09 AM" src="https://user-images.githubusercontent.com/26560152/115914162-72670a00-a426-11eb-81b3-83f308e16a27.png">

