### PR TITLE
fix(build): Fix package publish github actions

### DIFF
--- a/app/scripts/modules/github_actions_publish.sh
+++ b/app/scripts/modules/github_actions_publish.sh
@@ -77,6 +77,7 @@ for DIR in ${BUILDORDER} ; do
   pushd "${DIR}" > /dev/null || exit 5
   if [ "${DIR}" == "${MODULE}" ] ; then
     echo "Deck package publisher ---> Publishing ${MODULE}..."
+    yarn
     npm publish
   else
     echo "Deck package publisher ---> Building (but not publishing) upstream dependency '${DIR}'..."


### PR DESCRIPTION
Since the packages are independent now, they need to install their dependencies before running `npm publish`.