### PR TITLE
fix(build): Fix condition to handle html requires

### DIFF
--- a/packages/scripts/helpers/rollup-plugin-angularjs-template-loader.js
+++ b/packages/scripts/helpers/rollup-plugin-angularjs-template-loader.js
@@ -15,7 +15,7 @@ module.exports = function angularJsTemplateLoader(options = {}) {
       const templateRegex = /require\(['"]([^'"]+\.html)['"]\)/g;
 
       // look for things like require('./template.html')
-      if (!code.includes("require('./") || code.includes('node_modules')) {
+      if (!code.includes("require('") || code.includes('node_modules')) {
         return;
       }
 


### PR DESCRIPTION
The existing pattern missed cases like `require('../foo/bar.html')`