### PR TITLE
fix(build): Add rollup externals

### DIFF
--- a/packages/scripts/config/rollup.config.base.module.js
+++ b/packages/scripts/config/rollup.config.base.module.js
@@ -7,4 +7,5 @@ module.exports = {
   input: 'src/index.ts',
   output: [{ dir: 'dist', format: 'es', sourcemap: true }],
   plugins: [...baseRollupConfig.plugins, angularJsTemplateLoader({ sourceMap: true }), autoExternal()],
+  externals: ['rxjs/operators'],
 };

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/scripts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
`rollup-plugin-auto-external` plugin doesn't automatically take care of imports like `rxjs/operators`, so explicitly adding it to list of externals here.