### PR TITLE
fix(dependency): Fix @types/react version

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -348,6 +348,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
 
       return (
         <div className="col-md-9">
+          {/* @ts-ignore */}
           <TetheredSelect
             {...commonReactSelectProps}
             menuRenderer={this.buildImageMenu}
@@ -369,6 +370,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
       // User can pick an image from the preloaded 'packageImages' using the typeahead
       return (
         <div className="col-md-9">
+          {/* @ts-ignore */}
           <TetheredSelect
             {...commonReactSelectProps}
             menuRenderer={this.buildImageMenu}
@@ -389,6 +391,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
       // Show a disabled react-select while waiting for 'packageImages' to load
       return (
         <div className="col-md-9">
+          {/* @ts-ignore */}
           <TetheredSelect
             {...commonReactSelectProps}
             isLoading={isLoadingPackageImages}

--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/LaunchTemplateDetailsSection.spec.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/LaunchTemplateDetailsSection.spec.tsx
@@ -176,10 +176,10 @@ describe('Launch template details', () => {
     const multipleInstanceTypesTableRows = multipleInstanceTypes.find('td');
 
     expect(multipleInstanceTypesTableRows.length).toEqual(4);
-    expect(multipleInstanceTypesTableRows.at(0).equals('some.type.medium'));
-    expect(multipleInstanceTypesTableRows.at(1).equals('2'));
-    expect(multipleInstanceTypesTableRows.at(2).equals('some.type.large'));
-    expect(multipleInstanceTypesTableRows.at(3).equals('4'));
+    expect(multipleInstanceTypesTableRows.at(0).text()).toEqual('some.type.medium');
+    expect(multipleInstanceTypesTableRows.at(1).text()).toEqual('2');
+    expect(multipleInstanceTypesTableRows.at(2).text()).toEqual('some.type.large');
+    expect(multipleInstanceTypesTableRows.at(3).text()).toEqual('4');
   });
 
   it('should conditionally render image information', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,12 +4548,7 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.0.40"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.40.tgz#caabc2296886f40b67f6fc80f0f3464476461df9"
-  integrity sha512-OZi2OPNI1DGwnC3Fgbr1CcYfOD6V0pbv+aehXdvuFE+L+sipWjividsasuqFW/G0CZrZ81Ao+9IzjvkRDWCE9Q==
-
-"@types/react@~16.8.0":
+"@types/react@*", "@types/react@~16.8.0":
   version "16.8.13"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.13.tgz#a82b15aad9ab91c40edca0d6889b7745ae24f053"
   integrity sha512-otJ4ntMuHGrvm67CdDJMAls4WqotmAmW0g3HmWi9LCjSWXrxoXY/nHXrtmMfvPEEmGFNm6NdgMsJmnfH820Qaw==


### PR DESCRIPTION
`@types/react` was set to `16.8.0`, but many of the dependencies were using `16.0.40` due to how yarn set up the dependencies in the first run. So fixing that to point to `16.8.0` and also fixing a few typescript issues that cropped up.
