### PR TITLE
feat(md): History - scroll to version + share link

### DIFF
--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -7,7 +7,7 @@ import { SETTINGS } from 'core/config/settings';
 import { Spinner } from 'core/widgets';
 
 import { ColumnHeader } from './ColumnHeader';
-import { Environments2 } from './Environments2';
+import { Environments2, getIsNewUI, UISwitcher } from './Environments2';
 import { EnvironmentsHeader } from './EnvironmentsHeader';
 import { EnvironmentsList } from './EnvironmentsList';
 import { Application, ApplicationDataSource } from '../application';
@@ -66,11 +66,13 @@ interface IEnvironmentsProps {
 }
 
 export const Environments: React.FC<IEnvironmentsProps> = (props) => {
-  const { params } = useCurrentStateAndParams();
-  if (params.new_ui === '1') {
-    return <Environments2 />;
-  }
-  return <EnvironmentsOld {...props} />;
+  const isNewUI = getIsNewUI();
+  return (
+    <>
+      {isNewUI ? <Environments2 /> : <EnvironmentsOld {...props} />}
+      <UISwitcher />
+    </>
+  );
 };
 
 export const EnvironmentsOld: React.FC<IEnvironmentsProps> = ({ app }) => {

--- a/app/scripts/modules/core/src/managed/Environments2.less
+++ b/app/scripts/modules/core/src/managed/Environments2.less
@@ -21,3 +21,13 @@
     }
   }
 }
+
+.ui-switcher {
+  background-color: var(--color-white);
+  padding: var(--xs-spacing) var(--s-spacing);
+  position: absolute;
+  border-radius: 4px;
+  border: 1px solid var(--color-alto);
+  bottom: 4px;
+  right: 30px;
+}

--- a/app/scripts/modules/core/src/managed/Environments2.tsx
+++ b/app/scripts/modules/core/src/managed/Environments2.tsx
@@ -1,4 +1,4 @@
-import { UIView, useSref } from '@uirouter/react';
+import { UIView, useCurrentStateAndParams, useSref } from '@uirouter/react';
 import React from 'react';
 
 import { HorizontalTabs } from 'core/presentation/horizontalTabs/HorizontalTabs';
@@ -8,7 +8,43 @@ import { Routes } from './managed.states';
 import './Environments2.less';
 import './overview/baseStyles.less';
 
