### PR TITLE
upgrade rxjs

### DIFF
--- a/app/scripts/modules/amazon/src/common/AwsModalFooter.tsx
+++ b/app/scripts/modules/amazon/src/common/AwsModalFooter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ModalFooter } from 'react-bootstrap';
+import { map, take } from 'rxjs/operators';
 
 import { AccountService, IAccountDetails, UserVerification } from '@spinnaker/core';
 
@@ -24,8 +25,10 @@ export class AwsModalFooter extends React.Component<IAwsModalFooterProps, IAwsMo
 
   public componentDidMount() {
     AccountService.accounts$
-      .take(1)
-      .map((accounts: IAccountDetails[]) => accounts.find((account) => account.name === this.props.account))
+      .pipe(
+        take(1),
+        map((accounts: IAccountDetails[]) => accounts.find((account) => account.name === this.props.account)),
+      )
       .subscribe((account: IAccountDetails) => {
         this.setState({ requireVerification: !!account && account.challengeDestructiveActions });
       });

--- a/app/scripts/modules/amazon/src/function/configure/FunctionBasicInformation.tsx
+++ b/app/scripts/modules/amazon/src/function/configure/FunctionBasicInformation.tsx
@@ -121,13 +121,13 @@ export class FunctionBasicInformation
 
     const allAccounts$ = observableFrom(AccountService.listAccounts('aws')).pipe(shareReplay(1));
     // combineLatest with allAccounts to wait for accounts to load and be cached
-    const accountRegions$ = observableCombineLatest(form.account$, allAccounts$).pipe(
+    const accountRegions$ = observableCombineLatest([form.account$, allAccounts$]).pipe(
       switchMap(([currentAccount, _allAccounts]) => AccountService.getRegionsForAccount(currentAccount)),
       shareReplay(1),
     );
 
     const allFunctions$ = this.props.app.getDataSource('functions').data$ as Observable<IAmazonFunction[]>;
-    const regionfunctions$ = observableCombineLatest(allFunctions$, form.account$, form.region$).pipe(
+    const regionfunctions$ = observableCombineLatest([allFunctions$, form.account$, form.region$]).pipe(
       map(([allFunctions, currentAccount, currentRegion]) => {
         return allFunctions
           .filter((fn) => fn.account === currentAccount && fn.region === currentRegion)
@@ -145,7 +145,7 @@ export class FunctionBasicInformation
         }
       });
 
-    observableCombineLatest(allAccounts$, accountRegions$, regionfunctions$)
+    observableCombineLatest([allAccounts$, accountRegions$, regionfunctions$])
       .pipe(takeUntil(this.destroy$))
       .subscribe(([accounts, regions, existingFunctionNames]) => {
         return this.setState({ accounts, regions, existingFunctionNames });

--- a/app/scripts/modules/amazon/src/function/configure/Network.tsx
+++ b/app/scripts/modules/amazon/src/function/configure/Network.tsx
@@ -2,7 +2,8 @@ import { FormikErrors, FormikProps } from 'formik';
 import { forOwn, uniqBy } from 'lodash';
 import React from 'react';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { combineLatest as observableCombineLatest, from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   Application,
@@ -62,8 +63,8 @@ export class Network
   private destroy$ = new Subject<void>();
 
   private getAllVpcs(): void {
-    Observable.fromPromise(VpcReader.listVpcs())
-      .takeUntil(this.destroy$)
+    observableFrom(VpcReader.listVpcs())
+      .pipe(takeUntil(this.destroy$))
       .subscribe((Vpcs) => {
         this.setState({ vpcOptions: Vpcs });
       });
@@ -112,8 +113,8 @@ export class Network
       });
 
     const secGroups$ = Promise.resolve(this.getAvailableSecurityGroups());
-    Observable.combineLatest(allSubnets, secGroups$)
-      .takeUntil(this.destroy$)
+    observableCombineLatest(allSubnets, secGroups$)
+      .pipe(takeUntil(this.destroy$))
       .subscribe(([availableSubnets, securityGroups]) => {
         return this.setState({ availableSubnets, securityGroups });
       });

--- a/app/scripts/modules/amazon/src/function/configure/Network.tsx
+++ b/app/scripts/modules/amazon/src/function/configure/Network.tsx
@@ -2,7 +2,7 @@ import { FormikErrors, FormikProps } from 'formik';
 import { forOwn, uniqBy } from 'lodash';
 import React from 'react';
 import { Option } from 'react-select';
-import { combineLatest as observableCombineLatest, from as observableFrom, Observable, Subject } from 'rxjs';
+import { combineLatest as observableCombineLatest, from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/amazon/src/function/configure/Network.tsx
+++ b/app/scripts/modules/amazon/src/function/configure/Network.tsx
@@ -113,7 +113,7 @@ export class Network
       });
 
     const secGroups$ = Promise.resolve(this.getAvailableSecurityGroups());
-    observableCombineLatest(allSubnets, secGroups$)
+    observableCombineLatest([allSubnets, secGroups$])
       .pipe(takeUntil(this.destroy$))
       .subscribe(([availableSubnets, securityGroups]) => {
         return this.setState({ availableSubnets, securityGroups });

--- a/app/scripts/modules/amazon/src/function/details/AmazonFunctionDetails.tsx
+++ b/app/scripts/modules/amazon/src/function/details/AmazonFunctionDetails.tsx
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/amazon/src/function/details/AmazonFunctionDetails.tsx
+++ b/app/scripts/modules/amazon/src/function/details/AmazonFunctionDetails.tsx
@@ -1,7 +1,7 @@
 import { isEmpty } from 'lodash';
 import React from 'react';
-import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountTag,
@@ -49,7 +49,7 @@ export class AmazonFunctionDetails extends React.Component<IAmazonFunctionDetail
     });
 
     if (functionDef) {
-      Observable.fromPromise(
+      observableFrom(
         AwsReactInjector.functionReader.getFunctionDetails(
           'aws',
           functionFromProps.account,
@@ -57,7 +57,7 @@ export class AmazonFunctionDetails extends React.Component<IAmazonFunctionDetail
           functionFromProps.functionName,
         ),
       )
-        .takeUntil(this.destroy$)
+        .pipe(takeUntil(this.destroy$))
         .subscribe((details: IAmazonFunctionSourceData[]) => {
           if (details.length) {
             this.setState({
@@ -77,8 +77,8 @@ export class AmazonFunctionDetails extends React.Component<IAmazonFunctionDetail
   public componentDidMount(): void {
     const { app } = this.props;
     const dataSource = app.functions;
-    Observable.fromPromise(dataSource.ready())
-      .takeUntil(this.destroy$)
+    observableFrom(dataSource.ready())
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         const dataSourceUnsubscribe = dataSource.onRefresh(null, () => this.extractFunction());
         this.setState({ dataSourceUnsubscribe });

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -1,7 +1,8 @@
 import { FormikErrors, FormikProps } from 'formik';
 import { filter, flatten, groupBy, set, uniq } from 'lodash';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   Application,
@@ -138,8 +139,8 @@ export class TargetGroups
     const { app, loadBalancer } = props;
 
     const targetGroupsByAccountAndRegion: { [account: string]: { [region: string]: string[] } } = {};
-    Observable.fromPromise(app.getDataSource('loadBalancers').refresh(true))
-      .takeUntil(this.destroy$)
+    observableFrom(app.getDataSource('loadBalancers').refresh(true))
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         app.getDataSource('loadBalancers').data.forEach((lb: IAmazonApplicationLoadBalancer) => {
           if (lb.loadBalancerType !== 'classic') {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -1,7 +1,7 @@
 import { FormikErrors, FormikProps } from 'formik';
 import { filter, flatten, groupBy, set, uniq } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
@@ -122,7 +122,7 @@ export class SecurityGroups
       distinctUntilChanged(),
     );
 
-    const availableSecurityGroups$ = observableCombineLatest(vpcId$, allSecurityGroups$).pipe(
+    const availableSecurityGroups$ = observableCombineLatest([vpcId$, allSecurityGroups$]).pipe(
       withLatestFrom(formValues$),
       map(([[vpcId, allSecurityGroups], formValues]) => {
         const forAccount = allSecurityGroups[formValues.credentials] || {};

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
@@ -2,7 +2,7 @@ import { FormikErrors, FormikProps } from 'formik';
 import { get, isEqual, partition, uniq } from 'lodash';
 import React from 'react';
 import VirtualizedSelect from 'react-virtualized-select';
-import { combineLatest as observableCombineLatest, Observable, Subject } from 'rxjs';
+import { combineLatest as observableCombineLatest, Subject } from 'rxjs';
 import { distinctUntilChanged, map, mergeMap, switchMap, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
@@ -1,7 +1,7 @@
 import { FormikErrors, FormikProps } from 'formik';
 import { filter, flatten, groupBy, set, uniq } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
@@ -1,7 +1,8 @@
 import { FormikErrors, FormikProps } from 'formik';
 import { filter, flatten, groupBy, set, uniq } from 'lodash';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   Application,
@@ -111,8 +112,8 @@ export class TargetGroups
     const { app, loadBalancer } = props;
 
     const targetGroupsByAccountAndRegion: { [account: string]: { [region: string]: string[] } } = {};
-    Observable.fromPromise(app.getDataSource('loadBalancers').refresh(true))
-      .takeUntil(this.destroy$)
+    observableFrom(app.getDataSource('loadBalancers').refresh(true))
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         app.getDataSource('loadBalancers').data.forEach((lb: IAmazonApplicationLoadBalancer) => {
           if (lb.loadBalancerType !== 'classic') {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -1,17 +1,14 @@
 import { $q } from 'ngimport';
 import React from 'react';
 import { HandlerRendererResult, MenuRendererProps, Option, OptionValues, ReactSelectProps } from 'react-select';
-import { BehaviorSubject, from as observableFrom, of as observableOf, Subject } from 'rxjs';
 import {
-  catchError,
-  combineLatest,
-  debounceTime,
-  distinctUntilChanged,
-  map,
-  switchMap,
-  takeUntil,
-  tap,
-} from 'rxjs/operators';
+  BehaviorSubject,
+  combineLatest as observableCombineLatest,
+  from as observableFrom,
+  of as observableOf,
+  Subject,
+} from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 import { Application, HelpField, TetheredSelect, ValidationMessage } from '@spinnaker/core';
 import { AwsImageReader, IAmazonImage } from 'amazon/image';
@@ -144,8 +141,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
       tap(() => this.setState({ isLoadingPackageImages: false })),
     );
 
-    const packageImagesInRegion$ = packageImages$.pipe(
-      combineLatest([region$, this.sortImagesBy$]),
+    const packageImagesInRegion$ = observableCombineLatest([packageImages$, region$, this.sortImagesBy$]).pipe(
       map(([packageImages, latestRegion, sortImagesBy]) => {
         const images = packageImages.filter((img) => !!img.amis[latestRegion]);
         return this.sortImages(images, sortImagesBy);
@@ -169,8 +165,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
       tap(() => this.setState({ isSearching: false })),
     );
 
-    const searchImagesInRegion$ = searchImages$.pipe(
-      combineLatest([region$, this.sortImagesBy$]),
+    const searchImagesInRegion$ = observableCombineLatest([searchImages$, region$, this.sortImagesBy$]).pipe(
       map(([searchResults, latestRegion, sortImagesBy]) => {
         const { searchString } = this.state;
         // allow 'advanced' users to continue with just an ami id (backing image may not have been indexed yet)

--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -1,7 +1,17 @@
 import { $q } from 'ngimport';
 import React from 'react';
 import { HandlerRendererResult, MenuRendererProps, Option, OptionValues, ReactSelectProps } from 'react-select';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, from as observableFrom, Observable, of as observableOf, Subject } from 'rxjs';
+import {
+  catchError,
+  combineLatest,
+  debounceTime,
+  distinctUntilChanged,
+  map,
+  switchMap,
+  takeUntil,
+  tap,
+} from 'rxjs/operators';
 
 import { Application, HelpField, TetheredSelect, ValidationMessage } from '@spinnaker/core';
 import { AwsImageReader, IAmazonImage } from 'amazon/image';
@@ -116,45 +126,52 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
   }
 
   public componentDidMount() {
-    const region$ = this.props$.map((x) => x.region).distinctUntilChanged();
+    const region$ = this.props$.pipe(
+      map((x) => x.region),
+      distinctUntilChanged(),
+    );
     const { value, region, credentials, application } = this.props;
 
     this.setState({ isLoadingPackageImages: true });
     const fetchPromise = this.fetchPackageImages(value, region, credentials, application);
 
-    const packageImages$ = Observable.fromPromise(fetchPromise)
-      .catch((err) => {
+    const packageImages$ = observableFrom(fetchPromise).pipe(
+      catchError((err) => {
         console.error(err);
         this.setState({ errorMessage: 'Unable to load package images' });
-        return Observable.of([] as IAmazonImage[]);
-      })
-      .do(() => this.setState({ isLoadingPackageImages: false }));
+        return observableOf([] as IAmazonImage[]);
+      }),
+      tap(() => this.setState({ isLoadingPackageImages: false })),
+    );
 
-    const packageImagesInRegion$ = packageImages$
-      .combineLatest(region$, this.sortImagesBy$)
-      .map(([packageImages, latestRegion, sortImagesBy]) => {
+    const packageImagesInRegion$ = packageImages$.pipe(
+      combineLatest(region$, this.sortImagesBy$),
+      map(([packageImages, latestRegion, sortImagesBy]) => {
         const images = packageImages.filter((img) => !!img.amis[latestRegion]);
         return this.sortImages(images, sortImagesBy);
-      });
+      }),
+    );
 
-    const searchString$ = this.searchInput$
-      .do((searchString) => this.setState({ searchString }))
-      .distinctUntilChanged()
-      .debounceTime(250);
+    const searchString$ = this.searchInput$.pipe(
+      tap((searchString) => this.setState({ searchString })),
+      distinctUntilChanged(),
+      debounceTime(250),
+    );
 
-    const searchImages$ = searchString$
-      .do(() => this.setState({ isSearching: true }))
-      .switchMap((searchString) => this.searchForImages(searchString))
-      .catch((err) => {
+    const searchImages$ = searchString$.pipe(
+      tap(() => this.setState({ isSearching: true })),
+      switchMap((searchString) => this.searchForImages(searchString)),
+      catchError((err) => {
         console.error(err);
         this.setState({ errorMessage: 'Unable to search for images' });
-        return Observable.of([] as IAmazonImage[]);
-      })
-      .do(() => this.setState({ isSearching: false }));
+        return observableOf([] as IAmazonImage[]);
+      }),
+      tap(() => this.setState({ isSearching: false })),
+    );
 
-    const searchImagesInRegion$ = searchImages$
-      .combineLatest(region$, this.sortImagesBy$)
-      .map(([searchResults, latestRegion, sortImagesBy]) => {
+    const searchImagesInRegion$ = searchImages$.pipe(
+      combineLatest(region$, this.sortImagesBy$),
+      map(([searchResults, latestRegion, sortImagesBy]) => {
         const { searchString } = this.state;
         // allow 'advanced' users to continue with just an ami id (backing image may not have been indexed yet)
         if (searchResults.length === 0 && !!/ami-[0-9a-f]{8,17}/.exec(searchString)) {
@@ -165,28 +182,31 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
         // Filter down to only images which have an ami in the currently selected region
         const images = searchResults.filter((img) => !!img.amis[latestRegion]);
         return this.sortImages(images, sortImagesBy);
-      });
+      }),
+    );
 
-    searchImagesInRegion$.takeUntil(this.destroy$).subscribe((searchResults) => this.setState({ searchResults }));
-    packageImagesInRegion$.takeUntil(this.destroy$).subscribe((packageImages) => {
+    searchImagesInRegion$.pipe(takeUntil(this.destroy$)).subscribe((searchResults) => this.setState({ searchResults }));
+    packageImagesInRegion$.pipe(takeUntil(this.destroy$)).subscribe((packageImages) => {
       this.setState({ packageImages });
       this.selectImage(this.findMatchingImage(packageImages, this.props.value));
     });
 
     // Clear out the selected image if the region changes and the image is not found in the new region
     region$
-      .switchMap((selectedRegion) => {
-        const image = this.props.value;
-        if (this.state.selectionMode === 'packageImages') {
-          // in packageImages mode, wait for the packageImages to load then find the matching one, or undefined
-          return packageImagesInRegion$.map((images) => this.findMatchingImage(images, image));
-        } else {
-          // in searchImages mode, return undefined if the selected image is not found in the new region
-          const hasAmiInRegion = !!(image && image.amis && image.amis[selectedRegion]);
-          return Observable.of(hasAmiInRegion ? image : undefined);
-        }
-      })
-      .takeUntil(this.destroy$)
+      .pipe(
+        switchMap((selectedRegion) => {
+          const image = this.props.value;
+          if (this.state.selectionMode === 'packageImages') {
+            // in packageImages mode, wait for the packageImages to load then find the matching one, or undefined
+            return packageImagesInRegion$.pipe(map((images) => this.findMatchingImage(images, image)));
+          } else {
+            // in searchImages mode, return undefined if the selected image is not found in the new region
+            const hasAmiInRegion = !!(image && image.amis && image.amis[selectedRegion]);
+            return observableOf(hasAmiInRegion ? image : undefined);
+          }
+        }),
+        takeUntil(this.destroy$),
+      )
       .subscribe((image) => this.selectImage(image));
   }
 

--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -145,7 +145,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
     );
 
     const packageImagesInRegion$ = packageImages$.pipe(
-      combineLatest(region$, this.sortImagesBy$),
+      combineLatest([region$, this.sortImagesBy$]),
       map(([packageImages, latestRegion, sortImagesBy]) => {
         const images = packageImages.filter((img) => !!img.amis[latestRegion]);
         return this.sortImages(images, sortImagesBy);
@@ -170,7 +170,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
     );
 
     const searchImagesInRegion$ = searchImages$.pipe(
-      combineLatest(region$, this.sortImagesBy$),
+      combineLatest([region$, this.sortImagesBy$]),
       map(([searchResults, latestRegion, sortImagesBy]) => {
         const { searchString } = this.state;
         // allow 'advanced' users to continue with just an ami id (backing image may not have been indexed yet)

--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -1,7 +1,7 @@
 import { $q } from 'ngimport';
 import React from 'react';
 import { HandlerRendererResult, MenuRendererProps, Option, OptionValues, ReactSelectProps } from 'react-select';
-import { BehaviorSubject, from as observableFrom, Observable, of as observableOf, Subject } from 'rxjs';
+import { BehaviorSubject, from as observableFrom, of as observableOf, Subject } from 'rxjs';
 import {
   catchError,
   combineLatest,

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/MetricAlarmChart.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/MetricAlarmChart.tsx
@@ -1,7 +1,7 @@
 import { module } from 'angular';
 import * as React from 'react';
 import { react2angular } from 'react2angular';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 
 import {
   CloudMetricsReader,

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.js
@@ -2,7 +2,8 @@
 
 import { module } from 'angular';
 import _ from 'lodash';
-import { Observable, Subject } from 'rxjs';
+import { Subject, from as observableFrom } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 import { CloudMetricsReader } from '@spinnaker/core';
 
@@ -29,14 +30,14 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_DIMENSIONSEDITOR_CO
       this.fetchDimensionOptions = () => {
         this.viewState.loadingDimensions = true;
         const filters = { namespace: this.alarm.namespace };
-        return Observable.fromPromise(
+        return observableFrom(
           CloudMetricsReader.listMetrics('aws', this.serverGroup.account, this.serverGroup.region, filters),
         );
       };
 
       const dimensionSubject = new Subject();
 
-      dimensionSubject.switchMap(this.fetchDimensionOptions).subscribe((results) => {
+      dimensionSubject.pipe(switchMap(this.fetchDimensionOptions)).subscribe((results) => {
         this.viewState.loadingDimensions = false;
         results = results || [];
         results.forEach((r) => (r.dimensions = r.dimensions || []));

--- a/app/scripts/modules/app.ts
+++ b/app/scripts/modules/app.ts
@@ -1,6 +1,7 @@
 ///<reference path="./core/src/types/index.d.ts" />
 /* eslint-disable @spinnaker/import-sort */
 import 'jquery'; // ensures jQuery is loaded before Angular so Angular does not use jqlite
+import 'rxjs-compat';
 import { module } from 'angular';
 import './strictDi';
 

--- a/app/scripts/modules/appengine/src/common/FormikAccountRegionSelector.tsx
+++ b/app/scripts/modules/appengine/src/common/FormikAccountRegionSelector.tsx
@@ -1,7 +1,7 @@
 import { FormikProps } from 'formik';
 import { get } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/appengine/src/common/FormikAccountRegionSelector.tsx
+++ b/app/scripts/modules/appengine/src/common/FormikAccountRegionSelector.tsx
@@ -1,7 +1,8 @@
 import { FormikProps } from 'formik';
 import { get } from 'lodash';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   Application,
@@ -66,8 +67,8 @@ export class FormikAccountRegionSelector extends React.Component<
     const { application } = this.props;
     const accountFilter: IServerGroupFilter = (serverGroup: IServerGroup) =>
       serverGroup ? serverGroup.account === credentials : true;
-    Observable.fromPromise(application.ready())
-      .takeUntil(this.destroy$)
+    observableFrom(application.ready())
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         const availableRegions = AppListExtractor.getRegions([application], accountFilter);
         availableRegions.sort();

--- a/app/scripts/modules/appengine/src/pipeline/stages/deployAppengineConfig/DeployAppengineConfigForm.tsx
+++ b/app/scripts/modules/appengine/src/pipeline/stages/deployAppengineConfig/DeployAppengineConfigForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -38,8 +39,8 @@ export class DeployAppengineConfigForm extends React.Component<
   };
 
   public componentDidMount() {
-    Observable.fromPromise(AccountService.listAccounts('appengine'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('appengine'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
   }
 

--- a/app/scripts/modules/appengine/src/pipeline/stages/deployAppengineConfig/DeployAppengineConfigForm.tsx
+++ b/app/scripts/modules/appengine/src/pipeline/stages/deployAppengineConfig/DeployAppengineConfigForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/CloudFoundryMapLoadBalancerModal.tsx
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/CloudFoundryMapLoadBalancerModal.tsx
@@ -4,7 +4,8 @@ import { Form, Formik } from 'formik';
 import { $q } from 'ngimport';
 import React from 'react';
 import { Modal, ModalFooter } from 'react-bootstrap';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -84,8 +85,8 @@ export class CloudFoundryMapLoadBalancerModal extends React.Component<
         onTaskComplete: () => this.props.application.serverGroups.refresh(),
       }),
     };
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((rawAccounts: IAccount[]) => this.setState({ accounts: rawAccounts }));
   }
 
@@ -102,8 +103,8 @@ export class CloudFoundryMapLoadBalancerModal extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
   }
 

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/CloudFoundryMapLoadBalancerModal.tsx
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/CloudFoundryMapLoadBalancerModal.tsx
@@ -4,7 +4,7 @@ import { Form, Formik } from 'formik';
 import { $q } from 'ngimport';
 import React from 'react';
 import { Modal, ModalFooter } from 'react-bootstrap';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/loadBalancerDetails.tsx
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/loadBalancerDetails.tsx
@@ -1,7 +1,8 @@
 import { FormikErrors, FormikProps } from 'formik';
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, Application, IAccount, IRegion, IWizardPageComponent } from '@spinnaker/core';
 import { ICloudFoundryAccount, ICloudFoundryDomain, ICloudFoundryLoadBalancerUpsertCommand } from 'cloudfoundry/domain';
@@ -65,8 +66,8 @@ export class LoadBalancerDetails
   }
 
   private loadAccounts(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => {
         this.setState({ accounts });
         this.loadDomainsAndRegions();
@@ -82,11 +83,11 @@ export class LoadBalancerDetails
   private loadDomainsAndRegions(): void {
     const account = this.props.formik.values.credentials;
     if (account) {
-      Observable.fromPromise(AccountService.getAccountDetails(account))
-        .takeUntil(this.destroy$)
+      observableFrom(AccountService.getAccountDetails(account))
+        .pipe(takeUntil(this.destroy$))
         .subscribe((accountDetails: ICloudFoundryAccount) => this.setState({ domains: accountDetails.domains }));
-      Observable.fromPromise(AccountService.getRegionsForAccount(account))
-        .takeUntil(this.destroy$)
+      observableFrom(AccountService.getRegionsForAccount(account))
+        .pipe(takeUntil(this.destroy$))
         .subscribe((regions) => this.setState({ regions }));
     }
   }
@@ -96,8 +97,8 @@ export class LoadBalancerDetails
     this.props.formik.setFieldValue('region', region);
     if (region) {
       const { credentials } = this.props.formik.values;
-      Observable.fromPromise(AccountService.getAccountDetails(credentials))
-        .takeUntil(this.destroy$)
+      observableFrom(AccountService.getAccountDetails(credentials))
+        .pipe(takeUntil(this.destroy$))
         .subscribe((accountDetails: ICloudFoundryAccount) => {
           const { domains } = accountDetails;
           this.setState({

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/loadBalancerDetails.tsx
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/loadBalancerDetails.tsx
@@ -1,7 +1,7 @@
 import { FormikErrors, FormikProps } from 'formik';
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, Application, IAccount, IRegion, IWizardPageComponent } from '@spinnaker/core';

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/createServiceBindings/CloudFoundryCreateServiceBindingsStageConfigForm.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/createServiceBindings/CloudFoundryCreateServiceBindingsStageConfigForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -49,8 +50,8 @@ export class CloudFoundryCreateServiceBindingsStageConfigForm extends React.Comp
       regions: [],
       application: props.application,
     };
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((rawAccounts: IAccount[]) => this.setState({ accounts: rawAccounts }));
   }
 
@@ -76,8 +77,8 @@ export class CloudFoundryCreateServiceBindingsStageConfigForm extends React.Comp
 
   private loadRegions = (creds: string) => {
     this.setState({ regions: [] });
-    Observable.fromPromise(AccountService.getRegionsForAccount(creds))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.getRegionsForAccount(creds))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((regionList: IRegion[]) => {
         const regions = regionList.map((r) => r.name);
         regions.sort((a, b) => a.localeCompare(b));

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/createServiceBindings/CloudFoundryCreateServiceBindingsStageConfigForm.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/createServiceBindings/CloudFoundryCreateServiceBindingsStageConfigForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/createServiceKey/CloudfoundryCreateServiceKeyStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/createServiceKey/CloudfoundryCreateServiceKeyStageConfig.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -33,8 +34,8 @@ export class CloudfoundryCreateServiceKeyStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((rawAccounts: IAccount[]) => this.setState({ accounts: rawAccounts.map((it) => it.name) }));
     if (this.props.stage.credentials) {
       this.clearAndReloadRegions();
@@ -47,8 +48,8 @@ export class CloudfoundryCreateServiceKeyStageConfig extends React.Component<
 
   private clearAndReloadRegions = () => {
     this.setState({ regions: [] });
-    Observable.fromPromise(AccountService.getRegionsForAccount(this.props.stage.credentials))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.getRegionsForAccount(this.props.stage.credentials))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((regionList: IRegion[]) => {
         const regions = regionList.map((r) => r.name);
         regions.sort((a, b) => a.localeCompare(b));

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/createServiceKey/CloudfoundryCreateServiceKeyStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/createServiceKey/CloudfoundryCreateServiceKeyStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteServiceKey/CloudfoundryDeleteServiceKeyStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteServiceKey/CloudfoundryDeleteServiceKeyStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteServiceKey/CloudfoundryDeleteServiceKeyStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteServiceKey/CloudfoundryDeleteServiceKeyStageConfig.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -33,8 +34,8 @@ export class CloudfoundryDeleteServiceKeyStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((rawAccounts: IAccount[]) => this.setState({ accounts: rawAccounts.map((it) => it.name) }));
     if (this.props.stage.credentials) {
       this.clearAndReloadRegions();
@@ -47,8 +48,8 @@ export class CloudfoundryDeleteServiceKeyStageConfig extends React.Component<
 
   private clearAndReloadRegions = () => {
     this.setState({ regions: [] });
-    Observable.fromPromise(AccountService.getRegionsForAccount(this.props.stage.credentials))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.getRegionsForAccount(this.props.stage.credentials))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((regionList: IRegion[]) => {
         const regions = regionList.map((r) => r.name);
         regions.sort((a, b) => a.localeCompare(b));

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CloudfoundryDeployServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CloudfoundryDeployServiceStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CloudfoundryDeployServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CloudfoundryDeployServiceStageConfig.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -61,8 +62,8 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
   };
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
     this.reloadRegions();
   }
@@ -74,8 +75,8 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
   private reloadRegions = () => {
     const { credentials } = this.props.stage;
     if (credentials) {
-      Observable.fromPromise(AccountService.getRegionsForAccount(credentials))
-        .takeUntil(this.destroy$)
+      observableFrom(AccountService.getRegionsForAccount(credentials))
+        .pipe(takeUntil(this.destroy$))
         .subscribe((regions) => this.setState({ regions }));
     }
   };

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CreateServiceInstanceDirectInput.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CreateServiceInstanceDirectInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CreateServiceInstanceDirectInput.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CreateServiceInstanceDirectInput.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   IService,
@@ -53,8 +54,8 @@ export class CreateServiceInstanceDirectInput extends React.Component<
 
   private loadServices(credentials: string, region: string) {
     if (credentials && region) {
-      Observable.fromPromise(ServicesReader.getServices(credentials, region))
-        .takeUntil(this.destroy$)
+      observableFrom(ServicesReader.getServices(credentials, region))
+        .pipe(takeUntil(this.destroy$))
         .subscribe((serviceNamesAndPlans) => this.setState({ serviceNamesAndPlans }));
     }
   }

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/CloudfoundryDestroyServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/CloudfoundryDestroyServiceStageConfig.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-
 import Select, { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, IAccount, IRegion, IStageConfigProps, StageConfigField } from '@spinnaker/core';
 
@@ -25,8 +25,8 @@ export class CloudfoundryDestroyServiceStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => {
         this.setState({ accounts });
         if (this.props.stage.credentials) {
@@ -43,8 +43,8 @@ export class CloudfoundryDestroyServiceStageConfig extends React.Component<
     this.setState({ regions: [] });
     const { credentials } = this.props.stage;
     if (credentials) {
-      Observable.fromPromise(AccountService.getRegionsForAccount(credentials))
-        .takeUntil(this.destroy$)
+      observableFrom(AccountService.getRegionsForAccount(credentials))
+        .pipe(takeUntil(this.destroy$))
         .subscribe((regions) => this.setState({ regions }));
     }
   };

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/CloudfoundryDestroyServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/CloudfoundryDestroyServiceStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, IAccount, IRegion, IStageConfigProps, StageConfigField } from '@spinnaker/core';

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/CloudfoundryResizeAsgStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/CloudfoundryResizeAsgStageConfig.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -46,8 +47,8 @@ export class CloudfoundryResizeAsgStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
     this.props.stageFieldUpdated();
   }

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/CloudfoundryResizeAsgStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/CloudfoundryResizeAsgStageConfig.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/rollbackCluster/CloudfoundryRollbackClusterStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/rollbackCluster/CloudfoundryRollbackClusterStageConfig.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, IAccount, IPipeline, IStageConfigProps, StageConfigField } from '@spinnaker/core';

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/rollbackCluster/CloudfoundryRollbackClusterStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/rollbackCluster/CloudfoundryRollbackClusterStageConfig.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, IAccount, IPipeline, IStageConfigProps, StageConfigField } from '@spinnaker/core';
 import { AccountRegionClusterSelector } from 'cloudfoundry/presentation';
@@ -31,8 +32,8 @@ export class CloudfoundryRollbackClusterStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
   }
 

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/runJob/CloudfoundryRunJobStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/runJob/CloudfoundryRunJobStageConfig.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/runJob/CloudfoundryRunJobStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/runJob/CloudfoundryRunJobStageConfig.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -34,8 +35,8 @@ export class CloudfoundryRunJobStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
     this.props.stageFieldUpdated();
   }

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/shareService/CloudfoundryShareServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/shareService/CloudfoundryShareServiceStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/shareService/CloudfoundryShareServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/shareService/CloudfoundryShareServiceStageConfig.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -35,8 +36,8 @@ export class CloudfoundryShareServiceStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
     if (this.props.stage.credentials) {
       this.clearAndReloadRegions();
@@ -49,8 +50,8 @@ export class CloudfoundryShareServiceStageConfig extends React.Component<
 
   private clearAndReloadRegions = () => {
     this.setState({ regions: [] });
-    Observable.fromPromise(AccountService.getRegionsForAccount(this.props.stage.credentials))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.getRegionsForAccount(this.props.stage.credentials))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((regionList: IRegion[]) => {
         const { region } = this.props.stage;
         const regions = regionList.map((r) => r.name);

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/unshareService/CloudfoundryUnshareServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/unshareService/CloudfoundryUnshareServiceStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/unshareService/CloudfoundryUnshareServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/unshareService/CloudfoundryUnshareServiceStageConfig.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -33,8 +34,8 @@ export class CloudfoundryUnshareServiceStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
     if (this.props.stage.credentials) {
       this.clearAndReloadRegions();
@@ -47,8 +48,8 @@ export class CloudfoundryUnshareServiceStageConfig extends React.Component<
 
   private clearAndReloadRegions = () => {
     this.setState({ regions: [] });
-    Observable.fromPromise(AccountService.getRegionsForAccount(this.props.stage.credentials))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.getRegionsForAccount(this.props.stage.credentials))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((regionList: IRegion[]) => {
         const regions = regionList.map((r) => r.name);
         regions.sort((a, b) => a.localeCompare(b));

--- a/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryAsgStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryAsgStageConfig.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -26,8 +27,8 @@ export class CloudfoundryAsgStageConfig extends React.Component<IStageConfigProp
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
   }
 

--- a/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryAsgStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryAsgStageConfig.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryLoadBalancersStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryLoadBalancersStageConfig.tsx
@@ -1,6 +1,6 @@
 import { Formik } from 'formik';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryLoadBalancersStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryLoadBalancersStageConfig.tsx
@@ -1,6 +1,7 @@
 import { Formik } from 'formik';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -58,8 +59,8 @@ export class CloudfoundryLoadBalancersStageConfig extends React.Component<
   }
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
   }
 

--- a/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.tsx
@@ -1,7 +1,7 @@
 import { first, isNil, uniq } from 'lodash';
 import React from 'react';
 import Select, { Creatable, Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.tsx
@@ -1,7 +1,8 @@
 import { first, isNil, uniq } from 'lodash';
 import React from 'react';
 import Select, { Creatable, Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   Application,
@@ -68,8 +69,8 @@ export class AccountRegionClusterSelector extends React.Component<
     const { application } = this.props;
     const accountFilter: IServerGroupFilter = (serverGroup: IServerGroup) =>
       serverGroup ? serverGroup.account === credentials : true;
-    Observable.fromPromise(application.ready())
-      .takeUntil(this.destroy$)
+    observableFrom(application.ready())
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         const availableRegions = AppListExtractor.getRegions([application], accountFilter);
         availableRegions.sort();
@@ -79,8 +80,8 @@ export class AccountRegionClusterSelector extends React.Component<
 
   private setClusterList = (credentials: string, regions: string[]): void => {
     const { application } = this.props;
-    Observable.fromPromise(application.ready())
-      .takeUntil(this.destroy$)
+    observableFrom(application.ready())
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         const clusterFilter = AppListExtractor.clusterFilterForCredentialsAndRegion(credentials, regions);
         const clusters = AppListExtractor.getClusters([application], clusterFilter);

--- a/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/FormikAccountRegionClusterSelector.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/FormikAccountRegionClusterSelector.tsx
@@ -1,7 +1,8 @@
 import { FormikProps } from 'formik';
 import { get } from 'lodash';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   Application,
@@ -74,8 +75,8 @@ export class FormikAccountRegionClusterSelector extends React.Component<
     const { application } = this.props;
     const accountFilter: IServerGroupFilter = (serverGroup: IServerGroup) =>
       serverGroup ? serverGroup.account === credentials : true;
-    Observable.fromPromise(application.ready())
-      .takeUntil(this.destroy$)
+    observableFrom(application.ready())
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         const availableRegions = AppListExtractor.getRegions([application], accountFilter);
         availableRegions.sort();
@@ -85,8 +86,8 @@ export class FormikAccountRegionClusterSelector extends React.Component<
 
   private setClusterList = (credentials: string, regions: string[]): void => {
     const { application } = this.props;
-    Observable.fromPromise(application.ready())
-      .takeUntil(this.destroy$)
+    observableFrom(application.ready())
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         const clusterFilter = AppListExtractor.clusterFilterForCredentialsAndRegion(credentials, regions);
         const clusters = AppListExtractor.getClusters([application], clusterFilter);

--- a/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/FormikAccountRegionClusterSelector.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/FormikAccountRegionClusterSelector.tsx
@@ -1,7 +1,7 @@
 import { FormikProps } from 'formik';
 import { get } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/basicSettings/BasicSettings.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/basicSettings/BasicSettings.cf.tsx
@@ -1,7 +1,7 @@
 import { FormikErrors, FormikProps } from 'formik';
 import { get } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/basicSettings/BasicSettings.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/basicSettings/BasicSettings.cf.tsx
@@ -1,7 +1,8 @@
 import { FormikErrors, FormikProps } from 'formik';
 import { get } from 'lodash';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -39,8 +40,8 @@ export class CloudFoundryServerGroupBasicSettings
   };
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => {
         this.setState({ accounts });
         this.updateRegionList();
@@ -59,8 +60,8 @@ export class CloudFoundryServerGroupBasicSettings
   private updateRegionList = (): void => {
     const credentials = get(this.props.formik.values, 'credentials', undefined);
     if (credentials) {
-      Observable.fromPromise(AccountService.getRegionsForAccount(credentials))
-        .takeUntil(this.destroy$)
+      observableFrom(AccountService.getRegionsForAccount(credentials))
+        .pipe(takeUntil(this.destroy$))
         .subscribe((regions) => this.setState({ regions }));
     }
   };

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/cloneSettings/CloneSettings.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/cloneSettings/CloneSettings.cf.tsx
@@ -1,6 +1,7 @@
 import { FormikErrors, FormikProps } from 'formik';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountService,
@@ -37,8 +38,8 @@ export class CloudFoundryServerGroupCloneSettings
   };
 
   public componentDidMount(): void {
-    Observable.fromPromise(AccountService.listAccounts('cloudfoundry'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.listAccounts('cloudfoundry'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts) => this.setState({ accounts }));
   }
 

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/cloneSettings/CloneSettings.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/cloneSettings/CloneSettings.cf.tsx
@@ -1,6 +1,6 @@
 import { FormikErrors, FormikProps } from 'formik';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/core/src/account/AccountService.ts
+++ b/app/scripts/modules/core/src/account/AccountService.ts
@@ -68,8 +68,8 @@ export class AccountService {
 
   public static initialize(): void {
     this.accounts$ = observableDefer(() => {
-      const promise = REST('/credentials').useCache().query({ expand: true }).get();
-      return observableFrom<IAccountDetails[]>(promise);
+      const promise = REST('/credentials').useCache().query({ expand: true }).get<IAccountDetails[]>();
+      return observableFrom(promise);
     }).pipe(publishReplay(1), refCount());
 
     this.providers$ = AccountService.accounts$.pipe(

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -2,7 +2,7 @@ import { IScope } from 'angular';
 import { map, union, uniq } from 'lodash';
 import { $log, $q } from 'ngimport';
 import { combineLatest as observableCombineLatest, Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map as rxMap } from 'rxjs/operators';
 
 import { ICluster } from '../domain/ICluster';
 import { ApplicationDataSource, IDataSourceConfig, IFetchStatus } from './service/applicationDataSource';
@@ -114,8 +114,8 @@ export class Application {
     dataSourceConfigs: Array<IDataSourceConfig<any>>,
   ) {
     dataSourceConfigs.forEach((config) => this.addDataSource(config));
-    this.status$ = observableCombineLatest([this.dataSources.map((ds) => ds.status$)]).pipe(
-      map((statuses) => this.getDerivedApplicationStatus(statuses)),
+    this.status$ = observableCombineLatest(this.dataSources.map((ds) => ds.status$)).pipe(
+      rxMap((statuses: IFetchStatus[]) => this.getDerivedApplicationStatus(statuses)),
     );
   }
 

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -1,7 +1,8 @@
 import { IScope } from 'angular';
 import { map, union, uniq } from 'lodash';
 import { $log, $q } from 'ngimport';
-import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
+import { combineLatest as observableCombineLatest, Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { ICluster } from '../domain/ICluster';
 import { ApplicationDataSource, IDataSourceConfig, IFetchStatus } from './service/applicationDataSource';
@@ -113,8 +114,8 @@ export class Application {
     dataSourceConfigs: Array<IDataSourceConfig<any>>,
   ) {
     dataSourceConfigs.forEach((config) => this.addDataSource(config));
-    this.status$ = Observable.combineLatest(this.dataSources.map((ds) => ds.status$)).map((statuses) =>
-      this.getDerivedApplicationStatus(statuses),
+    this.status$ = observableCombineLatest(this.dataSources.map((ds) => ds.status$)).pipe(
+      map((statuses) => this.getDerivedApplicationStatus(statuses)),
     );
   }
 

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -114,7 +114,7 @@ export class Application {
     dataSourceConfigs: Array<IDataSourceConfig<any>>,
   ) {
     dataSourceConfigs.forEach((config) => this.addDataSource(config));
-    this.status$ = observableCombineLatest(this.dataSources.map((ds) => ds.status$)).pipe(
+    this.status$ = observableCombineLatest([this.dataSources.map((ds) => ds.status$)]).pipe(
       map((statuses) => this.getDerivedApplicationStatus(statuses)),
     );
   }

--- a/app/scripts/modules/core/src/application/search/Applications.tsx
+++ b/app/scripts/modules/core/src/application/search/Applications.tsx
@@ -79,7 +79,7 @@ export class Applications extends React.Component<{}, IApplicationsState> {
         map((apps) => apps.map((app) => this.fixAccount(app))),
 
         // Apply filter/sort
-        combineLatest(this.filter$, this.sort$),
+        combineLatest([this.filter$, this.sort$]),
         map(([apps, filter, sort]) => {
           const viewState: IViewState = { filter, sort };
           this.applicationsCache.put('#global', viewState);
@@ -87,7 +87,7 @@ export class Applications extends React.Component<{}, IApplicationsState> {
         }),
 
         // validate and update pagination
-        combineLatest(this.pagination$.pipe(distinctUntilChanged(isEqual))),
+        combineLatest([this.pagination$.pipe(distinctUntilChanged(isEqual))]),
         map(([applications, pagination]) => {
           const lastPage = Math.floor(applications.length / pagination.itemsPerPage) + 1;
           const currentPage = Math.min(pagination.currentPage, lastPage);

--- a/app/scripts/modules/core/src/application/search/Applications.tsx
+++ b/app/scripts/modules/core/src/application/search/Applications.tsx
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash';
 import React from 'react';
 import { SelectCallback } from 'react-bootstrap';
-import { BehaviorSubject, from as observableFrom, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, from as observableFrom, Subject } from 'rxjs';
 import { combineLatest, distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
 
 import { IAccount } from 'core/account';

--- a/app/scripts/modules/core/src/application/search/Applications.tsx
+++ b/app/scripts/modules/core/src/application/search/Applications.tsx
@@ -2,7 +2,8 @@ import { isEqual } from 'lodash';
 import React from 'react';
 import { SelectCallback } from 'react-bootstrap';
 import { BehaviorSubject, from as observableFrom, Subject } from 'rxjs';
-import { combineLatest, distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
+import { combineLatest as observableCombineLatest } from 'rxjs';
+import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
 
 import { IAccount } from 'core/account';
 import { ICache, ViewStateCache } from 'core/cache';
@@ -74,20 +75,22 @@ export class Applications extends React.Component<{}, IApplicationsState> {
       return (a[key] || '').localeCompare(b[key] || '') * (reverse ? -1 : 1);
     };
 
-    observableFrom(ApplicationReader.listApplications())
+    const applicationSummaries$ = observableFrom(ApplicationReader.listApplications()).pipe(
+      map((apps) => apps.map((app) => this.fixAccount(app))),
+    );
+
+    const filteredApps$ = observableCombineLatest([applicationSummaries$, this.filter$, this.sort$]).pipe(
+      // Apply filter/sort
+      map(([apps, filter, sort]) => {
+        const viewState: IViewState = { filter, sort };
+        this.applicationsCache.put('#global', viewState);
+        return apps.filter((app) => appMatchesQuery(filter, app)).sort((a, b) => appSort(sort, a, b));
+      }),
+    );
+
+    // validate and update pagination
+    observableCombineLatest([filteredApps$, this.pagination$.pipe(distinctUntilChanged(isEqual))])
       .pipe(
-        map((apps) => apps.map((app) => this.fixAccount(app))),
-
-        // Apply filter/sort
-        combineLatest([this.filter$, this.sort$]),
-        map(([apps, filter, sort]) => {
-          const viewState: IViewState = { filter, sort };
-          this.applicationsCache.put('#global', viewState);
-          return apps.filter((app) => appMatchesQuery(filter, app)).sort((a, b) => appSort(sort, a, b));
-        }),
-
-        // validate and update pagination
-        combineLatest([this.pagination$.pipe(distinctUntilChanged(isEqual))]),
         map(([applications, pagination]) => {
           const lastPage = Math.floor(applications.length / pagination.itemsPerPage) + 1;
           const currentPage = Math.min(pagination.currentPage, lastPage);
@@ -95,7 +98,6 @@ export class Applications extends React.Component<{}, IApplicationsState> {
           const validatedPagination = { ...pagination, currentPage, maxSize } as IApplicationPagination;
           return { applications, pagination: validatedPagination };
         }),
-
         takeUntil(this.destroy$),
       )
       .subscribe(

--- a/app/scripts/modules/core/src/artifact/react/StageArtifactSelector.tsx
+++ b/app/scripts/modules/core/src/artifact/react/StageArtifactSelector.tsx
@@ -2,7 +2,7 @@ import { module } from 'angular';
 import React from 'react';
 import Select from 'react-select';
 import { react2angular } from 'react2angular';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, IArtifactAccount } from 'core/account';

--- a/app/scripts/modules/core/src/artifact/react/StageArtifactSelector.tsx
+++ b/app/scripts/modules/core/src/artifact/react/StageArtifactSelector.tsx
@@ -2,7 +2,8 @@ import { module } from 'angular';
 import React from 'react';
 import Select from 'react-select';
 import { react2angular } from 'react2angular';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, IArtifactAccount } from 'core/account';
 import { IArtifact, IExpectedArtifact, IPipeline, IStage } from 'core/domain';
@@ -58,8 +59,8 @@ export class StageArtifactSelector extends React.Component<IStageArtifactSelecto
 
   public componentDidMount(): void {
     const excludedPatterns = this.props.excludedArtifactTypePatterns;
-    Observable.fromPromise(AccountService.getArtifactAccounts())
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.getArtifactAccounts())
+      .pipe(takeUntil(this.destroy$))
       .subscribe((artifactAccounts) => {
         this.setState({
           artifactAccounts: excludedPatterns

--- a/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
+++ b/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
@@ -1,6 +1,6 @@
 import { IHttpPromiseCallbackArg } from 'angular';
 import { $http, $location, $rootScope } from 'ngimport';
-import { fromEvent as observableFromEvent, Observable, Subscription } from 'rxjs';
+import { fromEvent as observableFromEvent, Subscription } from 'rxjs';
 
 import { SETTINGS } from 'core/config/settings';
 import { ModalInjector } from 'core/reactShims/modal.injector';

--- a/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
+++ b/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
@@ -1,6 +1,6 @@
 import { IHttpPromiseCallbackArg } from 'angular';
 import { $http, $location, $rootScope } from 'ngimport';
-import { Observable, Subscription } from 'rxjs';
+import { fromEvent as observableFromEvent, Observable, Subscription } from 'rxjs';
 
 import { SETTINGS } from 'core/config/settings';
 import { ModalInjector } from 'core/reactShims/modal.injector';
@@ -39,7 +39,7 @@ export class AuthenticationInitializer {
     this.userLoggedOut = true;
     this.openLoggedOutModal();
 
-    this.visibilityWatch = Observable.fromEvent(document, 'visibilitychange').subscribe(() => {
+    this.visibilityWatch = observableFromEvent(document, 'visibilitychange').subscribe(() => {
       if (document.visibilityState === 'visible') {
         this.checkForReauthentication();
       }

--- a/app/scripts/modules/core/src/cluster/AllClustersGroupings.tsx
+++ b/app/scripts/modules/core/src/cluster/AllClustersGroupings.tsx
@@ -2,6 +2,7 @@ import { UIRouterContext } from '@uirouter/react-hybrid';
 import React from 'react';
 import { AutoSizer, CellMeasurer, CellMeasurerCache, List, ListRowProps } from 'react-virtualized';
 import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import { Application } from 'core/application';
 import { ISortFilter } from 'core/filterModel';
@@ -116,7 +117,7 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
   private scrollToRow = () => {
     const { $stateParams } = ReactInjector;
     // Automatically scroll server group into view if deep linkedif ($stateParams.serverGroup) {
-    this.clusterFilterService.groupsUpdatedStream.take(1).subscribe(() => {
+    this.clusterFilterService.groupsUpdatedStream.pipe(take(1)).subscribe(() => {
       const scrollToRow = this.state.groups.findIndex((group) =>
         group.subgroups.some((subgroup) =>
           subgroup.serverGroups.some(

--- a/app/scripts/modules/core/src/cluster/clusterSearchResultType.tsx
+++ b/app/scripts/modules/core/src/cluster/clusterSearchResultType.tsx
@@ -1,6 +1,7 @@
 import { uniqBy } from 'lodash';
 import React from 'react';
 import { Observable } from 'rxjs';
+import { filter, first, map } from 'rxjs/operators';
 
 import { IQueryParams } from 'core/navigation';
 import { ReactInjector } from 'core/reactShims';
@@ -82,10 +83,10 @@ class ClustersSearchResultType extends SearchResultType<IClusterSearchResult> {
     _params: IQueryParams,
     otherResults: Observable<ISearchResultSet>,
   ): Observable<ISearchResults<IClusterSearchResult>> {
-    return otherResults
-      .filter((resultSet) => resultSet.type.id === 'serverGroups')
-      .first()
-      .map((resultSet: ISearchResultSet) => {
+    return otherResults.pipe(
+      filter((resultSet) => resultSet.type.id === 'serverGroups'),
+      first(),
+      map((resultSet: ISearchResultSet) => {
         const { status, results, error } = resultSet;
         if (status === SearchStatus.ERROR) {
           throw error;
@@ -95,7 +96,8 @@ class ClustersSearchResultType extends SearchResultType<IClusterSearchResult> {
         const searchResults = serverGroups.map((sg) => this.makeSearchResult(sg));
         const clusters: IClusterSearchResult[] = uniqBy(searchResults, (sg) => `${sg.account}-${sg.cluster}`);
         return { results: clusters };
-      });
+      }),
+    );
   }
 
   public displayFormatter(searchResult: IClusterSearchResult) {

--- a/app/scripts/modules/core/src/event/EventBus.ts
+++ b/app/scripts/modules/core/src/event/EventBus.ts
@@ -1,4 +1,5 @@
 import { Observable, Subject } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 
 export interface IEventMessage {
   key: string;
@@ -17,7 +18,10 @@ export class EventBus {
    * @return {Observable<any>}
    */
   public static observe<T>(key: string): Observable<T> {
-    return this.message$.filter((m) => m.key === key).map((m) => m.payload);
+    return this.message$.pipe(
+      filter((m) => m.key === key),
+      map((m) => m.payload),
+    );
   }
 
   /**

--- a/app/scripts/modules/core/src/instance/InstanceList.tsx
+++ b/app/scripts/modules/core/src/instance/InstanceList.tsx
@@ -1,6 +1,7 @@
 import { isEqual } from 'lodash';
 import React from 'react';
 import { Subject } from 'rxjs';
+import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
 
 import { IInstance, IServerGroup } from 'core/domain';
 import { SortToggle } from 'core/presentation/sortToggle/SortToggle';
@@ -49,14 +50,16 @@ export class InstanceList extends React.Component<IInstanceListProps, IInstanceL
   }
 
   public componentDidMount() {
-    ClusterState.multiselectModel.instancesStream.takeUntil(this.destroy$).subscribe(() => {
+    ClusterState.multiselectModel.instancesStream.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.setState({ allSelected: this.instanceGroup.selectAll });
     });
 
     this.$uiRouter.globals.params$
-      .map((params) => [params.multiselect, params.instanceSort])
-      .distinctUntilChanged(isEqual)
-      .takeUntil(this.destroy$)
+      .pipe(
+        map((params) => [params.multiselect, params.instanceSort]),
+        distinctUntilChanged(isEqual),
+        takeUntil(this.destroy$),
+      )
       .subscribe(() => {
         this.setState({
           multiselect: this.$state.params.multiselect,

--- a/app/scripts/modules/core/src/instance/details/InstanceDetails.tsx
+++ b/app/scripts/modules/core/src/instance/details/InstanceDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { forkJoin as observableForkJoin, from as observableFrom, Observable, Subject } from 'rxjs';
+import { forkJoin as observableForkJoin, from as observableFrom, Subject } from 'rxjs';
 import { mergeMap, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 import { AccountService } from 'core/account/AccountService';

--- a/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -1,6 +1,6 @@
 import { isEmpty, template } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { Application } from 'core/application';

--- a/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -1,6 +1,7 @@
 import { isEmpty, template } from 'lodash';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { Application } from 'core/application';
 import { IManifest } from 'core/domain/IManifest';
@@ -31,8 +32,8 @@ export class JobStageExecutionLogs extends React.Component<IJobStageExecutionLog
 
   public componentDidMount() {
     const { account, location, deployedName } = this.props;
-    Observable.from(ManifestReader.getManifest(account, location, deployedName))
-      .takeUntil(this.destroy$)
+    observableFrom(ManifestReader.getManifest(account, location, deployedName))
+      .pipe(takeUntil(this.destroy$))
       .subscribe(
         (manifest) => this.setState({ manifest }),
         () => {},

--- a/app/scripts/modules/core/src/notification/NotificationsList.tsx
+++ b/app/scripts/modules/core/src/notification/NotificationsList.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
 import { capitalize, filter, flatten, get, isEmpty } from 'lodash';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { Application } from 'core/application';
 import { INotification, INotificationTypeConfig } from 'core/domain';
@@ -151,8 +152,8 @@ export class NotificationsList extends React.Component<INotificationsListProps, 
    */
     const { application, updateNotifications } = this.props;
     const { supportedNotificationTypes } = this.state;
-    Observable.fromPromise(AppNotificationsService.getNotificationsForApplication(application.name))
-      .takeUntil(this.destroy$)
+    observableFrom(AppNotificationsService.getNotificationsForApplication(application.name))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((notifications) => {
         const results = filter(
           flatten(

--- a/app/scripts/modules/core/src/notification/NotificationsList.tsx
+++ b/app/scripts/modules/core/src/notification/NotificationsList.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { capitalize, filter, flatten, get, isEmpty } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { Application } from 'core/application';

--- a/app/scripts/modules/core/src/overrideRegistry/Overridable.tsx
+++ b/app/scripts/modules/core/src/overrideRegistry/Overridable.tsx
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import React from 'react';
-import { Observable, of as observableOf, Subject } from 'rxjs';
+import { of as observableOf, Subject } from 'rxjs';
 import { map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { AccountService, IAccountDetails } from 'core/account/AccountService';

--- a/app/scripts/modules/core/src/pagerDuty/Pager.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/Pager.tsx
@@ -15,7 +15,7 @@ import {
   TableCellProps,
   TableHeaderProps,
 } from 'react-virtualized';
-import { forkJoin as observableForkJoin, from as observableFrom, Observable } from 'rxjs';
+import { forkJoin as observableForkJoin, from as observableFrom } from 'rxjs';
 
 import { ApplicationReader, IApplicationSummary } from 'core/application';
 import { SETTINGS } from 'core/config';

--- a/app/scripts/modules/core/src/pagerDuty/Pager.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/Pager.tsx
@@ -15,7 +15,7 @@ import {
   TableCellProps,
   TableHeaderProps,
 } from 'react-virtualized';
-import { Observable } from 'rxjs';
+import { forkJoin as observableForkJoin, from as observableFrom, Observable } from 'rxjs';
 
 import { ApplicationReader, IApplicationSummary } from 'core/application';
 import { SETTINGS } from 'core/config';
@@ -120,8 +120,8 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
 
   public componentDidMount(): void {
     // Get the data from all the necessary sources before rendering
-    Observable.forkJoin(
-      Observable.fromPromise(ApplicationReader.listApplications()),
+    observableForkJoin(
+      observableFrom(ApplicationReader.listApplications()),
       PagerDutyReader.listOnCalls(),
       PagerDutyReader.listServices(),
     ).subscribe((results: [IApplicationSummary[], { [id: string]: IOnCall[] }, IPagerDutyService[]]) => {

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { from as observableFrom, Observable } from 'rxjs';
 
 import { REST } from 'core/api/ApiService';
 
@@ -24,10 +24,10 @@ export interface IOnCall {
 
 export class PagerDutyReader {
   public static listServices(): Observable<IPagerDutyService[]> {
-    return Observable.fromPromise(REST('/pagerDuty/services').get());
+    return observableFrom(REST('/pagerDuty/services').get());
   }
 
   public static listOnCalls(): Observable<{ [id: string]: IOnCall[] }> {
-    return Observable.fromPromise(REST('/pagerDuty/oncalls').get());
+    return observableFrom(REST('/pagerDuty/oncalls').get());
   }
 }

--- a/app/scripts/modules/core/src/pagerDuty/pagerDutyTag.component.spec.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDutyTag.component.spec.ts
@@ -1,4 +1,4 @@
-import { of as observableOf, Observable } from 'rxjs';
+import { of as observableOf } from 'rxjs';
 import { IComponentControllerService, mock } from 'angular';
 import { IPagerDutyService, PagerDutyReader } from './pagerDuty.read.service';
 import { PAGER_DUTY_TAG_COMPONENT, PagerDutyTagComponentController } from './pagerDutyTag.component';

--- a/app/scripts/modules/core/src/pagerDuty/pagerDutyTag.component.spec.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDutyTag.component.spec.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { of as observableOf, Observable } from 'rxjs';
 import { IComponentControllerService, mock } from 'angular';
 import { IPagerDutyService, PagerDutyReader } from './pagerDuty.read.service';
 import { PAGER_DUTY_TAG_COMPONENT, PagerDutyTagComponentController } from './pagerDutyTag.component';
@@ -43,7 +43,7 @@ describe('PagerDutyTagComponent', () => {
   beforeEach(
     mock.inject((_$componentController_: IComponentControllerService) => {
       $componentController = _$componentController_;
-      spyOn(PagerDutyReader, 'listServices').and.returnValue(Observable.of(services));
+      spyOn(PagerDutyReader, 'listServices').and.returnValue(observableOf(services));
     }),
   );
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.js
@@ -3,6 +3,7 @@
 import { module } from 'angular';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { take } from 'rxjs/operators';
 
 import { AccountService } from 'core/account/AccountService';
 import { SETTINGS } from 'core/config/settings';
@@ -33,7 +34,7 @@ module(CORE_PIPELINE_CONFIG_STAGES_BASEPROVIDERSTAGE_BASEPROVIDERSTAGE, []).cont
     }
 
     AccountService.listProviders$($scope.application)
-      .take(1)
+      .pipe(take(1))
       .subscribe(function (providers) {
         $scope.viewState.loading = false;
         const availableProviders = [];

--- a/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Select from 'react-select';
-import { Observable } from 'rxjs';
+import { forkJoin as observableForkJoin, from as observableFrom, Observable } from 'rxjs';
 
 import { REST } from 'core/api/ApiService';
 
@@ -43,7 +43,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
   };
 
   private fetchCommands = (apiKey: string) => {
-    return Observable.fromPromise(
+    return observableFrom(
       REST('/integrations/gremlin/templates/command')
         .post({
           apiKey,
@@ -61,7 +61,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
   };
 
   private fetchTargets = (apiKey: string) => {
-    return Observable.fromPromise(
+    return observableFrom(
       REST('/integrations/gremlin/templates/target')
         .post({
           apiKey,
@@ -89,7 +89,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
     });
 
     // Get the data from all the necessary sources before rendering
-    Observable.forkJoin(this.fetchCommands(gremlinApiKey), this.fetchTargets(gremlinApiKey)).subscribe((results) => {
+    observableForkJoin(this.fetchCommands(gremlinApiKey), this.fetchTargets(gremlinApiKey)).subscribe((results) => {
       const newState: IState = {
         isFetchingData: false,
       };

--- a/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Select from 'react-select';
-import { forkJoin as observableForkJoin, from as observableFrom, Observable } from 'rxjs';
+import { forkJoin as observableForkJoin, from as observableFrom } from 'rxjs';
 
 import { REST } from 'core/api/ApiService';
 

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { Application, ApplicationReader, IApplicationSummary } from 'core/application';

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { Application, ApplicationReader, IApplicationSummary } from 'core/application';
 import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
@@ -46,8 +47,8 @@ export class CreatePipelineFromTemplate extends React.Component<
   private destroy$ = new Subject();
 
   public componentDidMount() {
-    Observable.fromPromise(ApplicationReader.listApplications())
-      .takeUntil(this.destroy$)
+    observableFrom(ApplicationReader.listApplications())
+      .pipe(takeUntil(this.destroy$))
       .subscribe(
         (applications) => this.setState({ applications, loading: false }),
         () => {
@@ -82,8 +83,8 @@ export class CreatePipelineFromTemplate extends React.Component<
     } = this.state;
 
     this.setState({ submitting: true });
-    Observable.fromPromise(ApplicationReader.getApplication(name))
-      .takeUntil(this.destroy$)
+    observableFrom(ApplicationReader.getApplication(name))
+      .pipe(takeUntil(this.destroy$))
       .subscribe(
         (loadedApplication) => {
           loadedApplication.getDataSource('pipelineConfigs').activate();

--- a/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTriggerTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTriggerTemplate.tsx
@@ -2,7 +2,7 @@ import { capitalize, get } from 'lodash';
 import { $q } from 'ngimport';
 import React from 'react';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { BuildServiceType, IgorService } from 'core/ci';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTriggerTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTriggerTemplate.tsx
@@ -2,7 +2,8 @@ import { capitalize, get } from 'lodash';
 import { $q } from 'ngimport';
 import React from 'react';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { BuildServiceType, IgorService } from 'core/ci';
 import { IBuild, IBuildInfo, IBuildTrigger, IPipelineCommand } from 'core/domain';
@@ -101,8 +102,8 @@ export class BaseBuildTriggerTemplate extends React.Component<
       return;
     }
 
-    Observable.fromPromise(IgorService.listBuildsForJob(trigger.master, trigger.job))
-      .takeUntil(this.destroy$)
+    observableFrom(IgorService.listBuildsForJob(trigger.master, trigger.job))
+      .pipe(takeUntil(this.destroy$))
       .subscribe(this.buildLoadSuccess, this.buildLoadFailure);
   };
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/cron/CronAdvance.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/cron/CronAdvance.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { HelpField } from 'core/help';
 
@@ -31,8 +32,8 @@ export class CronAdvance extends React.Component<ICronTriggerConfigProps, ICronA
   }
 
   private validateCronExpression = (cronExpression: string) => {
-    Observable.fromPromise(CronValidatorService.validate(cronExpression))
-      .takeUntil(this.destroy$)
+    observableFrom(CronValidatorService.validate(cronExpression))
+      .pipe(takeUntil(this.destroy$))
       .subscribe(
         (result: { valid: boolean; message?: string; description?: string }) => {
           if (result.valid) {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/cron/CronAdvance.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/cron/CronAdvance.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { HelpField } from 'core/help';

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { flatten, uniq, without } from 'lodash';
 import React from 'react';
 import ReactGA from 'react-ga';
-import { from as observableFrom, Observable, Subject, Subscription } from 'rxjs';
+import { from as observableFrom, Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { AccountTag } from 'core/account';

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -2,7 +2,8 @@ import classnames from 'classnames';
 import { flatten, uniq, without } from 'lodash';
 import React from 'react';
 import ReactGA from 'react-ga';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { from as observableFrom, Observable, Subject, Subscription } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { AccountTag } from 'core/account';
 import { Application } from 'core/application/application.model';
@@ -144,7 +145,7 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
   }
 
   public triggerPipeline(trigger: IExecutionTrigger = null, config = this.state.pipelineConfig): void {
-    Observable.fromPromise(
+    observableFrom(
       new Promise((resolve) => {
         if (PipelineTemplateV2Service.isV2PipelineConfig(config)) {
           PipelineTemplateReader.getPipelinePlan(config as IPipelineTemplateConfigV2)
@@ -155,7 +156,7 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
         }
       }),
     )
-      .takeUntil(this.destroy$)
+      .pipe(takeUntil(this.destroy$))
       .subscribe((pipeline) =>
         ManualExecutionModal.show({
           pipeline,

--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -2,7 +2,8 @@ import { Form, Formik } from 'formik';
 import { assign, clone, compact, extend, get, head, isArray, isEmpty, isEqual, pickBy, uniq } from 'lodash';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { Application } from 'core/application';
 import { AuthenticationService } from 'core/authentication';
@@ -134,8 +135,8 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
 
     this.triggerChanged(trigger);
 
-    Observable.fromPromise(AppNotificationsService.getNotificationsForApplication(application.name))
-      .takeUntil(this.destroy$)
+    observableFrom(AppNotificationsService.getNotificationsForApplication(application.name))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((notifications) => {
         const applicationNotifications: INotification[] = [];
         Object.keys(notifications)
@@ -274,10 +275,8 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
 
   private updateTriggerOptions = (triggers: ITrigger[]) => {
     triggers.map((t, i) => {
-      Observable.fromPromise(
-        (Registry.pipeline.getManualExecutionComponentForTriggerType(t.type) as any).formatLabel(t),
-      )
-        .takeUntil(this.destroy$)
+      observableFrom((Registry.pipeline.getManualExecutionComponentForTriggerType(t.type) as any).formatLabel(t))
+        .pipe(takeUntil(this.destroy$))
         .subscribe(
           (label: string) => {
             const newTriggers = triggers.slice(0);

--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -2,7 +2,7 @@ import { Form, Formik } from 'formik';
 import { assign, clone, compact, extend, get, head, isArray, isEmpty, isEqual, pickBy, uniq } from 'lodash';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { Application } from 'core/application';

--- a/app/scripts/modules/core/src/pipeline/manualExecution/PipelineOptions.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/PipelineOptions.tsx
@@ -2,7 +2,7 @@ import { FormikProps } from 'formik';
 import { head } from 'lodash';
 import React from 'react';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { IParameter, IPipeline, IPipelineCommand, ITrigger } from 'core/domain';

--- a/app/scripts/modules/core/src/pipeline/manualExecution/PipelineOptions.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/PipelineOptions.tsx
@@ -2,7 +2,8 @@ import { FormikProps } from 'formik';
 import { head } from 'lodash';
 import React from 'react';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { IParameter, IPipeline, IPipelineCommand, ITrigger } from 'core/domain';
 import { FormField, TetheredSelect } from 'core/presentation';
@@ -46,8 +47,8 @@ export class PipelineOptions extends React.Component<IPipelineOptionsProps, IPip
         type: 'templatedPipeline',
         ...pipeline,
       };
-      Observable.fromPromise(PipelineTemplateReader.getPipelinePlan(pipelineTemplateConfig))
-        .takeUntil(this.destroy$)
+      observableFrom(PipelineTemplateReader.getPipelinePlan(pipelineTemplateConfig))
+        .pipe(takeUntil(this.destroy$))
         .subscribe(
           (plan: IPipeline) => {
             this.setPipelineSelectedValues(isV2Pipeline ? formatPipeline(plan) : pipeline);

--- a/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
@@ -2,7 +2,7 @@ import { FormikProps } from 'formik';
 import { clone, head } from 'lodash';
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { IPipelineCommand, ITrigger } from 'core/domain';

--- a/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
@@ -2,7 +2,8 @@ import { FormikProps } from 'formik';
 import { clone, head } from 'lodash';
 import React from 'react';
 import Select, { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { IPipelineCommand, ITrigger } from 'core/domain';
 import { FormField } from 'core/presentation';
@@ -35,10 +36,10 @@ export class Triggers extends React.Component<ITriggersProps> {
 
   private updateTriggerDescription = (trigger: ITrigger) => {
     if (trigger && !trigger.description && Registry.pipeline.hasManualExecutionComponentForTriggerType(trigger.type)) {
-      Observable.fromPromise(
+      observableFrom(
         (Registry.pipeline.getManualExecutionComponentForTriggerType(trigger.type) as any).formatLabel(trigger),
       )
-        .takeUntil(this.destroy$)
+        .pipe(takeUntil(this.destroy$))
         .subscribe((label: string) => {
           const newTrigger = clone(trigger);
           newTrigger.description = label;

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Overlay, Popover, PopoverProps } from 'react-bootstrap';
 import ReactDOM from 'react-dom';
-import { merge as observableMerge, Observable, of as observableOf, Subject } from 'rxjs';
+import { merge as observableMerge, of as observableOf, Subject } from 'rxjs';
 import { delay, filter, map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { UUIDGenerator } from 'core/utils';

--- a/app/scripts/modules/core/src/projects/ProjectHeader.tsx
+++ b/app/scripts/modules/core/src/projects/ProjectHeader.tsx
@@ -4,6 +4,7 @@ import '@uirouter/rx';
 import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { IProject } from 'core/domain';
 import { Overridable } from 'core/overrideRegistry';
@@ -32,7 +33,7 @@ export class ProjectHeader extends React.Component<IProjectHeaderProps, IProject
 
   public componentDidMount() {
     const { success$ } = this.props.transition.router.globals;
-    success$.takeUntil(this.destroy$).subscribe((success) => {
+    success$.pipe(takeUntil(this.destroy$)).subscribe((success) => {
       const state = success.to().name;
       const application = success.params().application;
       this.setState({ state, application });

--- a/app/scripts/modules/core/src/scheduler/SchedulerFactory.ts
+++ b/app/scripts/modules/core/src/scheduler/SchedulerFactory.ts
@@ -1,5 +1,5 @@
 import { $log, $timeout, $window } from 'ngimport';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { Observable, Subject, Subscription, timer as observableTimer } from 'rxjs';
 
 import { SETTINGS } from 'core/config/settings';
 
@@ -19,7 +19,7 @@ export class SchedulerFactory {
 
     // When creating the timer, use last run as the dueTime (first arg); zero can lead to concurrency issues
     // where the scheduler will fire shortly after being subscribed to, resulting in surprising immediate refreshes
-    let source = Observable.timer(pollSchedule, pollSchedule);
+    let source = observableTimer(pollSchedule, pollSchedule);
 
     const run = (): void => {
       if (suspended) {

--- a/app/scripts/modules/core/src/scheduler/SchedulerFactory.ts
+++ b/app/scripts/modules/core/src/scheduler/SchedulerFactory.ts
@@ -1,5 +1,5 @@
 import { $log, $timeout, $window } from 'ngimport';
-import { Observable, Subject, Subscription, timer as observableTimer } from 'rxjs';
+import { Subject, Subscription, timer as observableTimer } from 'rxjs';
 
 import { SETTINGS } from 'core/config/settings';
 

--- a/app/scripts/modules/core/src/search/global/GlobalSearch.tsx
+++ b/app/scripts/modules/core/src/search/global/GlobalSearch.tsx
@@ -3,7 +3,7 @@ import { flatten } from 'lodash';
 import { Debounce } from 'lodash-decorators';
 import React from 'react';
 import ReactGA from 'react-ga';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { debounceTime, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 import { Tooltip } from 'core/presentation/Tooltip';

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructureSearch.service.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructureSearch.service.ts
@@ -1,5 +1,5 @@
 import { IDeferred, IQService, module } from 'angular';
-import { Observable, of as observableOf, Subject } from 'rxjs';
+import { of as observableOf, Subject } from 'rxjs';
 import { switchMap, toArray } from 'rxjs/operators';
 
 import { PROVIDER_SERVICE_DELEGATE, ProviderServiceDelegate } from 'core/cloudProvider';

--- a/app/scripts/modules/core/src/search/searchResult/searchResultType.ts
+++ b/app/scripts/modules/core/src/search/searchResult/searchResultType.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Observable } from 'rxjs';
+import { from as observableFrom, Observable } from 'rxjs';
 
 import { DefaultSearchResultTab } from './DefaultSearchResultTab';
 import { ISearchResultSet } from '../infrastructure/infrastructureSearch.service';
@@ -50,6 +50,6 @@ export abstract class SearchResultType<T extends ISearchResult = ISearchResult> 
       searchParams.allowShortQuery = 'true';
     }
 
-    return Observable.fromPromise(SearchService.search(searchParams));
+    return observableFrom(SearchService.search(searchParams));
   }
 }

--- a/app/scripts/modules/core/src/search/searchResult/searchResultType.ts
+++ b/app/scripts/modules/core/src/search/searchResult/searchResultType.ts
@@ -50,6 +50,6 @@ export abstract class SearchResultType<T extends ISearchResult = ISearchResult> 
       searchParams.allowShortQuery = 'true';
     }
 
-    return observableFrom(SearchService.search(searchParams));
+    return observableFrom(SearchService.search<T>(searchParams));
   }
 }

--- a/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
+++ b/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
@@ -4,6 +4,7 @@ import { $interpolate } from 'ngimport';
 import React from 'react';
 import ReactGA from 'react-ga';
 import { Subscription } from 'rxjs';
+import { merge } from 'rxjs/operators';
 
 import { Application } from 'core/application';
 import { SETTINGS } from 'core/config';
@@ -144,7 +145,9 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
   public componentDidMount(): void {
     const { serverGroupsStream, instancesStream } = ClusterState.multiselectModel;
 
-    this.serverGroupsSubscription = serverGroupsStream.merge(instancesStream).subscribe(this.onServerGroupsChanged);
+    this.serverGroupsSubscription = serverGroupsStream
+      .pipe(merge(instancesStream))
+      .subscribe(this.onServerGroupsChanged);
     this.stateChangeSubscription = ReactInjector.$uiRouter.globals.success$.subscribe(this.onStateChanged);
     this.onStateChanged();
   }

--- a/app/scripts/modules/core/src/serverGroup/details/ServerGroupDetails.tsx
+++ b/app/scripts/modules/core/src/serverGroup/details/ServerGroupDetails.tsx
@@ -1,6 +1,7 @@
 import { UISref } from '@uirouter/react';
 import React from 'react';
 import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { CloudProviderLogo } from 'core/cloudProvider/CloudProviderLogo';
 import { SETTINGS } from 'core/config/settings';
@@ -38,15 +39,24 @@ export class ServerGroupDetails extends React.Component<IServerGroupDetailsProps
   };
 
   public componentDidMount(): void {
-    this.props.detailsGetter(this.props, this.autoClose).takeUntil(this.destroy$).subscribe(this.updateServerGroup);
+    this.props
+      .detailsGetter(this.props, this.autoClose)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(this.updateServerGroup);
     this.serverGroupsRefreshUnsubscribe = this.props.app.serverGroups.onRefresh(null, () => {
-      this.props.detailsGetter(this.props, this.autoClose).takeUntil(this.destroy$).subscribe(this.updateServerGroup);
+      this.props
+        .detailsGetter(this.props, this.autoClose)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(this.updateServerGroup);
     });
   }
 
   public componentWillReceiveProps(nextProps: IServerGroupDetailsProps): void {
     if (nextProps.serverGroup !== this.props.serverGroup) {
-      this.props.detailsGetter(nextProps, this.autoClose).takeUntil(this.destroy$).subscribe(this.updateServerGroup);
+      this.props
+        .detailsGetter(nextProps, this.autoClose)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(this.updateServerGroup);
     }
   }
 

--- a/app/scripts/modules/core/src/widgets/spelText/SpelText.tsx
+++ b/app/scripts/modules/core/src/widgets/spelText/SpelText.tsx
@@ -4,7 +4,8 @@ import $ from 'jquery';
 import 'jquery-textcomplete';
 import { $q, $timeout } from 'ngimport';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { SpelAutocompleteService } from './SpelAutocompleteService';
 import { IPipeline } from '../../domain';
@@ -38,8 +39,8 @@ export class SpelText extends React.Component<ISpelTextProps, ISpelTextState> {
     super(props);
     this.state = { textcompleteConfig: [] };
     this.autocompleteService = new SpelAutocompleteService($q, new ExecutionService($q, {} as StateService, $timeout));
-    Observable.fromPromise(this.autocompleteService.addPipelineInfo(this.props.pipeline))
-      .takeUntil(this.destroy$)
+    observableFrom(this.autocompleteService.addPipelineInfo(this.props.pipeline))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((textcompleteConfig) => {
         this.setState({ textcompleteConfig: textcompleteConfig });
       });

--- a/app/scripts/modules/core/src/widgets/spelText/SpelText.tsx
+++ b/app/scripts/modules/core/src/widgets/spelText/SpelText.tsx
@@ -4,7 +4,7 @@ import $ from 'jquery';
 import 'jquery-textcomplete';
 import { $q, $timeout } from 'ngimport';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { SpelAutocompleteService } from './SpelAutocompleteService';

--- a/app/scripts/modules/dcos/serverGroup/configure/wizard/containerSettings.controller.js
+++ b/app/scripts/modules/dcos/serverGroup/configure/wizard/containerSettings.controller.js
@@ -1,7 +1,8 @@
 'use strict';
 
 import { module } from 'angular';
-import { Observable, Subject } from 'rxjs';
+import { Subject, from as observableFrom } from 'rxjs';
+import { debounceTime, switchMap } from 'rxjs/operators';
 
 export const DCOS_SERVERGROUP_CONFIGURE_WIZARD_CONTAINERSETTINGS_CONTROLLER =
   'spinnaker.dcos.serverGroup.configure.containerSettings';
@@ -25,14 +26,14 @@ module(DCOS_SERVERGROUP_CONFIGURE_WIZARD_CONTAINERSETTINGS_CONTROLLER, []).contr
       };
 
       function searchImages(q) {
-        return Observable.fromPromise(
+        return observableFrom(
           dcosServerGroupConfigurationService.configureCommand($scope.application, $scope.command, q),
         );
       }
 
       const imageSearchResultsStream = new Subject();
 
-      imageSearchResultsStream.debounceTime(250).switchMap(searchImages).subscribe();
+      imageSearchResultsStream.pipe(debounceTime(250), switchMap(searchImages)).subscribe();
 
       this.searchImages = function (q) {
         imageSearchResultsStream.next(q);

--- a/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx
+++ b/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx
@@ -2,7 +2,7 @@ import { get } from 'lodash';
 import { $q } from 'ngimport';
 import React from 'react';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject, Subscription } from 'rxjs';
+import { from as observableFrom, Subject, Subscription } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx
+++ b/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx
@@ -2,7 +2,8 @@ import { get } from 'lodash';
 import { $q } from 'ngimport';
 import React from 'react';
 import { Option } from 'react-select';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { from as observableFrom, Observable, Subject, Subscription } from 'rxjs';
+import { debounceTime, switchMap } from 'rxjs/operators';
 
 import {
   HelpField,
@@ -54,7 +55,7 @@ export class DockerTriggerTemplate extends React.Component<
 
   private handleQuery = () => {
     const trigger = this.props.command.trigger as IDockerTrigger;
-    return Observable.fromPromise(
+    return observableFrom(
       DockerImageReader.findTags({
         provider: 'dockerRegistry',
         account: trigger.account,
@@ -150,8 +151,7 @@ export class DockerTriggerTemplate extends React.Component<
     }
 
     this.subscription = this.queryStream
-      .debounceTime(250)
-      .switchMap(this.handleQuery)
+      .pipe(debounceTime(250), switchMap(this.handleQuery))
       .subscribe(this.tagLoadSuccess, this.tagLoadFailure);
 
     this.searchTags();

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
@@ -3,8 +3,8 @@
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 import * as angular from 'angular';
 import ANGULAR_UI_BOOTSTRAP from 'angular-ui-bootstrap';
-import { extend } from 'lodash';
-import { Observable, Subject } from 'rxjs';
+import { Subject, from as observableFrom } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 import {
   ArtifactTypePatterns,
@@ -38,7 +38,7 @@ angular
     '$state',
     function ($scope, $controller, $uibModalStack, $state) {
       function fetchImagesForAccount() {
-        return Observable.fromPromise(
+        return observableFrom(
           GceImageReader.findImages({
             account: $scope.command.credentials,
             provider: $scope.command.selectedProvider,
@@ -48,7 +48,7 @@ angular
       }
 
       const imageSearchResultsStream = new Subject();
-      imageSearchResultsStream.switchMap(fetchImagesForAccount).subscribe((images) => {
+      imageSearchResultsStream.pipe(switchMap(fetchImagesForAccount)).subscribe((images) => {
         $scope.command.backingData.allImages = images;
       });
 

--- a/app/scripts/modules/kubernetes/src/manifest/selector/ManifestSelector.tsx
+++ b/app/scripts/modules/kubernetes/src/manifest/selector/ManifestSelector.tsx
@@ -2,7 +2,7 @@ import { get, isEmpty } from 'lodash';
 import { $q } from 'ngimport';
 import React from 'react';
 import Select, { Creatable, Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { switchMap, takeUntil, tap } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/DeployManifestStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/DeployManifestStageConfig.tsx
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, FormikStageConfig, IAccountDetails, IStage, IStageConfigProps } from '@spinnaker/core';
 
@@ -51,8 +52,8 @@ export class DeployManifestStageConfig extends React.Component<IStageConfigProps
   }
 
   private fetchAccounts = (): void => {
-    Observable.fromPromise(AccountService.getAllAccountDetailsForProvider('kubernetes'))
-      .takeUntil(this.destroy$)
+    observableFrom(AccountService.getAllAccountDetailsForProvider('kubernetes'))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((accounts: IAccountDetails[]) => {
         this.setState({ accounts });
       });

--- a/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/DeployManifestStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/DeployManifestStageConfig.tsx
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 import React from 'react';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { AccountService, FormikStageConfig, IAccountDetails, IStage, IStageConfigProps } from '@spinnaker/core';

--- a/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/ManifestCopier.tsx
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/ManifestCopier.tsx
@@ -2,7 +2,7 @@ import { groupBy, sortBy } from 'lodash';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 import { Option } from 'react-select';
-import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {

--- a/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/ManifestCopier.tsx
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/ManifestCopier.tsx
@@ -2,7 +2,8 @@ import { groupBy, sortBy } from 'lodash';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 import { Option } from 'react-select';
-import { Observable, Subject } from 'rxjs';
+import { from as observableFrom, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   AccountTag,
@@ -139,8 +140,8 @@ export class ManifestCopier extends React.Component<IManifestCopierProps, IManif
     const {
       data: { account, region, name },
     } = this.state.selectedManifest;
-    Observable.fromPromise(ManifestReader.getManifest(account, region, name))
-      .takeUntil(this.destroy$)
+    observableFrom(ManifestReader.getManifest(account, region, name))
+      .pipe(takeUntil(this.destroy$))
       .subscribe((manifest: IManifest) => {
         this.props.onManifestSelected(JSON.parse(manifest.manifest.metadata.annotations[LAST_APPLIED_CONFIGURATION]));
       });

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "react2angular": "^3.2.1",
     "recoil": "^0.0.10",
     "reflect-metadata": "^0.1.9",
-    "rxjs": "^5.4.2",
+    "rxjs": "6",
+    "rxjs-compat": "6",
     "select2-bootstrap-css": "git://github.com/t0m/select2-bootstrap-css.git#v1.3.1",
     "source-map": "^0.4.4",
     "source-sans-pro": "^2.0.10",
@@ -236,6 +237,7 @@
     "@uirouter/core": "6.0.5",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
+    "rxjs": "6.6.7",
     "angular": "1.6.10"
   },
   "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17387,9 +17387,9 @@ rx@^4.1.0:
   integrity sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=
 
 rxjs@^5.4.2:
-  version "5.5.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.7.tgz#afb3d1642b069b2fbf203903d6501d1acb4cda27"
-  integrity sha512-Hxo2ac8gRQjwjtKgukMIwBRbq5+KAeEV5hXM4obYBOAghev41bDQWgFH4svYiU9UnQ5kNww2LgfyBdevCd2HXA==
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
+  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
   dependencies:
     symbol-observable "1.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17386,14 +17386,12 @@ rx@^4.1.0:
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
   integrity sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=
 
-rxjs@^5.4.2:
-  version "5.5.12"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
-  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
-  dependencies:
-    symbol-observable "1.0.1"
+rxjs-compat@6:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs-compat/-/rxjs-compat-6.6.7.tgz#6eb4ef75c0a58ea672854a701ccc8d49f41e69cb"
+  integrity sha512-szN4fK+TqBPOFBcBcsR0g2cmTTUF/vaFEOZNuSdfU8/pGFnNmmn2u8SystYXG1QMrjOPBc6XTKHMVfENDf6hHw==
 
-rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.3:
+rxjs@6, rxjs@6.6.7, rxjs@^5.4.2, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -18660,11 +18658,6 @@ swap-case@^2.0.1:
   integrity sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==
   dependencies:
     tslib "^2.0.3"
-
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-  integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
 symbol-observable@^1.0.3:
   version "1.1.0"


### PR DESCRIPTION
- chore: update rxjs to latest 5.5.x
- chore(rxjs): Upgrade to rxjs 6.x and add rxjs-compat (allows rxjs 5.x code to work for now)
- chore(rxjs): Run rxjs 5-to-6 migration tooling
- chore(rxjs): Fix combineLatest deprecated calls
- chore(rxjs): Manually migrate rxjs code in .js files
- chore(rxjs): Remove now unused imports of Observable from 'rxjs'
- chore(rxjs): Migrate to static combineLatest and fix typing errors
