### PR TITLE
feat(aws/titus): Add help text to IPv6 field

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettingsCommon.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettingsCommon.tsx
@@ -273,7 +273,8 @@ export class ServerGroupAdvancedSettingsCommon extends React.Component<IServerGr
         </div>
         <div className="form-group">
           <div className="col-md-5 sm-label-right">
-            <b>{`Associate ${asgSettings?.enableIPv6 ? 'IPv6' : 'Public IPv4'} Address`}</b>
+            <b>{`Associate ${asgSettings?.enableIPv6 ? 'IPv6 (Recommended)' : 'Public IPv4'} Address`}</b>
+            <HelpField id="serverGroup.ipv6" />
           </div>
           {asgSettings?.enableIPv6 && (
             <div className="col-md-6 checkbox">

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -386,6 +386,7 @@ const helpContents: { [key: string]: string } = {
     '<p>(Optional) If specified, only pushes to the branches that match this Java Regular Expression will be triggered. Leave empty to trigger builds for every branch.</p>',
   'pipeline.config.git.trigger.githubSecret':
     '<p>(Optional, but recommended) If specified, verifies GitHub as the sender of this trigger. See <a target="_blank" href="https://developer.github.com/webhooks/securing/">GitHub docs</a> for more information.</p>',
+  'serverGroup.ipv6': `<p>Associating an IPv6 address to nodes allows for ingress and egress communication over IPv6. Most modern software supports IPv6 and enablement is transparent. This is an incremental addition to IPv4 and will not remove the ability for connectivity over IPv4.</p>`,
   'serverGroupCapacity.useSourceCapacityTrue': `
       <p>Spinnaker will use the current capacity of the existing server group when deploying a new server group.</p>
       <p>This setting is intended to support a server group with auto-scaling enabled, where the bounds and desired capacity are controlled by an external process.</p>

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.tsx
@@ -163,7 +163,8 @@ export class ServerGroupParameters
 
         <FormikFormField
           name="containerAttributes['titusParameter.agent.assignIPv6Address']"
-          label="Associate IPv6 Address"
+          label="Associate IPv6 Address (Recommended)"
+          help={<HelpField id="serverGroup.ipv6" />}
           input={(props) => <IPv6CheckboxInput {...props} />}
         />
 


### PR DESCRIPTION
Add help field for Titus and AWS Ipv6 field in server group settings. 