### PR TITLE
chore: update to kayenta 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.14",
     "@fortawesome/fontawesome-free": "^5.4.1",
-    "@spinnaker/kayenta": "^1.0.2",
+    "@spinnaker/kayenta": "1.0.4",
     "@spinnaker/presentation": "^0.0.4",
     "@spinnaker/styleguide": "^1.0.22",
     "@uirouter/react-hybrid": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,10 +3178,10 @@
   dependencies:
     lodash "^4.17.20"
 
-"@spinnaker/kayenta@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@spinnaker/kayenta/-/kayenta-1.0.2.tgz#b79943ed1407620b804b0e9c4e2692cb71d310fb"
-  integrity sha512-E0GGeSRnH0/vNt0QqJ5D9Yb7h0WU8Uc2dGw5SoOVuGBe4R7bMJijcBsr4QWNBlf2olWI2EKTjHIHzQOf2X+l9Q==
+"@spinnaker/kayenta@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@spinnaker/kayenta/-/kayenta-1.0.4.tgz#fc01131a2505cf019e712c8a645844a1ffbf2d5a"
+  integrity sha512-SjY1OE21FAoEl+3TC9tOWkqs8LAmyem6zrwPITQJjlTfnxWmSu6ZbUulcCclviJT6zT2OGv+9JFceNSXGVpSHA==
   dependencies:
     "@uirouter/core" "6.0.4"
     "@uirouter/react" "1.0.2"


### PR DESCRIPTION
kayenta 1.0.4 bundles its own copy of rxjs 5.x
this is in prep for migrating deck to rxjs 6 in https://github.com/spinnaker/deck/pull/9113