### PR TITLE
Remove note for Slack bot channel installation

### DIFF
--- a/app/scripts/modules/core/src/notification/selector/types/slack/SlackNotificationType.tsx
+++ b/app/scripts/modules/core/src/notification/selector/types/slack/SlackNotificationType.tsx
@@ -5,7 +5,7 @@ import { FormikFormField, TextInput } from 'core/presentation';
 
 export class SlackNotificationType extends React.Component<INotificationTypeCustomConfig> {
   public render() {
-    const { botName, fieldName } = this.props;
+    const { fieldName } = this.props;
     return (
       <>
         <FormikFormField
@@ -16,16 +16,6 @@ export class SlackNotificationType extends React.Component<INotificationTypeCust
           )}
           required={true}
         />
-        {!!botName && (
-          <div className="row">
-            <div className="col-md-6 col-md-offset-4">
-              <strong>Note:</strong> You will need to invite the
-              <strong> {botName} </strong>
-              bot to this channel to receive Slack notifications
-              <br />
-            </div>
-          </div>
-        )}
       </>
     );
   }


### PR DESCRIPTION
## What

Users will no longer need to install the Slack bot to the destination channel since the `chat.write.public` channel will be able to write to channels that the bot is not a member of.

Therefore, I think it's better to remove this message to avoid no need invitation to the channel.

## Ref

Slacks permission: 
![Screen Shot 2021-05-07 at 22 09 53](https://user-images.githubusercontent.com/23056537/117454517-32089f80-af81-11eb-93ab-846884a89273.png)

