### PR TITLE
feat(md): pinned data tooltip info

### DIFF
--- a/app/scripts/modules/core/src/managed/AbsoluteTimestamp.tsx
+++ b/app/scripts/modules/core/src/managed/AbsoluteTimestamp.tsx
@@ -3,6 +3,7 @@ import React, { memo } from 'react';
 
 import { SETTINGS } from '../config';
 import { CopyToClipboard } from '../utils';
+import { ABSOLUTE_TIME_FORMAT } from './utils/defaults';
 
 export interface IAbsoluteTimestampProps {
   timestamp: DateTime;
@@ -15,7 +16,7 @@ export const AbsoluteTimestamp = memo(
   ({ timestamp: timestampInOriginalZone, clickToCopy }: IAbsoluteTimestampProps) => {
     const timestamp = TIMEZONE ? timestampInOriginalZone.setZone(TIMEZONE) : timestampInOriginalZone;
 
-    const fullTimestamp = timestamp.toFormat('yyyy-MM-dd HH:mm:ss ZZZZ');
+    const fullTimestamp = timestamp.toFormat(ABSOLUTE_TIME_FORMAT);
     const formattedTimestamp = timestamp.toFormat('MMM d, y HH:mm');
     const timestampElement = <span>{formattedTimestamp}</span>;
 

--- a/app/scripts/modules/core/src/managed/RelativeTimestamp.tsx
+++ b/app/scripts/modules/core/src/managed/RelativeTimestamp.tsx
@@ -1,9 +1,10 @@
-import { DateTime, Duration } from 'luxon';
+import { DateTime } from 'luxon';
 import React, { memo, useEffect, useState } from 'react';
 
 import { SETTINGS } from '../config';
 import { Tooltip, useInterval } from '../presentation';
 import { CopyToClipboard, timeDiffToString } from '../utils';
+import { ABSOLUTE_TIME_FORMAT } from './utils/defaults';
 
 export interface IRelativeTimestampProps {
   timestamp: DateTime | string;
@@ -30,7 +31,8 @@ export const DurationRender: React.FC<{ startedAt: string; completedAt?: string 
   return <>{timeDiffToString(startAtDateTime, endTime)}</>;
 };
 
-const formatTimestamp = (timestamp: DateTime, distance: Duration, withSuffix: boolean) => {
+export const formatToRelativeTimestamp = (timestamp: DateTime, withSuffix: boolean) => {
+  const distance = getDistanceFromNow(timestamp);
   const suffix = withSuffix ? ' ago' : '';
   if (distance.years || distance.months) {
     let currentTime = DateTime.local();
@@ -69,12 +71,10 @@ export const RelativeTimestamp = memo(
     const dateTimeTimestamp =
       typeof originalTimestamp === 'string' ? DateTime.fromISO(originalTimestamp) : originalTimestamp;
     const timestamp = TIMEZONE ? dateTimeTimestamp.setZone(TIMEZONE) : dateTimeTimestamp;
-    const [formattedTimestamp, setFormattedTimestamp] = useState(
-      formatTimestamp(timestamp, getDistanceFromNow(timestamp), withSuffix),
-    );
+    const [formattedTimestamp, setFormattedTimestamp] = useState(formatToRelativeTimestamp(timestamp, withSuffix));
 
     const updateTimestamp = () => {
-      setFormattedTimestamp(formatTimestamp(timestamp, getDistanceFromNow(timestamp), withSuffix));
+      setFormattedTimestamp(formatToRelativeTimestamp(timestamp, withSuffix));
     };
 
     useInterval(updateTimestamp, 1000);
@@ -83,7 +83,7 @@ export const RelativeTimestamp = memo(
       return null;
     }
 
-    const absoluteTimestamp = timestamp.toFormat('yyyy-MM-dd HH:mm:ss ZZZZ');
+    const absoluteTimestamp = timestamp.toFormat(ABSOLUTE_TIME_FORMAT);
     const relativeTimestamp = (
       <span
         className={removeStyles ? undefined : 'text-regular text-italic'}

--- a/app/scripts/modules/core/src/managed/environmentBaseElements/EnvironmentItem.tsx
+++ b/app/scripts/modules/core/src/managed/environmentBaseElements/EnvironmentItem.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { IIconProps } from '@spinnaker/presentation';
 import { IconTooltip } from 'core/presentation';
 
-import { TOOLTIP_DELAY } from '../utils/defaults';
+import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
 
 interface IEnvironmentItemProps {
   title: string | React.ReactElement;
@@ -30,7 +30,7 @@ export const EnvironmentItem: React.FC<IEnvironmentItemProps> = ({
           name={iconName}
           color="primary-g1"
           size={size === 'regular' ? '20px' : '18px'}
-          delayShow={TOOLTIP_DELAY}
+          delayShow={TOOLTIP_DELAY_SHOW}
         />
       </div>
       <div className="row-details">

--- a/app/scripts/modules/core/src/managed/overview/artifact/Artifact.less
+++ b/app/scripts/modules/core/src/managed/overview/artifact/Artifact.less
@@ -92,26 +92,6 @@
     }
   }
 
-  .version-badge {
-    border-radius: 3px;
-    padding: 0 var(--s-spacing);
-    display: flex;
-    flex-direction: row;
-    & > svg {
-      margin-right: 4px;
-    }
-  }
-
-  .version-deploying {
-    background-color: var(--color-accent);
-    color: var(--color-white);
-  }
-
-  .version-pinned {
-    background-color: var(--color-warning);
-    color: var(--color-black);
-  }
-
   .another-version-pinned-warning {
     margin-top: var(--s-spacing);
     font-weight: 600;

--- a/app/scripts/modules/core/src/managed/overview/artifact/Artifact.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/Artifact.tsx
@@ -8,6 +8,7 @@ import { PendingVersions } from './PendingVersion';
 import { EnvironmentItem } from '../../environmentBaseElements/EnvironmentItem';
 import { QueryArtifact, QueryArtifactVersion } from '../types';
 import { tooltipShowHideProps } from '../../utils/defaults';
+import { toPinnedMetadata } from '../../versionMetadata/MetadataComponents';
 
 import './Artifact.less';
 
@@ -81,7 +82,7 @@ export const Artifact = ({ artifact }: IArtifactProps) => {
           environment={artifact.environment}
           reference={artifact.reference}
           numNewerVersions={newerVersions?.length}
-          isPinned={pinnedVersion?.version === currentVersion.version}
+          pinned={pinnedVersion?.version === currentVersion.version ? toPinnedMetadata(pinnedVersion) : undefined}
         />
       ) : (
         <div>No version is deployed</div>

--- a/app/scripts/modules/core/src/managed/overview/artifact/Artifact.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/Artifact.tsx
@@ -7,7 +7,7 @@ import { CurrentVersion } from './CurrentVersion';
 import { PendingVersions } from './PendingVersion';
 import { EnvironmentItem } from '../../environmentBaseElements/EnvironmentItem';
 import { QueryArtifact, QueryArtifactVersion } from '../types';
-import { TOOLTIP_DELAY } from '../../utils/defaults';
+import { tooltipShowHideProps } from '../../utils/defaults';
 
 import './Artifact.less';
 
@@ -44,7 +44,7 @@ export const PinnedVersion = ({ version }: { version: NonNullable<QueryArtifact[
       <i className="fas fa-exclamation-triangle" /> Version{' '}
       {commitMessage ? (
         <HoverablePopover
-          delayHide={TOOLTIP_DELAY}
+          {...tooltipShowHideProps}
           placement="top"
           Component={() => <Markdown className="git-commit-tooltip" message={commitMessage} />}
         >

--- a/app/scripts/modules/core/src/managed/overview/artifact/ArtifactVersionTasks.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/ArtifactVersionTasks.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from 'core/presentation';
 import { DurationRender, RelativeTimestamp } from '../../RelativeTimestamp';
 import { VersionOperationIcon } from './VersionOperation';
 import { QueryArtifactVersionTask, QueryVerificationStatus } from '../types';
-import { TOOLTIP_DELAY } from '../../utils/defaults';
+import { TOOLTIP_DELAY_SHOW } from '../../utils/defaults';
 
 import './ArtifactVersionTasks.less';
 
@@ -39,7 +39,7 @@ const ArtifactVersionTask = ({ type, task }: IArtifactVersionTaskProps) => {
         )}
         {startedAt && (
           <span className="task-metadata task-runtime">
-            <Tooltip value="Runtime duration" delayShow={TOOLTIP_DELAY}>
+            <Tooltip value="Runtime duration" delayShow={TOOLTIP_DELAY_SHOW}>
               <i className="far fa-clock" />
             </Tooltip>
             <DurationRender {...{ startedAt, completedAt }} />

--- a/app/scripts/modules/core/src/managed/overview/artifact/CurrentVersion.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/CurrentVersion.tsx
@@ -5,7 +5,7 @@ import { Constraints } from './Constraints';
 import { GitLink } from './GitLink';
 import { QueryArtifactVersion } from '../types';
 import { useCreateVersionActions } from './utils';
-import { PinnedMetadata } from '../../versionMetadata/MetadataComponents';
+import { VersionMessageData } from '../../versionMetadata/MetadataComponents';
 import { getBaseMetadata, VersionMetadata } from '../../versionMetadata/VersionMetadata';
 
 interface ICurrentVersionProps {
@@ -13,7 +13,7 @@ interface ICurrentVersionProps {
   environment: string;
   reference: string;
   numNewerVersions?: number;
-  pinned?: PinnedMetadata;
+  pinned?: VersionMessageData;
 }
 
 export const CurrentVersion = ({ data, environment, reference, numNewerVersions, pinned }: ICurrentVersionProps) => {

--- a/app/scripts/modules/core/src/managed/overview/artifact/CurrentVersion.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/CurrentVersion.tsx
@@ -5,6 +5,7 @@ import { Constraints } from './Constraints';
 import { GitLink } from './GitLink';
 import { QueryArtifactVersion } from '../types';
 import { useCreateVersionActions } from './utils';
+import { PinnedMetadata } from '../../versionMetadata/MetadataComponents';
 import { getBaseMetadata, VersionMetadata } from '../../versionMetadata/VersionMetadata';
 
 interface ICurrentVersionProps {
@@ -12,10 +13,10 @@ interface ICurrentVersionProps {
   environment: string;
   reference: string;
   numNewerVersions?: number;
-  isPinned: boolean;
+  pinned?: PinnedMetadata;
 }
 
-export const CurrentVersion = ({ data, environment, reference, numNewerVersions, isPinned }: ICurrentVersionProps) => {
+export const CurrentVersion = ({ data, environment, reference, numNewerVersions, pinned }: ICurrentVersionProps) => {
   const { gitMetadata, constraints, verifications, postDeploy } = data;
   const actions = useCreateVersionActions({
     environment,
@@ -23,7 +24,7 @@ export const CurrentVersion = ({ data, environment, reference, numNewerVersions,
     version: data.version,
     buildNumber: data.buildNumber,
     commitMessage: gitMetadata?.commitInfo?.message,
-    isPinned,
+    isPinned: Boolean(pinned),
     compareLinks: {
       previous: gitMetadata?.comparisonLinks?.toPreviousVersion,
     },
@@ -31,12 +32,7 @@ export const CurrentVersion = ({ data, environment, reference, numNewerVersions,
   return (
     <div className="artifact-current-version">
       {gitMetadata ? <GitLink gitMetadata={gitMetadata} /> : <div>Build {data?.version}</div>}
-      <VersionMetadata
-        {...getBaseMetadata(data)}
-        buildsBehind={numNewerVersions}
-        actions={actions}
-        isPinned={isPinned}
-      />
+      <VersionMetadata {...getBaseMetadata(data)} buildsBehind={numNewerVersions} actions={actions} pinned={pinned} />
       {constraints && (
         <Constraints constraints={constraints} versionProps={{ environment, reference, version: data.version }} />
       )}

--- a/app/scripts/modules/core/src/managed/overview/artifact/CurrentVersion.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/CurrentVersion.tsx
@@ -4,8 +4,8 @@ import { ArtifactVersionTasks } from './ArtifactVersionTasks';
 import { Constraints } from './Constraints';
 import { GitLink } from './GitLink';
 import { QueryArtifactVersion } from '../types';
-import { getLifecycleEventDuration, getLifecycleEventLink, useCreateVersionActions } from './utils';
-import { VersionMetadata } from '../../versionMetadata/VersionMetadata';
+import { useCreateVersionActions } from './utils';
+import { getBaseMetadata, VersionMetadata } from '../../versionMetadata/VersionMetadata';
 
 interface ICurrentVersionProps {
   data: QueryArtifactVersion;
@@ -32,11 +32,7 @@ export const CurrentVersion = ({ data, environment, reference, numNewerVersions,
     <div className="artifact-current-version">
       {gitMetadata ? <GitLink gitMetadata={gitMetadata} /> : <div>Build {data?.version}</div>}
       <VersionMetadata
-        buildNumber={data.buildNumber}
-        buildLink={getLifecycleEventLink(data, 'BUILD')}
-        author={gitMetadata?.author}
-        deployedAt={data.deployedAt}
-        buildDuration={getLifecycleEventDuration(data, 'BUILD')}
+        {...getBaseMetadata(data)}
         buildsBehind={numNewerVersions}
         actions={actions}
         isPinned={isPinned}

--- a/app/scripts/modules/core/src/managed/overview/artifact/GitLink.less
+++ b/app/scripts/modules/core/src/managed/overview/artifact/GitLink.less
@@ -5,7 +5,6 @@
 
   .git-link-inner {
     display: flex;
-    text-decoration: none;
     flex-direction: row;
     align-self: flex-start;
     max-width: 100%;

--- a/app/scripts/modules/core/src/managed/overview/artifact/GitLink.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/GitLink.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { HoverablePopover, Markdown } from 'core/presentation';
 
 import { QueryGitMetadata } from '../types';
-import { TOOLTIP_DELAY } from '../../utils/defaults';
+import { tooltipShowHideProps } from '../../utils/defaults';
 
 import './GitLink.less';
 
@@ -19,9 +19,8 @@ export const GitLink = ({ gitMetadata: { commit, commitInfo, pullRequest }, asLi
   return (
     <div className="GitLink">
       <HoverablePopover
-        wrapperClassName="git-link-inner"
-        delayShow={TOOLTIP_DELAY}
-        delayHide={0}
+        {...tooltipShowHideProps}
+        wrapperClassName="git-link-inner no-underline"
         placement="top"
         Component={() => (
           <div className="git-commit-tooltip">

--- a/app/scripts/modules/core/src/managed/overview/artifact/PendingVersion.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/PendingVersion.tsx
@@ -8,7 +8,7 @@ import { RelativeTimestamp } from '../../RelativeTimestamp';
 import { QueryArtifact, QueryArtifactVersion } from '../types';
 import { useCreateVersionActions } from './utils';
 import { TOOLTIP_DELAY_SHOW } from '../../utils/defaults';
-import { PinnedMetadata, toPinnedMetadata } from '../../versionMetadata/MetadataComponents';
+import { toPinnedMetadata, VersionMessageData } from '../../versionMetadata/MetadataComponents';
 import { getBaseMetadata, VersionMetadata } from '../../versionMetadata/VersionMetadata';
 
 export interface IPendingVersionsProps {
@@ -63,7 +63,7 @@ interface IPendingVersionProps {
   data: QueryArtifactVersion;
   reference: string;
   environment: string;
-  pinned?: PinnedMetadata;
+  pinned?: VersionMessageData;
   index: number;
 }
 

--- a/app/scripts/modules/core/src/managed/overview/artifact/PendingVersion.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/PendingVersion.tsx
@@ -8,6 +8,7 @@ import { RelativeTimestamp } from '../../RelativeTimestamp';
 import { QueryArtifact, QueryArtifactVersion } from '../types';
 import { useCreateVersionActions } from './utils';
 import { TOOLTIP_DELAY_SHOW } from '../../utils/defaults';
+import { PinnedMetadata, toPinnedMetadata } from '../../versionMetadata/MetadataComponents';
 import { getBaseMetadata, VersionMetadata } from '../../versionMetadata/VersionMetadata';
 
 export interface IPendingVersionsProps {
@@ -39,7 +40,7 @@ export const PendingVersions = ({ artifact, pendingVersions }: IPendingVersionsP
             environment={artifact.environment}
             reference={artifact.reference}
             data={version}
-            isPinned={pinnedVersion?.version === version.version}
+            pinned={pinnedVersion?.version === version.version ? toPinnedMetadata(pinnedVersion) : undefined}
           />
         ))}
         {numVersions > NUM_VERSIONS_WHEN_COLLAPSED ? (
@@ -62,11 +63,11 @@ interface IPendingVersionProps {
   data: QueryArtifactVersion;
   reference: string;
   environment: string;
-  isPinned: boolean;
+  pinned?: PinnedMetadata;
   index: number;
 }
 
-const PendingVersion = ({ data, reference, environment, isPinned, index }: IPendingVersionProps) => {
+const PendingVersion = ({ data, reference, environment, pinned, index }: IPendingVersionProps) => {
   const { buildNumber, version, gitMetadata, constraints } = data;
   const actions = useCreateVersionActions({
     environment,
@@ -74,7 +75,7 @@ const PendingVersion = ({ data, reference, environment, isPinned, index }: IPend
     buildNumber,
     version,
     commitMessage: gitMetadata?.commitInfo?.message,
-    isPinned,
+    isPinned: Boolean(pinned),
     compareLinks: {
       current: gitMetadata?.comparisonLinks?.toCurrentVersion,
     },
@@ -90,7 +91,7 @@ const PendingVersion = ({ data, reference, environment, isPinned, index }: IPend
       <div className="artifact-pending-version-commit">
         {gitMetadata ? <GitLink gitMetadata={gitMetadata} /> : `Build ${buildNumber}`}
       </div>
-      <VersionMetadata {...getBaseMetadata(data)} isPinned={isPinned} actions={actions} />
+      <VersionMetadata {...getBaseMetadata(data)} pinned={pinned} actions={actions} />
       {constraints && !isEmpty(constraints) && (
         <Constraints
           key={index} // This is needed on refresh if a new version was added

--- a/app/scripts/modules/core/src/managed/overview/artifact/PendingVersion.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/PendingVersion.tsx
@@ -6,9 +6,9 @@ import { Constraints } from './Constraints';
 import { GitLink } from './GitLink';
 import { RelativeTimestamp } from '../../RelativeTimestamp';
 import { QueryArtifact, QueryArtifactVersion } from '../types';
-import { getLifecycleEventDuration, getLifecycleEventLink, useCreateVersionActions } from './utils';
-import { TOOLTIP_DELAY } from '../../utils/defaults';
-import { VersionMetadata } from '../../versionMetadata/VersionMetadata';
+import { useCreateVersionActions } from './utils';
+import { TOOLTIP_DELAY_SHOW } from '../../utils/defaults';
+import { getBaseMetadata, VersionMetadata } from '../../versionMetadata/VersionMetadata';
 
 export interface IPendingVersionsProps {
   artifact: QueryArtifact;
@@ -67,7 +67,7 @@ interface IPendingVersionProps {
 }
 
 const PendingVersion = ({ data, reference, environment, isPinned, index }: IPendingVersionProps) => {
-  const { buildNumber, version, gitMetadata, constraints, status } = data;
+  const { buildNumber, version, gitMetadata, constraints } = data;
   const actions = useCreateVersionActions({
     environment,
     reference,
@@ -84,21 +84,13 @@ const PendingVersion = ({ data, reference, environment, isPinned, index }: IPend
     <div className="artifact-pending-version">
       {data.createdAt && (
         <div className="artifact-pending-version-timestamp">
-          <RelativeTimestamp timestamp={DateTime.fromISO(data.createdAt)} delayShow={TOOLTIP_DELAY} />
+          <RelativeTimestamp timestamp={DateTime.fromISO(data.createdAt)} delayShow={TOOLTIP_DELAY_SHOW} />
         </div>
       )}
       <div className="artifact-pending-version-commit">
         {gitMetadata ? <GitLink gitMetadata={gitMetadata} /> : `Build ${buildNumber}`}
       </div>
-      <VersionMetadata
-        buildNumber={buildNumber}
-        buildLink={getLifecycleEventLink(data, 'BUILD')}
-        author={gitMetadata?.author}
-        buildDuration={getLifecycleEventDuration(data, 'BUILD')}
-        isDeploying={status === 'DEPLOYING'}
-        isPinned={isPinned}
-        actions={actions}
-      />
+      <VersionMetadata {...getBaseMetadata(data)} isPinned={isPinned} actions={actions} />
       {constraints && !isEmpty(constraints) && (
         <Constraints
           key={index} // This is needed on refresh if a new version was added

--- a/app/scripts/modules/core/src/managed/overview/artifact/utils.ts
+++ b/app/scripts/modules/core/src/managed/overview/artifact/utils.ts
@@ -37,11 +37,18 @@ export const getConstraintsStatusSummary = (constraints: QueryConstraint[]) => {
   return { text: summary, status: finalStatus };
 };
 
+export const getLifecycleEventByType = (
+  version: QueryArtifactVersion | undefined,
+  type: QueryLifecycleStep['type'],
+): QueryLifecycleStep | undefined => {
+  return version?.lifecycleSteps?.find((step) => step.type === type);
+};
+
 export const getLifecycleEventDuration = (
   version: QueryArtifactVersion | undefined,
   type: QueryLifecycleStep['type'],
 ) => {
-  const event = version?.lifecycleSteps?.find((step) => step.type === type);
+  const event = getLifecycleEventByType(version, type);
   if (!event) return undefined;
   const { startedAt, completedAt } = event;
   if (startedAt && completedAt) {
@@ -52,6 +59,27 @@ export const getLifecycleEventDuration = (
 
 export const getLifecycleEventLink = (version: QueryArtifactVersion | undefined, type: QueryLifecycleStep['type']) => {
   return version?.lifecycleSteps?.find((step) => step.type === type)?.link;
+};
+
+export interface LifecycleEventSummary {
+  startedAt?: DateTime;
+  duration?: string;
+  link?: string;
+  isRunning: boolean;
+}
+
+export const getLifecycleEventSummary = (
+  version: QueryArtifactVersion | undefined,
+  type: QueryLifecycleStep['type'],
+): LifecycleEventSummary | undefined => {
+  const event = getLifecycleEventByType(version, type);
+  if (!event) return undefined;
+  return {
+    startedAt: event.startedAt ? DateTime.fromISO(event.startedAt) : undefined,
+    duration: getLifecycleEventDuration(version, type),
+    isRunning: event.status === 'RUNNING',
+    link: event.link,
+  };
 };
 
 interface ICreateVersionActionsProps {

--- a/app/scripts/modules/core/src/managed/overview/artifact/utils.ts
+++ b/app/scripts/modules/core/src/managed/overview/artifact/utils.ts
@@ -58,7 +58,11 @@ export const getLifecycleEventDuration = (
 };
 
 export const getLifecycleEventLink = (version: QueryArtifactVersion | undefined, type: QueryLifecycleStep['type']) => {
-  return version?.lifecycleSteps?.find((step) => step.type === type)?.link;
+  return getLifecycleEventByType(version, type)?.link;
+};
+
+export const isBaking = (version: QueryArtifactVersion) => {
+  return getLifecycleEventByType(version, 'BAKE')?.status === 'RUNNING';
 };
 
 export interface LifecycleEventSummary {

--- a/app/scripts/modules/core/src/managed/overview/baseStyles.less
+++ b/app/scripts/modules/core/src/managed/overview/baseStyles.less
@@ -62,3 +62,7 @@ button.md-btn-danger:hover {
   color: var(--color-danger);
   border: 1px solid var(--color-danger);
 }
+
+.no-underline {
+  text-decoration: none;
+}

--- a/app/scripts/modules/core/src/managed/utils/defaults.ts
+++ b/app/scripts/modules/core/src/managed/utils/defaults.ts
@@ -1,6 +1,12 @@
+import { IHoverablePopoverProps } from 'core/presentation';
 import { ISpinnerProps } from 'core/widgets';
 
-export const TOOLTIP_DELAY = 300;
+export const TOOLTIP_DELAY_SHOW = 400;
+export const TOOLTIP_DELAY_HIDE = 100;
+export const tooltipShowHideProps: Partial<IHoverablePopoverProps> = {
+  delayShow: TOOLTIP_DELAY_SHOW,
+  delayHide: TOOLTIP_DELAY_HIDE,
+};
 export const MODAL_MAX_WIDTH = 750;
 export const spinnerProps: ISpinnerProps = {
   size: 'medium',

--- a/app/scripts/modules/core/src/managed/utils/defaults.ts
+++ b/app/scripts/modules/core/src/managed/utils/defaults.ts
@@ -12,3 +12,5 @@ export const spinnerProps: ISpinnerProps = {
   size: 'medium',
   fullWidth: true,
 };
+
+export const ABSOLUTE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss ZZZZ';

--- a/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
+++ b/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
@@ -4,11 +4,11 @@ import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 import { Icon } from '@spinnaker/presentation';
-import { HoverablePopover, IHoverablePopoverProps, Tooltip } from 'core/presentation';
+import { Tooltip } from 'core/presentation';
 
 import { RelativeTimestamp } from '../RelativeTimestamp';
 import { LifecycleEventSummary } from '../overview/artifact/utils';
-import { TOOLTIP_DELAY_SHOW, tooltipShowHideProps } from '../utils/defaults';
+import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
 
 import './VersionMetadata.less';
 
@@ -106,7 +106,7 @@ const badgeTypeToDetails = {
 
 interface IMetadataBadgeProps {
   type: keyof typeof badgeTypeToDetails;
-  tooltip?: IHoverablePopoverProps['Component'];
+  tooltip?: string;
   link?: string;
 }
 
@@ -123,9 +123,9 @@ export const MetadataBadge = ({ type, link, tooltip }: IMetadataBadgeProps) => {
   if (tooltip) {
     return (
       <MetadataElement>
-        <HoverablePopover {...tooltipShowHideProps} Component={tooltip} wrapperClassName="no-underline">
+        <Tooltip value={tooltip} delayShow={TOOLTIP_DELAY_SHOW}>
           {baseBadge}
-        </HoverablePopover>
+        </Tooltip>
       </MetadataElement>
     );
   } else {

--- a/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
+++ b/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
@@ -4,11 +4,11 @@ import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 import { Icon } from '@spinnaker/presentation';
-import { Tooltip } from 'core/presentation';
+import { HoverablePopover, IHoverablePopoverProps, Tooltip } from 'core/presentation';
 
 import { RelativeTimestamp } from '../RelativeTimestamp';
 import { LifecycleEventSummary } from '../overview/artifact/utils';
-import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
+import { TOOLTIP_DELAY_SHOW, tooltipShowHideProps } from '../utils/defaults';
 
 import './VersionMetadata.less';
 
@@ -23,6 +23,16 @@ export interface VersionAction {
   disabled?: boolean;
 }
 
+export interface PinnedMetadata {
+  by?: string;
+  at?: string;
+}
+
+export const toPinnedMetadata = (version: { pinnedAt?: string; pinnedBy?: string }): PinnedMetadata => ({
+  by: version.pinnedBy,
+  at: version.pinnedAt,
+});
+
 export interface IVersionMetadataProps {
   buildNumber?: string;
   buildLink?: string;
@@ -33,7 +43,7 @@ export interface IVersionMetadataProps {
   buildsBehind?: number;
   isDeploying?: boolean;
   baking?: LifecycleEventSummary;
-  isPinned?: boolean;
+  pinned?: PinnedMetadata;
   actions?: VersionAction[];
 }
 
@@ -96,7 +106,7 @@ const badgeTypeToDetails = {
 
 interface IMetadataBadgeProps {
   type: keyof typeof badgeTypeToDetails;
-  tooltip?: string;
+  tooltip?: IHoverablePopoverProps['Component'];
   link?: string;
 }
 
@@ -113,9 +123,9 @@ export const MetadataBadge = ({ type, link, tooltip }: IMetadataBadgeProps) => {
   if (tooltip) {
     return (
       <MetadataElement>
-        <Tooltip value={tooltip} delayShow={TOOLTIP_DELAY_SHOW}>
+        <HoverablePopover {...tooltipShowHideProps} Component={tooltip} wrapperClassName="no-underline">
           {baseBadge}
-        </Tooltip>
+        </HoverablePopover>
       </MetadataElement>
     );
   } else {

--- a/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
+++ b/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
@@ -7,7 +7,8 @@ import { Icon } from '@spinnaker/presentation';
 import { Tooltip } from 'core/presentation';
 
 import { RelativeTimestamp } from '../RelativeTimestamp';
-import { TOOLTIP_DELAY } from '../utils/defaults';
+import { LifecycleEventSummary } from '../overview/artifact/utils';
+import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
 
 import './VersionMetadata.less';
 
@@ -31,6 +32,7 @@ export interface IVersionMetadataProps {
   buildDuration?: string;
   buildsBehind?: number;
   isDeploying?: boolean;
+  baking?: LifecycleEventSummary;
   isPinned?: boolean;
   actions?: VersionAction[];
 }
@@ -71,30 +73,54 @@ export const VersionCreatedAt = ({ createdAt }: IVersionCreatedAtProps) => {
   if (!createdAt) return null;
   return (
     <MetadataElement>
-      <Tooltip delayShow={TOOLTIP_DELAY} value="Created at">
+      <Tooltip delayShow={TOOLTIP_DELAY_SHOW} value="Created at">
         <i className="far fa-calendar-alt metadata-icon" />
       </Tooltip>
-      <RelativeTimestamp timestamp={createdAt} delayShow={TOOLTIP_DELAY} removeStyles withSuffix />
+      <RelativeTimestamp timestamp={createdAt} delayShow={TOOLTIP_DELAY_SHOW} removeStyles withSuffix />
     </MetadataElement>
   );
 };
 
-export const DeployingBadge = () => {
-  return (
-    <MetadataElement>
-      <span className="version-deploying version-badge">Deploying</span>
-    </MetadataElement>
-  );
-};
-
-export const PinnedBadge = () => {
-  return (
-    <MetadataElement>
-      <span className="version-pinned version-badge">
+const badgeTypeToDetails = {
+  deploying: { className: 'version-deploying', text: 'Deploying' },
+  baking: { className: 'version-baking', text: 'Baking' },
+  pinned: {
+    className: 'version-pinned',
+    text: (
+      <>
         <Icon name="pin" size="12px" color="black" /> Pinned
-      </span>
-    </MetadataElement>
+      </>
+    ),
+  },
+};
+
+interface IMetadataBadgeProps {
+  type: keyof typeof badgeTypeToDetails;
+  tooltip?: string;
+  link?: string;
+}
+
+export const MetadataBadge = ({ type, link, tooltip }: IMetadataBadgeProps) => {
+  const details = badgeTypeToDetails[type];
+  const className = classnames('version-badge', details.className);
+  const baseBadge = link ? (
+    <a href={link} className={className}>
+      {details.text}
+    </a>
+  ) : (
+    <span className={className}>{details.text}</span>
   );
+  if (tooltip) {
+    return (
+      <MetadataElement>
+        <Tooltip value={tooltip} delayShow={TOOLTIP_DELAY_SHOW}>
+          {baseBadge}
+        </Tooltip>
+      </MetadataElement>
+    );
+  } else {
+    return <MetadataElement>{baseBadge}</MetadataElement>;
+  }
 };
 
 interface IVersionAuthorProps {

--- a/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
+++ b/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
@@ -118,17 +118,17 @@ export const MetadataBadge = ({ type, link, tooltip }: IMetadataBadgeProps) => {
   ) : (
     <span className={className}>{details.text}</span>
   );
-  if (tooltip) {
-    return (
-      <MetadataElement>
+  return (
+    <MetadataElement>
+      {tooltip ? (
         <Tooltip value={tooltip} delayShow={TOOLTIP_DELAY_SHOW}>
           {baseBadge}
         </Tooltip>
-      </MetadataElement>
-    );
-  } else {
-    return <MetadataElement>{baseBadge}</MetadataElement>;
-  }
+      ) : (
+        baseBadge
+      )}
+    </MetadataElement>
+  );
 };
 
 interface IVersionMessage {

--- a/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.less
+++ b/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.less
@@ -2,10 +2,11 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-top: var(~'--2xs-spacing');
+  margin-top: var(--xs-spacing);
   color: var(--color-concrete);
   white-space: pre-wrap;
   font-size: 13px;
+  flex-wrap: wrap;
 
   .metadata-element {
     display: flex;
@@ -63,7 +64,16 @@
   }
 
   .version-pinned {
-    background-color: var(--color-warning);
-    color: var(--color-black);
+    background-color: var(--color-status-warning-light);
+    color: var(--color-mineshaft);
+  }
+
+  .version-message {
+    border-radius: 4px;
+    padding: var(--s-spacing);
+    padding-right: var(--xl-spacing);
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
   }
 }

--- a/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.less
+++ b/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.less
@@ -39,4 +39,31 @@
       background-color: transparent;
     }
   }
+
+  .version-badge {
+    border-radius: 3px;
+    padding: 0 var(--s-spacing);
+    display: flex;
+    min-width: 60px;
+    justify-content: center;
+    flex-direction: row;
+    & > svg {
+      margin-right: 4px;
+    }
+  }
+
+  .version-deploying {
+    background-color: var(--color-accent);
+    color: var(--color-white);
+  }
+
+  .version-baking {
+    background-color: var(--color-accent-g1);
+    color: var(--color-black);
+  }
+
+  .version-pinned {
+    background-color: var(--color-warning);
+    color: var(--color-black);
+  }
 }

--- a/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.tsx
+++ b/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.tsx
@@ -13,10 +13,10 @@ import {
   VersionCreatedAt,
   VersionMetadataActions,
 } from './MetadataComponents';
-import { RelativeTimestamp } from '../RelativeTimestamp';
+import { formatToRelativeTimestamp, RelativeTimestamp } from '../RelativeTimestamp';
 import { getLifecycleEventDuration, getLifecycleEventLink, getLifecycleEventSummary } from '../overview/artifact/utils';
 import { QueryArtifactVersion } from '../overview/types';
-import { ABSOLUTE_TIME_FORMAT, TOOLTIP_DELAY_SHOW } from '../utils/defaults';
+import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
 import { SingleVersionArtifactVersion } from '../versionsHistory/types';
 
 export const getBaseMetadata = (
@@ -53,25 +53,15 @@ export const VersionMetadata = ({
         <MetadataBadge
           type="baking"
           link={baking.link}
-          tooltip={() => (
-            <div>
-              <div>
-                {baking.startedAt ? `Started at: ${baking.startedAt.toFormat(ABSOLUTE_TIME_FORMAT)}` : undefined}
-              </div>
-              <div className="sp-margin-xs-top">Click to view task</div>
-            </div>
-          )}
+          tooltip={`${baking.startedAt ? formatToRelativeTimestamp(baking.startedAt, true) : ''} (Click to view task)`}
         />
       )}
       {pinned && (
         <MetadataBadge
           type="pinned"
-          tooltip={() => (
-            <>
-              <div>{pinned.by ? `By: ${pinned.by}` : undefined}</div>
-              <div>{pinned.at ? `At: ${DateTime.fromISO(pinned.at).toFormat(ABSOLUTE_TIME_FORMAT)}` : undefined}</div>
-            </>
-          )}
+          tooltip={`${pinned.by ? `By ${pinned.by}, ` : ''}${
+            pinned.at ? `${formatToRelativeTimestamp(DateTime.fromISO(pinned.at), true)}` : ''
+          }`}
         />
       )}
 

--- a/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.tsx
+++ b/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import React from 'react';
 
 import { IconTooltip } from 'core/presentation';
@@ -15,7 +16,7 @@ import {
 import { RelativeTimestamp } from '../RelativeTimestamp';
 import { getLifecycleEventDuration, getLifecycleEventLink, getLifecycleEventSummary } from '../overview/artifact/utils';
 import { QueryArtifactVersion } from '../overview/types';
-import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
+import { ABSOLUTE_TIME_FORMAT, TOOLTIP_DELAY_SHOW } from '../utils/defaults';
 import { SingleVersionArtifactVersion } from '../versionsHistory/types';
 
 export const getBaseMetadata = (
@@ -42,7 +43,7 @@ export const VersionMetadata = ({
   buildsBehind,
   baking,
   isDeploying,
-  isPinned,
+  pinned,
   actions,
 }: IVersionMetadataProps) => {
   return (
@@ -52,13 +53,27 @@ export const VersionMetadata = ({
         <MetadataBadge
           type="baking"
           link={baking.link}
-          tooltip={
-            (baking.startedAt ? `Started at: ${baking.startedAt.toFormat('yyyy-MM-dd HH:mm:ss ZZZZ')}. ` : '') +
-            `Click to view task`
-          }
+          tooltip={() => (
+            <div>
+              <div>
+                {baking.startedAt ? `Started at: ${baking.startedAt.toFormat(ABSOLUTE_TIME_FORMAT)}` : undefined}
+              </div>
+              <div className="sp-margin-xs-top">Click to view task</div>
+            </div>
+          )}
         />
       )}
-      {isPinned && <MetadataBadge type="pinned" />}
+      {pinned && (
+        <MetadataBadge
+          type="pinned"
+          tooltip={() => (
+            <>
+              <div>{pinned.by ? `By: ${pinned.by}` : undefined}</div>
+              <div>{pinned.at ? `At: ${DateTime.fromISO(pinned.at).toFormat(ABSOLUTE_TIME_FORMAT)}` : undefined}</div>
+            </>
+          )}
+        />
+      )}
 
       {buildNumber && <VersionBuilds builds={[{ buildNumber, buildLink }]} />}
       <VersionAuthor author={author} />

--- a/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.tsx
+++ b/app/scripts/modules/core/src/managed/versionMetadata/VersionMetadata.tsx
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import React from 'react';
 
 import { IconTooltip } from 'core/presentation';
@@ -11,6 +10,7 @@ import {
   VersionAuthor,
   VersionBuilds,
   VersionCreatedAt,
+  VersionMessage,
   VersionMetadataActions,
 } from './MetadataComponents';
 import { formatToRelativeTimestamp, RelativeTimestamp } from '../RelativeTimestamp';
@@ -56,15 +56,6 @@ export const VersionMetadata = ({
           tooltip={`${baking.startedAt ? formatToRelativeTimestamp(baking.startedAt, true) : ''} (Click to view task)`}
         />
       )}
-      {pinned && (
-        <MetadataBadge
-          type="pinned"
-          tooltip={`${pinned.by ? `By ${pinned.by}, ` : ''}${
-            pinned.at ? `${formatToRelativeTimestamp(DateTime.fromISO(pinned.at), true)}` : ''
-          }`}
-        />
-      )}
-
       {buildNumber && <VersionBuilds builds={[{ buildNumber, buildLink }]} />}
       <VersionAuthor author={author} />
       {deployedAt && (
@@ -98,6 +89,7 @@ export const VersionMetadata = ({
         </MetadataElement>
       ) : null}
       {actions && <VersionMetadataActions id={`${buildNumber}-actions`} actions={actions} />}
+      {pinned && <VersionMessage type="pinned" data={pinned} />}
     </BaseVersionMetadata>
   );
 };

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
@@ -95,10 +95,10 @@ interface IVersionContentProps {
 export const VersionContent = ({ versionData, pinnedVersions }: IVersionContentProps) => {
   return (
     <React.Fragment>
-      {Object.entries(versionData.environments).map(([env, artifactVersions]) => {
+      {Object.entries(versionData.environments).map(([env, { versions }]) => {
         return (
           <BaseEnvironment key={env} title={env} size="small">
-            {artifactVersions.map((version) => (
+            {versions.map((version) => (
               <VersionInEnvironment
                 environment={env}
                 key={version.id}

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
@@ -10,7 +10,7 @@ import { ArtifactVersionTasks } from '../overview/artifact/ArtifactVersionTasks'
 import { Constraints } from '../overview/artifact/Constraints';
 import { useCreateVersionActions } from '../overview/artifact/utils';
 import { PinnedVersions, VersionData, VersionInEnvironment } from './types';
-import { PinnedMetadata, toPinnedMetadata } from '../versionMetadata/MetadataComponents';
+import { toPinnedMetadata, VersionMessageData } from '../versionMetadata/MetadataComponents';
 import { getBaseMetadata, VersionMetadata } from '../versionMetadata/VersionMetadata';
 
 import './VersionsHistory.less';
@@ -40,7 +40,7 @@ const LoadingAnimation = () => (
 
 const VersionInEnvironment = ({ environment, version, envPinnedVersions }: IVersionInEnvironmentProps) => {
   const { detailedVersionData, loading } = useGetDetailedVersionData({ environment, version });
-  let pinnedData: PinnedMetadata | undefined;
+  let pinnedData: VersionMessageData | undefined;
   const currentPinnedVersion = envPinnedVersions?.[version.reference];
   if (currentPinnedVersion && currentPinnedVersion.buildNumber === version.buildNumber) {
     pinnedData = toPinnedMetadata(currentPinnedVersion);

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
@@ -8,9 +8,9 @@ import { EnvironmentItem } from '../environmentBaseElements/EnvironmentItem';
 import { useFetchVersionQuery } from '../graphql/graphql-sdk';
 import { ArtifactVersionTasks } from '../overview/artifact/ArtifactVersionTasks';
 import { Constraints } from '../overview/artifact/Constraints';
-import { getLifecycleEventDuration, getLifecycleEventLink, useCreateVersionActions } from '../overview/artifact/utils';
+import { useCreateVersionActions } from '../overview/artifact/utils';
 import { PinnedVersions, VersionData, VersionInEnvironment } from './types';
-import { VersionMetadata } from '../versionMetadata/VersionMetadata';
+import { getBaseMetadata, VersionMetadata } from '../versionMetadata/VersionMetadata';
 
 import './VersionsHistory.less';
 
@@ -65,10 +65,8 @@ const VersionInEnvironment = ({ environment, version, envPinnedVersions }: IVers
       <VersionMetadata
         key={version.id}
         buildNumber={version.buildNumber}
-        buildLink={getLifecycleEventLink(detailedVersionData, 'BUILD')}
         author={version.gitMetadata?.author}
-        deployedAt={detailedVersionData?.deployedAt}
-        buildDuration={getLifecycleEventDuration(detailedVersionData, 'BUILD')}
+        {...(detailedVersionData ? getBaseMetadata(detailedVersionData) : undefined)}
         actions={actions}
         isPinned={isPinned}
       />

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
@@ -10,6 +10,7 @@ import { ArtifactVersionTasks } from '../overview/artifact/ArtifactVersionTasks'
 import { Constraints } from '../overview/artifact/Constraints';
 import { useCreateVersionActions } from '../overview/artifact/utils';
 import { PinnedVersions, VersionData, VersionInEnvironment } from './types';
+import { PinnedMetadata, toPinnedMetadata } from '../versionMetadata/MetadataComponents';
 import { getBaseMetadata, VersionMetadata } from '../versionMetadata/VersionMetadata';
 
 import './VersionsHistory.less';
@@ -39,16 +40,19 @@ const LoadingAnimation = () => (
 
 const VersionInEnvironment = ({ environment, version, envPinnedVersions }: IVersionInEnvironmentProps) => {
   const { detailedVersionData, loading } = useGetDetailedVersionData({ environment, version });
-  const isPinned = Boolean(
-    version.buildNumber !== undefined && envPinnedVersions?.[version.reference]?.buildNumber === version.buildNumber,
-  );
+  let pinnedData: PinnedMetadata | undefined;
+  const currentPinnedVersion = envPinnedVersions?.[version.reference];
+  if (currentPinnedVersion && currentPinnedVersion.buildNumber === version.buildNumber) {
+    pinnedData = toPinnedMetadata(currentPinnedVersion);
+  }
+
   const actions = useCreateVersionActions({
     environment,
     reference: version.reference,
     version: version.version,
     buildNumber: version.buildNumber,
     commitMessage: version.gitMetadata?.commitInfo?.message,
-    isPinned,
+    isPinned: Boolean(pinnedData),
     compareLinks: {
       previous: detailedVersionData?.gitMetadata?.comparisonLinks?.toPreviousVersion,
       current: detailedVersionData?.gitMetadata?.comparisonLinks?.toCurrentVersion,
@@ -68,7 +72,7 @@ const VersionInEnvironment = ({ environment, version, envPinnedVersions }: IVers
         author={version.gitMetadata?.author}
         {...(detailedVersionData ? getBaseMetadata(detailedVersionData) : undefined)}
         actions={actions}
-        isPinned={isPinned}
+        pinned={pinnedData}
       />
 
       {loading && <LoadingAnimation />}

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionHeading.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionHeading.tsx
@@ -8,7 +8,7 @@ import { Tooltip, useApplicationContextSafe } from 'core/presentation';
 import { FetchVersionDocument, FetchVersionQueryVariables } from '../graphql/graphql-sdk';
 import { GitLink } from '../overview/artifact/GitLink';
 import { HistoryArtifactVersion, VersionData } from './types';
-import { TOOLTIP_DELAY } from '../utils/defaults';
+import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
 import {
   BaseVersionMetadata,
   VersionAuthor,
@@ -108,10 +108,8 @@ export const VersionHeading = ({ group, chevron }: IVersionHeadingProps) => {
               const statusSummary = getEnvStatusSummary(artifacts);
               const statusClassName = statusToClassName[statusSummary];
               return (
-                <Tooltip delayShow={TOOLTIP_DELAY} value={statusToText[statusSummary]}>
-                  <div key={env} className={classnames('chip', statusClassName)}>
-                    {env}
-                  </div>
+                <Tooltip key={env} delayShow={TOOLTIP_DELAY_SHOW} value={statusToText[statusSummary]}>
+                  <div className={classnames('chip', statusClassName)}>{env}</div>
                 </Tooltip>
               );
             })}

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionHeading.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionHeading.tsx
@@ -3,14 +3,19 @@ import classnames from 'classnames';
 import { sortBy, toNumber } from 'lodash';
 import React from 'react';
 
-import { Tooltip, useApplicationContextSafe } from 'core/presentation';
+import { Icon, Tooltip, useApplicationContextSafe } from 'core/presentation';
 
-import { FetchVersionDocument, FetchVersionQueryVariables } from '../graphql/graphql-sdk';
+import {
+  FetchVersionDocument,
+  FetchVersionQueryVariables,
+  MdArtifactStatusInEnvironment,
+} from '../graphql/graphql-sdk';
 import { GitLink } from '../overview/artifact/GitLink';
 import { HistoryArtifactVersion, VersionData } from './types';
 import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
 import {
   BaseVersionMetadata,
+  MetadataBadge,
   VersionAuthor,
   VersionBuilds,
   VersionCreatedAt,
@@ -18,14 +23,14 @@ import {
 
 import './VersionsHistory.less';
 
-type VersionStatus = NonNullable<HistoryArtifactVersion['status']>;
+type VersionStatus = MdArtifactStatusInEnvironment;
 
 // TODO: could we have vetoed + current in the same env? unlikely
 const getEnvStatusSummary = (artifacts: HistoryArtifactVersion[]): VersionStatus => {
   // We sort from the newest to the oldest
   const sortedArtifacts = sortBy(artifacts, (artifact) => -1 * toNumber(artifact.buildNumber || 0));
 
-  let status: HistoryArtifactVersion['status'] = 'SKIPPED';
+  let status: MdArtifactStatusInEnvironment = 'SKIPPED';
   for (const artifact of sortedArtifacts) {
     switch (artifact.status) {
       case 'CURRENT':
@@ -96,6 +101,7 @@ export const VersionHeading = ({ group, chevron }: IVersionHeadingProps) => {
           <div>Build {Array.from(group.buildNumbers).join(', ')}</div>
         )}
         <BaseVersionMetadata>
+          {group.isBaking && <MetadataBadge type="baking" />}
           <VersionAuthor author={gitMetadata?.author} />
           <VersionBuilds builds={Array.from(group.buildNumbers).map((buildNumber) => ({ buildNumber }))} />
           <VersionCreatedAt createdAt={group.createdAt} />
@@ -105,11 +111,14 @@ export const VersionHeading = ({ group, chevron }: IVersionHeadingProps) => {
           {Object.entries(group.environments)
             .reverse()
             .map(([env, artifacts]) => {
-              const statusSummary = getEnvStatusSummary(artifacts);
+              const statusSummary = getEnvStatusSummary(artifacts.versions);
               const statusClassName = statusToClassName[statusSummary];
               return (
                 <Tooltip key={env} delayShow={TOOLTIP_DELAY_SHOW} value={statusToText[statusSummary]}>
-                  <div className={classnames('chip', statusClassName)}>{env}</div>
+                  <div className={classnames('chip', statusClassName)}>
+                    {artifacts.isPinned && <Icon name="pin" size="16px" className="environment-pinned" color="black" />}{' '}
+                    {env}
+                  </div>
                 </Tooltip>
               );
             })}

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.less
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.less
@@ -40,10 +40,21 @@
     flex-direction: row;
     margin-top: var(--s-spacing);
 
-    > .chip {
+    .chip {
       min-width: 100px;
       justify-content: center;
       margin-right: var(--m-spacing);
+      position: relative;
+    }
+
+    .environment-pinned {
+      position: absolute;
+      top: -5px;
+      right: -5px;
+      padding: 2px;
+      box-shadow: 1px 1px 1px 0 rgba(0, 0, 0, 0.5);
+      border-radius: 999px;
+      background-color: var(--color-status-warning-light);
     }
   }
 

--- a/app/scripts/modules/core/src/managed/versionsHistory/types.ts
+++ b/app/scripts/modules/core/src/managed/versionsHistory/types.ts
@@ -1,9 +1,13 @@
 import { DateTime } from 'luxon';
-import { FetchVersionsHistoryQuery } from '../graphql/graphql-sdk';
+import { FetchVersionQuery, FetchVersionsHistoryQuery } from '../graphql/graphql-sdk';
 
 export type HistoryEnvironment = NonNullable<FetchVersionsHistoryQuery['application']>['environments'][number];
 export type HistoryArtifact = NonNullable<HistoryEnvironment['state']['artifacts']>[number];
 export type HistoryArtifactVersion = NonNullable<HistoryArtifact['versions']>[number];
+
+export type SingleVersionEnvironment = NonNullable<FetchVersionQuery['application']>['environments'][number];
+export type SingleVersionArtifact = NonNullable<SingleVersionEnvironment['state']['artifacts']>[number];
+export type SingleVersionArtifactVersion = NonNullable<SingleVersionArtifact['versions']>[number];
 
 export interface VersionInEnvironment extends HistoryArtifactVersion {
   reference: string;

--- a/app/scripts/modules/core/src/managed/versionsHistory/types.ts
+++ b/app/scripts/modules/core/src/managed/versionsHistory/types.ts
@@ -19,7 +19,8 @@ export interface VersionData {
   buildNumbers: Set<string>;
   versions: Set<string>;
   createdAt?: DateTime;
-  environments: { [env: string]: VersionInEnvironment[] };
+  isBaking?: boolean;
+  environments: { [env: string]: { versions: VersionInEnvironment[]; isPinned?: boolean } };
   gitMetadata?: HistoryArtifactVersion['gitMetadata'];
   key: string;
 }

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -707,6 +707,11 @@ body > .container {
   width: 100%;
 }
 
+.flex-break {
+  flex-basis: 100%;
+  height: 0;
+}
+
 .add-new {
   border: 1px dashed var(--color-concrete);
   color: var(--color-concrete);


### PR DESCRIPTION
This PR is based on #9206.
Commit 5bde855 adds the pinned data and switches to the white hoverable tooltip
Commit 2d8b7c9 switches back to the black tooltip with a relative timestamp. I'm keeping the commit separate because I haven't decided which tooltip is better. 
Commit ab7cc04 moves the pinned data to a separate row to make it more prominent.

Bonus: use relative time instead of absolute