-export const featureFlag = 'MD_new_ui';
+export const uiFeatureFlag = {
+  key: 'MD_new_ui',
+  value: '1',
+};
+
+export const getIsNewUI = () => {
+  return localStorage.getItem(uiFeatureFlag.key) === uiFeatureFlag.value;
+};
+
+export const UISwitcher = () => {
+  const { state, params } = useCurrentStateAndParams();
+  const isNewUI = getIsNewUI();
+
+  const newUIstate =
+    'home.applications.application.environments' +
+    (state.name?.endsWith('.artifactVersion') ? '.history' : '.overview');
+
+  const { href, onClick } = useSref(isNewUI ? 'home.applications.application.environments' : newUIstate || '', params, {
+    reload: true,
+  });
+  return (
+    <a
+      href={href}
+      onClick={(e) => {
+        if (isNewUI) {
+          localStorage.removeItem(uiFeatureFlag.key);
+        } else {
+          localStorage.setItem(uiFeatureFlag.key, uiFeatureFlag.value);
+        }
+        onClick(e);
+      }}
+      className="ui-switcher"
+    >
+      {isNewUI ? 'Switch to old view' : 'Try out our new UI'}
+    </a>
+  );
+};
 
 const tabsInternal: { [key in Routes]: string } = {
   overview: 'Overview',
@@ -20,22 +56,12 @@ const tabs = Object.entries(tabsInternal).map(([key, title]) => ({ title, path: 
 
 // TODO: this is a temporary name until we remove the old view
 export const Environments2 = () => {
-  const { href } = useSref('home.applications.application.environments', { new_ui: '0' });
   return (
     <div className="vertical Environments2">
       <HorizontalTabs tabs={tabs} />
       <UIView />
       {/* Some padding at the bottom */}
       <div style={{ minHeight: 32, minWidth: 32 }} />
-      <a
-        href={href}
-        onClick={() => {
-          localStorage.removeItem(featureFlag);
-        }}
-        style={{ position: 'absolute', bottom: 4, right: 36 }}
-      >
-        Switch to old view
-      </a>
     </div>
   );
 };

--- a/app/scripts/modules/core/src/managed/managed.states.ts
+++ b/app/scripts/modules/core/src/managed/managed.states.ts
@@ -5,7 +5,7 @@ import { SETTINGS } from 'core/config';
 import { INestedState } from 'core/navigation/state.provider';
 
 import { Environments } from './Environments';
-import { featureFlag } from './Environments2';
+import { getIsNewUI, uiFeatureFlag } from './Environments2';
 import { Configuration } from './config/Configuration';
 import { EnvironmentsOverview } from './overview/EnvironmentsOverview';
 import { VersionsHistory } from './versionsHistory/VersionsHistory';
@@ -60,19 +60,40 @@ module(MANAGED_STATES, [APPLICATION_STATE_PROVIDER]).config([
   'applicationStateProvider',
   (applicationStateProvider: ApplicationStateProvider) => {
     if (SETTINGS.feature.managedDelivery) {
+      const isNewUI = () => {
+        const isNew = getIsNewUI();
+        if (isNew) {
+          localStorage.setItem(uiFeatureFlag.key, uiFeatureFlag.value);
+        } else {
+          localStorage.removeItem(uiFeatureFlag.key);
+        }
+        return isNew;
+      };
+
       const artifactVersion: INestedState = {
         name: 'artifactVersion',
-        url: '/{reference}/{version}',
+        url: `/{reference}/{version}`,
         params: {
           reference: { dynamic: true },
           version: { dynamic: true },
         },
         children: [],
+        redirectTo: (transition) => {
+          if (isNewUI()) {
+            return {
+              state: 'home.applications.application.environments.history',
+              params: {
+                version: transition.params().version,
+              },
+            };
+          }
+          return undefined;
+        },
       };
 
       const environments: INestedState = {
         name: 'environments',
-        url: '/environments?{new_ui:query}',
+        url: `/environments`,
         views: {
           insight: { component: Environments, $type: 'react' },
         },
@@ -81,14 +102,9 @@ module(MANAGED_STATES, [APPLICATION_STATE_PROVIDER]).config([
             title: 'Environments',
           },
         },
-        params: {
-          new_ui: localStorage.getItem(featureFlag),
-        },
         children: [artifactVersion, ...routes],
-        redirectTo: (transition) => {
-          const { new_ui } = transition.params();
-          if (new_ui === '1') {
-            localStorage.setItem(featureFlag, '1');
+        redirectTo: () => {
+          if (isNewUI()) {
             return 'home.applications.application.environments.overview';
           }
           return undefined;

--- a/app/scripts/modules/core/src/managed/managed.states.ts
+++ b/app/scripts/modules/core/src/managed/managed.states.ts
@@ -29,10 +29,14 @@ const routes: Array<INestedState & { name: Routes }> = [
   },
   {
     name: 'history',
-    url: '/history',
+    url: '/history/:version?sha',
     component: VersionsHistory,
     $type: 'react',
     children: [],
+    params: {
+      version: { isOptional: true, value: null },
+      sha: { isOptional: true, value: null },
+    },
   },
 ];
 

--- a/app/scripts/modules/core/src/managed/managed.states.ts
+++ b/app/scripts/modules/core/src/managed/managed.states.ts
@@ -39,7 +39,7 @@ const routes: Array<INestedState & { name: Routes }> = [
   },
   {
     name: 'history',
-    url: '/history/:version?sha',
+    url: '/history/{version:.*}?sha',
     component: VersionsHistory,
     $type: 'react',
     children: [],

--- a/app/scripts/modules/core/src/managed/managed.states.ts
+++ b/app/scripts/modules/core/src/managed/managed.states.ts
@@ -19,6 +19,11 @@ const routes: Array<INestedState & { name: Routes }> = [
     component: EnvironmentsOverview,
     $type: 'react',
     children: [],
+    data: {
+      pageTitleSection: {
+        title: 'Environments overview',
+      },
+    },
   },
   {
     name: 'config',
@@ -26,6 +31,11 @@ const routes: Array<INestedState & { name: Routes }> = [
     component: Configuration,
     $type: 'react',
     children: [],
+    data: {
+      pageTitleSection: {
+        title: 'Environments config',
+      },
+    },
   },
   {
     name: 'history',
@@ -36,6 +46,11 @@ const routes: Array<INestedState & { name: Routes }> = [
     params: {
       version: { isOptional: true, value: null },
       sha: { isOptional: true, value: null },
+    },
+    data: {
+      pageTitleSection: {
+        title: 'Environments history',
+      },
     },
   },
 ];

--- a/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
+++ b/app/scripts/modules/core/src/managed/versionMetadata/MetadataComponents.tsx
@@ -5,6 +5,7 @@ import { Dropdown, MenuItem } from 'react-bootstrap';
 
 import { Icon, IconNames } from '@spinnaker/presentation';
 import { Tooltip } from 'core/presentation';
+import { CopyToClipboard } from 'core/utils';
 
 import { RelativeTimestamp } from '../RelativeTimestamp';
 import { LifecycleEventSummary } from '../overview/artifact/utils';
@@ -232,6 +233,23 @@ export const VersionBuilds = ({ builds }: IVersionBuildsProps) => {
           ))}
         </>
       )}
+    </MetadataElement>
+  );
+};
+
+export const ShareLink = ({ link }: { link: string }) => {
+  return (
+    <MetadataElement className="copy-version-link">
+      <CopyToClipboard
+        text={link}
+        className="as-link"
+        stopPropagation
+        buttonInnerNode={
+          <span>
+            <span className="glyphicon glyphicon-copy" /> Copy link
+          </span>
+        }
+      />
     </MetadataElement>
   );
 };

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionHeading.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionHeading.tsx
@@ -1,4 +1,6 @@
 import { useApolloClient } from '@apollo/client';
+import { useSref } from '@uirouter/react';
+
 import classnames from 'classnames';
 import { sortBy, toNumber } from 'lodash';
 import React from 'react';
@@ -16,6 +18,7 @@ import { TOOLTIP_DELAY_SHOW } from '../utils/defaults';
 import {
   BaseVersionMetadata,
   MetadataBadge,
+  ShareLink,
   VersionAuthor,
   VersionBuilds,
   VersionCreatedAt,
@@ -84,6 +87,7 @@ export const VersionHeading = ({ group, chevron }: IVersionHeadingProps) => {
   const gitMetadata = group.gitMetadata;
   const client = useApolloClient();
   const app = useApplicationContextSafe();
+  const { href } = useSref('home.applications.application.environments.history', { sha: group.key });
 
   const prefetchData = () => {
     // This function is pre-loading the content of the version and caching it before mounting the VersionContent component
@@ -105,6 +109,7 @@ export const VersionHeading = ({ group, chevron }: IVersionHeadingProps) => {
           <VersionAuthor author={gitMetadata?.author} />
           <VersionBuilds builds={Array.from(group.buildNumbers).map((buildNumber) => ({ buildNumber }))} />
           <VersionCreatedAt createdAt={group.createdAt} />
+          {href && <ShareLink link={window.location.host + '/' + href} />}
         </BaseVersionMetadata>
         {/* Shows a badge for each environment with the status of the artifacts in it */}
         <div className="version-environments">

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.less
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.less
@@ -6,6 +6,15 @@
     margin-bottom: var(--xl-spacing);
     box-shadow: 1px 3px 6px 0 rgba(0, 0, 0, 0.05);
 
+    .copy-version-link {
+      display: none;
+    }
+    &:hover {
+      .copy-version-link {
+        display: block;
+      }
+    }
+
     .version-heading {
       display: flex;
       flex-direction: row;

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.tsx
@@ -1,3 +1,4 @@
+import { useCurrentStateAndParams } from '@uirouter/react';
 import { sortBy } from 'lodash';
 import { DateTime } from 'luxon';
 import React from 'react';
@@ -111,20 +112,41 @@ export const VersionsHistory = () => {
     <main className="VersionsHistory">
       <ManagementWarning appName={app.name} />
       {groupedVersions.map((group) => {
-        return (
-          <div key={group.key}>
-            <CollapsibleSection
-              outerDivClassName="version-item"
-              toggleClassName="version-toggle"
-              bodyClassName="version-body"
-              expandIconType="plus"
-              heading={({ chevron }) => <VersionHeading group={group} chevron={chevron} />}
-            >
-              <VersionContent versionData={group} pinnedVersions={pinnedVersions} />
-            </CollapsibleSection>
-          </div>
-        );
+        return <SingleVersion key={group.key} versionData={group} pinnedVersions={pinnedVersions} />;
       })}
     </main>
+  );
+};
+
+interface ISingleVersionProps {
+  versionData: VersionData;
+  pinnedVersions?: PinnedVersions;
+}
+
+const SingleVersion = ({ versionData, pinnedVersions }: ISingleVersionProps) => {
+  const { params } = useCurrentStateAndParams();
+  const isFocused = params.sha && params.sha === versionData.gitMetadata?.commit;
+
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (isFocused && ref.current) {
+      ref.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, []);
+
+  return (
+    <div ref={ref}>
+      <CollapsibleSection
+        outerDivClassName="version-item"
+        toggleClassName="version-toggle"
+        bodyClassName="version-body"
+        expandIconType="plus"
+        defaultExpanded={isFocused}
+        heading={({ chevron }) => <VersionHeading group={versionData} chevron={chevron} />}
+      >
+        <VersionContent versionData={versionData} pinnedVersions={pinnedVersions} />
+      </CollapsibleSection>
+    </div>
   );
 };

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.tsx
@@ -1,4 +1,4 @@
-import { useCurrentStateAndParams } from '@uirouter/react';
+import { RawParams, useCurrentStateAndParams } from '@uirouter/react';
 import { sortBy } from 'lodash';
 import { DateTime } from 'luxon';
 import React from 'react';
@@ -11,7 +11,7 @@ import { VersionHeading } from './VersionHeading';
 import { ManagementWarning } from '../config/ManagementWarning';
 import { useFetchVersionsHistoryQuery } from '../graphql/graphql-sdk';
 import { isBaking } from '../overview/artifact/utils';
-import { HistoryEnvironment, PinnedVersions, VersionData } from './types';
+import { HistoryArtifactVersion, HistoryEnvironment, PinnedVersions, VersionData } from './types';
 import { spinnerProps } from '../utils/defaults';
 
 import './VersionsHistory.less';
@@ -35,7 +35,17 @@ const setValueIfMissing = <Obj extends Record<string, any>, Key extends keyof Ob
   }
 };
 
-const groupVersionsByShaOrBuild = (environments: HistoryEnvironment[]) => {
+const getIsFocused = (version: HistoryArtifactVersion, params: RawParams) => {
+  if (params.sha && params.sha === version.gitMetadata?.commit) {
+    return true;
+  }
+  if (params.version?.includes(version.version)) {
+    return true;
+  }
+  return false;
+};
+
+const groupVersionsByShaOrBuild = (environments: HistoryEnvironment[], params: RawParams) => {
   const groupedVersions: GroupedVersions = {};
   for (const env of environments) {
     for (const artifact of env.state.artifacts || []) {
@@ -53,6 +63,10 @@ const groupVersionsByShaOrBuild = (environments: HistoryEnvironment[]) => {
 
         if (isBaking(version)) {
           groupedVersions[key].isBaking = true;
+        }
+
+        if (getIsFocused(version, params)) {
+          groupedVersions[key].isFocused = true;
         }
 
         groupedVersions[key].versions.add(version.version);
@@ -91,6 +105,7 @@ const getPinnedVersions = (environments: HistoryEnvironment[]) => {
 
 export const VersionsHistory = () => {
   const app = useApplicationContextSafe();
+  const { params } = useCurrentStateAndParams();
 
   const { data, error, loading } = useFetchVersionsHistoryQuery({
     variables: { appName: app.name, limit: 100 }, // Fetch the last 100 versions
@@ -105,7 +120,7 @@ export const VersionsHistory = () => {
     return <div style={{ width: '100%' }}>Failed to load history, please refresh and try again.</div>;
   }
 
-  const groupedVersions = groupVersionsByShaOrBuild(data?.application?.environments || []);
+  const groupedVersions = groupVersionsByShaOrBuild(data?.application?.environments || [], params);
   const pinnedVersions = getPinnedVersions(data?.application?.environments || []);
 
   return (
@@ -124,13 +139,10 @@ interface ISingleVersionProps {
 }
 
 const SingleVersion = ({ versionData, pinnedVersions }: ISingleVersionProps) => {
-  const { params } = useCurrentStateAndParams();
-  const isFocused = params.sha && params.sha === versionData.gitMetadata?.commit;
-
   const ref = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
-    if (isFocused && ref.current) {
+    if (versionData.isFocused && ref.current) {
       ref.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, []);
@@ -142,7 +154,7 @@ const SingleVersion = ({ versionData, pinnedVersions }: ISingleVersionProps) => 
         toggleClassName="version-toggle"
         bodyClassName="version-body"
         expandIconType="plus"
-        defaultExpanded={isFocused}
+        defaultExpanded={versionData.isFocused}
         heading={({ chevron }) => <VersionHeading group={versionData} chevron={chevron} />}
       >
         <VersionContent versionData={versionData} pinnedVersions={pinnedVersions} />

--- a/app/scripts/modules/core/src/managed/versionsHistory/types.ts
+++ b/app/scripts/modules/core/src/managed/versionsHistory/types.ts
@@ -20,6 +20,7 @@ export interface VersionData {
   versions: Set<string>;
   createdAt?: DateTime;
   isBaking?: boolean;
+  isFocused?: boolean;
   environments: { [env: string]: { versions: VersionInEnvironment[]; isPinned?: boolean } };
   gitMetadata?: HistoryArtifactVersion['gitMetadata'];
   key: string;

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1593,3 +1593,14 @@ div.modal-header.has-sticky-headers {
     margin-left: auto;
   }
 }
+
+button.as-link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
+++ b/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
@@ -11,6 +11,7 @@ export interface ICopyToClipboardProps {
   text: string;
   toolTip?: string;
   className?: string;
+  stopPropagation?: boolean;
 }
 
 interface ICopyToClipboardState {
@@ -59,6 +60,9 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
    */
   public handleClick = (e: React.SyntheticEvent): void => {
     e.preventDefault();
+    if (this.props.stopPropagation) {
+      e.stopPropagation();
+    }
 
     const { analyticsLabel, text } = this.props;
     ReactGA.event({


### PR DESCRIPTION
This PR includes two features:
- Share button to copy a link to a specific version
- Expand and scroll to a version based on the `sha` query params.

What's missing?
Linking to /reference/version to support the existing notification links (@christopherthielen, I'd love to get your help with that)