### PR TITLE
feat(build): Add base tsconfig for independent packages

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    // project options
+    "allowJs": true,
+    "declaration": true,
+    "jsx": "react",
+    "module": "esnext",
+    "sourceMap": true,
+    "target": "es6",
+
+    // strict checks
+    "noImplicitAny": true,
+    "noImplicitThis": false, // should really get to a place where we can turn this on
+    "strictNullChecks": false, // should really get to a place where we can turn this on
+
+    // module resolution
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+
+    // linter
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    // experimental
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+
+    // advanced
+    "noEmitHelpers": false,
+    "pretty": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
In order to convert deck to a mono-repo, we need to make each spinnaker package independently specify their dependencies and make them self-sufficient. The foundational build changes are completed now and in this PR, a base `tsconfig` file is created which will be used by these packages.

NOTE: This PR is pulling just the `tsconfig.base.json` file from https://github.com/spinnaker/deck/pull/9185