### PR TITLE
fix(redblack): Update redblack fields for angular DeploymentStrategyS…

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
@@ -132,5 +132,13 @@ module(AMAZON_PIPELINE_STAGES_CLONESERVERGROUP_AWSCLONESERVERGROUPSTAGE, [])
           stage.useAmiBlockDeviceMappings = false;
         }
       };
+
+      this.onRedBlackFieldChange = (key, value) => {
+        if (key === 'rollback.onFailure') {
+          stage.rollback.onFailure = value;
+        } else {
+          stage[key] = value;
+        }
+      };
     },
   ]);

--- a/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
@@ -134,11 +134,7 @@ module(AMAZON_PIPELINE_STAGES_CLONESERVERGROUP_AWSCLONESERVERGROUPSTAGE, [])
       };
 
       this.onRedBlackFieldChange = (key, value) => {
-        if (key === 'rollback.onFailure') {
-          stage.rollback.onFailure = value;
-        } else {
-          stage[key] = value;
-        }
+        _.set(stage, key, value);
       };
     },
   ]);

--- a/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/cloneServerGroupStage.html
+++ b/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/cloneServerGroupStage.html
@@ -135,5 +135,9 @@
   </stage-config-field>
   <stage-platform-health-override application="application" stage="stage" platform-health-type="'Amazon'">
   </stage-platform-health-override>
-  <deployment-strategy-selector field-columns="6" command="stage"></deployment-strategy-selector>
+  <deployment-strategy-selector
+    field-columns="6"
+    command="stage"
+    on-field-change="cloneServerGroupStageCtrl.onRedBlackFieldChange"
+  ></deployment-strategy-selector>
 </div>

--- a/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
@@ -83,17 +83,11 @@ export class DeploymentStrategySelector extends React.Component<
     this.selectStrategy(this.props.command.strategy, true);
   }
 
-  public onChange = (key: string, value: any) => {
-    this.props.onFieldChange(key, value);
-
-    // This hack is needed to force the component to re-render when the angular deployment-strategy-selector updates the underlying command
-    this.setState({ AdditionalFieldsComponent: this.state.AdditionalFieldsComponent });
-  };
-
   public render() {
-    const { command, fieldColumns, labelColumns } = this.props;
+    const { command, fieldColumns, labelColumns, onFieldChange } = this.props;
     const { AdditionalFieldsComponent, currentStrategy, strategies } = this.state;
     const hasAdditionalFields = Boolean(AdditionalFieldsComponent);
+
     if (strategies && strategies.length) {
       return (
         <div className="form-group">
@@ -116,7 +110,7 @@ export class DeploymentStrategySelector extends React.Component<
           </div>
           {hasAdditionalFields && (
             <div className="col-md-9 col-md-offset-3" style={{ marginTop: '5px' }}>
-              <AdditionalFieldsComponent command={command} onChange={this.onChange} />
+              <AdditionalFieldsComponent command={command} onChange={onFieldChange} />
             </div>
           )}
         </div>

--- a/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
@@ -83,8 +83,15 @@ export class DeploymentStrategySelector extends React.Component<
     this.selectStrategy(this.props.command.strategy, true);
   }
 
+  public onChange = (key: string, value: any) => {
+    this.props.onFieldChange(key, value);
+
+    // This hack is needed to force the component to re-render when the angular deployment-strategy-selector updates the underlying command
+    this.setState({ AdditionalFieldsComponent: this.state.AdditionalFieldsComponent });
+  };
+
   public render() {
-    const { command, fieldColumns, labelColumns, onFieldChange } = this.props;
+    const { command, fieldColumns, labelColumns } = this.props;
     const { AdditionalFieldsComponent, currentStrategy, strategies } = this.state;
     const hasAdditionalFields = Boolean(AdditionalFieldsComponent);
     if (strategies && strategies.length) {
@@ -109,7 +116,7 @@ export class DeploymentStrategySelector extends React.Component<
           </div>
           {hasAdditionalFields && (
             <div className="col-md-9 col-md-offset-3" style={{ marginTop: '5px' }}>
-              <AdditionalFieldsComponent command={command} onChange={onFieldChange} />
+              <AdditionalFieldsComponent command={command} onChange={this.onChange} />
             </div>
           )}
         </div>

--- a/app/scripts/modules/core/src/deploymentStrategy/deploymentStrategySelector.component.ts
+++ b/app/scripts/modules/core/src/deploymentStrategy/deploymentStrategySelector.component.ts
@@ -10,6 +10,7 @@ module(DEPLOYMENT_STRATEGY_SELECTOR_COMPONENT, []).component(
   'deploymentStrategySelector',
   react2angular(withErrorBoundary(DeploymentStrategySelector, 'deploymentStrategySelector'), [
     'command',
+    'onFieldChange',
     'onStrategyChange',
     'labelColumns',
     'fieldColumns',

--- a/app/scripts/modules/titus/src/pipeline/stages/cloneServerGroup/cloneServerGroupStage.html
+++ b/app/scripts/modules/titus/src/pipeline/stages/cloneServerGroup/cloneServerGroupStage.html
@@ -97,5 +97,10 @@
   </stage-config-field>
   <stage-platform-health-override application="application" stage="stage" platform-health-type="'Titus'">
   </stage-platform-health-override>
-  <deployment-strategy-selector label-columns="3" field-columns="6" command="stage"></deployment-strategy-selector>
+  <deployment-strategy-selector
+    label-columns="3"
+    field-columns="6"
+    command="stage"
+    on-field-change="cloneServerGroupStageCtrl.onRedBlackFieldChange"
+  ></deployment-strategy-selector>
 </div>

--- a/app/scripts/modules/titus/src/pipeline/stages/cloneServerGroup/titusCloneServerGroupStage.js
+++ b/app/scripts/modules/titus/src/pipeline/stages/cloneServerGroup/titusCloneServerGroupStage.js
@@ -93,5 +93,13 @@ module(TITUS_PIPELINE_STAGES_CLONESERVERGROUP_TITUSCLONESERVERGROUPSTAGE, [
       this.processIsSuspended = (process) => {
         return stage.suspendedProcesses && stage.suspendedProcesses.includes(process);
       };
+
+      this.onRedBlackFieldChange = (key, value) => {
+        if (key === 'rollback.onFailure') {
+          stage.rollback.onFailure = value;
+        } else {
+          stage[key] = value;
+        }
+      };
     },
   ]);

--- a/app/scripts/modules/titus/src/pipeline/stages/cloneServerGroup/titusCloneServerGroupStage.js
+++ b/app/scripts/modules/titus/src/pipeline/stages/cloneServerGroup/titusCloneServerGroupStage.js
@@ -95,11 +95,7 @@ module(TITUS_PIPELINE_STAGES_CLONESERVERGROUP_TITUSCLONESERVERGROUPSTAGE, [
       };
 
       this.onRedBlackFieldChange = (key, value) => {
-        if (key === 'rollback.onFailure') {
-          stage.rollback.onFailure = value;
-        } else {
-          stage[key] = value;
-        }
+        _.set(stage, key, value);
       };
     },
   ]);


### PR DESCRIPTION
The `DeploymentStrategySelector` had angular implementations in the `cloneServerGroup` stage. The `onChange` function for additional red-black fields was not being passed to the angular implementation.

This PR includes: 
- Create `onChange` function in the angular controllers and pass to the component
- Force `DeploymentStrategySelector` to re-render. The angular updates are applied to the underlying command, but the UI doesn't update

I really don't like forcing the re-render, but it simple enough for now since I don't have time to refactor the entire stage.  