### PR TITLE
fix(md): sort versions even when no current exists

### DIFF
--- a/app/scripts/modules/core/src/managed/overview/artifact/Artifact.tsx
+++ b/app/scripts/modules/core/src/managed/overview/artifact/Artifact.tsx
@@ -1,4 +1,4 @@
-import { sortBy } from 'lodash';
+import { orderBy } from 'lodash';
 import React from 'react';
 
 import { HoverablePopover, Markdown } from 'core/presentation';
@@ -17,17 +17,23 @@ const hasCreatedAt = (version?: QueryArtifactVersion): version is RequiredKeys<Q
   return Boolean(version?.createdAt);
 };
 
+const sortVersions = (versions: QueryArtifact['versions']) => {
+  return orderBy(versions || [], (version) => (version.createdAt ? new Date(version.createdAt).getTime() : 0), [
+    'desc',
+  ]);
+};
+
 const filterPendingVersions = (versions: QueryArtifact['versions'], currentVersion?: QueryArtifactVersion) => {
   if (!hasCreatedAt(currentVersion)) {
     // Everything is newer than current
-    return versions;
+    return sortVersions(versions);
   }
   const currentVersionCreatedAt = new Date(currentVersion.createdAt);
   const newerVersions = versions
     ?.filter(hasCreatedAt)
     ?.filter((version) => new Date(version.createdAt) > currentVersionCreatedAt || version.status === 'DEPLOYING');
-  // Sort from newest to oldest
-  return sortBy(newerVersions || [], (version) => -1 * new Date(version.createdAt).getTime());
+
+  return sortVersions(newerVersions);
 };
 
 export const PinnedVersion = ({ version }: { version: NonNullable<QueryArtifact['pinnedVersion']> }) => {


### PR DESCRIPTION
When no current version exists, we didn't order the versions and the backend returned the versions in the wrong order