### PR TITLE
fix(core): classnames package cleanup

### DIFF
--- a/app/scripts/modules/core/src/utils/classnames.d.ts
+++ b/app/scripts/modules/core/src/utils/classnames.d.ts
@@ -1,1 +1,0 @@
-declare module 'classnames';

--- a/app/scripts/modules/core/src/utils/index.ts
+++ b/app/scripts/modules/core/src/utils/index.ts
@@ -1,4 +1,3 @@
-///<reference path="./classnames.d.ts" />
 ///<reference path="./angular-messages.d.ts" />
 ///<reference path="./angular-sanitize.d.ts" />
 ///<reference path="./angular-spinner.d.ts" />

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cachefactory": "^3.0.0",
     "chart.js": "^3.0.0-rc.5",
     "chartjs-adapter-luxon": "^1.0.0-beta.2",
-    "classname": "^0.0.0",
+    "classnames": "^2.2.5",
     "clipboard": "^1.5.12",
     "commonmark": "^0.28.1",
     "core-js": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7093,11 +7093,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classname@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/classname/-/classname-0.0.0.tgz#43d171b484e354c7a293a5b78004df6852db20d6"
-  integrity sha1-Q9FxtITjVMeik6W3gATfaFLbINY=
-
 classnames@^2.2.0, classnames@^2.2.3, classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"


### PR DESCRIPTION
- Removed an old `classname` package that no one used
- Removed the empty `classnames` types file
- Added `classnames` to deps