### PR TITLE
fix(md): order of environments 2

### DIFF
--- a/app/scripts/modules/core/src/managed/overview/EnvironmentsOverview.tsx
+++ b/app/scripts/modules/core/src/managed/overview/EnvironmentsOverview.tsx
@@ -34,15 +34,16 @@ export const EnvironmentsOverview = () => {
     );
   }
 
-  // environments that depend on others appear last. We want to reverse that
-  const environments = [...(data?.application?.environments || [])].reverse();
+  const environments = data?.application?.environments || [];
 
   return (
     <div className="EnvironmentsOverview">
       <ManagementWarning appName={app.name} />
-      {environments.map((env) => (
-        <EnvironmentOverview key={env.name} environment={env} appName={app.name} />
-      ))}
+      {environments.length ? (
+        environments.map((env) => <EnvironmentOverview key={env.name} environment={env} appName={app.name} />)
+      ) : (
+        <div className="error-message">No environments found</div>
+      )}
     </div>
   );
 };

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionHeading.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionHeading.tsx
@@ -102,17 +102,19 @@ export const VersionHeading = ({ group, chevron }: IVersionHeadingProps) => {
         </BaseVersionMetadata>
         {/* Shows a badge for each environment with the status of the artifacts in it */}
         <div className="version-environments">
-          {Object.entries(group.environments).map(([env, artifacts]) => {
-            const statusSummary = getEnvStatusSummary(artifacts);
-            const statusClassName = statusToClassName[statusSummary];
-            return (
-              <Tooltip delayShow={TOOLTIP_DELAY} value={statusToText[statusSummary]}>
-                <div key={env} className={classnames('chip', statusClassName)}>
-                  {env}
-                </div>
-              </Tooltip>
-            );
-          })}
+          {Object.entries(group.environments)
+            .reverse()
+            .map(([env, artifacts]) => {
+              const statusSummary = getEnvStatusSummary(artifacts);
+              const statusClassName = statusToClassName[statusSummary];
+              return (
+                <Tooltip delayShow={TOOLTIP_DELAY} value={statusToText[statusSummary]}>
+                  <div key={env} className={classnames('chip', statusClassName)}>
+                    {env}
+                  </div>
+                </Tooltip>
+              );
+            })}
         </div>
       </div>
       <div>{chevron}</div>


### PR DESCRIPTION
environments are now sorted on the backend. We only need to reverse the order in the history heading
