### PR TITLE
fix(core): fix state update for pipeline tags

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/MetadataPageContent.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/MetadataPageContent.tsx
@@ -122,7 +122,7 @@ export function MetadataPageContent(props: IMetadataPageContentProps) {
         name="tags"
         label="Tags"
         value={pipeline.tags}
-        onChange={(e) => updatePipelineConfig({ description: e.target.value })}
+        onChange={(e) => updatePipelineConfig({ tags: e.target.value })}
         help={<HelpField id="pipeline.config.tags" />}
         input={(inputProps) => <TagsInput {...inputProps} />}
       />

--- a/app/scripts/modules/core/src/pipeline/config/triggers/MetadataPageContent.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/MetadataPageContent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { IPipeline, IPipelineTag } from 'core/domain';
 import { HelpField } from 'core/help';
+import { IOverridableProps, overridableComponent } from 'core/overrideRegistry';
 import {
   createFakeReactSyntheticEvent,
   FormField,
@@ -98,7 +99,7 @@ function TagsInput({ name, onChange, value, validation }: ITagsInput) {
   );
 }
 
-export function MetadataPageContent(props: IMetadataPageContentProps) {
+export function MetadataPage(props: IMetadataPageContentProps) {
   const { pipeline, updatePipelineConfig } = props;
 
   return (
@@ -129,3 +130,8 @@ export function MetadataPageContent(props: IMetadataPageContentProps) {
     </>
   );
 }
+
+export const MetadataPageContent = overridableComponent<
+  IMetadataPageContentProps & IOverridableProps,
+  typeof MetadataPage
+>(MetadataPage, 'metadataPageContent');


### PR DESCRIPTION
Current behavior in 1.26 breaks the description field for users that attempt to use the tags feature introduced in this release