### PR TITLE
fix(aws): Avoid showing an incorrect 'EC2 Classic' subnet

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/AmazonInfoDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/AmazonInfoDetailsSection.tsx
@@ -78,8 +78,8 @@ export class AmazonInfoDetailsSection extends React.Component<
           <dd>
             <VpcTag vpcId={serverGroup.vpcId} />
           </dd>
-          {serverGroup.vpcId && <dt>Subnet</dt>}
-          {serverGroup.vpcId && <dd>{serverGroup.subnetType || 'None (EC2 Classic)'}</dd>}
+          {serverGroup.vpcId && serverGroup.subnetType && <dt>Subnet</dt>}
+          {serverGroup.vpcId && serverGroup.subnetType && <dd>{serverGroup.subnetType}</dd>}
           {serverGroup.asg && <dt>Zones</dt>}
           {serverGroup.asg && (
             <dd>


### PR DESCRIPTION
This PR avoids rendering 'EC2 Classic' when the
server group is actually in a VPC but the subnet
is not tagged correctly.
