### PR TITLE
refactor(core): Convert alias imports to relative imports in less

### DIFF
--- a/app/scripts/modules/canary/canary/canaryScore.component.less
+++ b/app/scripts/modules/canary/canary/canaryScore.component.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../core/src/presentation/less/imports/commonImports.less';
 
 .score.label {
   font-size: 110%;

--- a/app/scripts/modules/core/src/application/application.less
+++ b/app/scripts/modules/core/src/application/application.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/search/searchResult/baseTable.less';
+@import (reference) '../search/searchResult/baseTable.less';
 
 .application {
   display: flex;

--- a/app/scripts/modules/core/src/application/applications.less
+++ b/app/scripts/modules/core/src/application/applications.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .applications {
   flex: 1 1 auto;

--- a/app/scripts/modules/core/src/application/nav/verticalNav.less
+++ b/app/scripts/modules/core/src/application/nav/verticalNav.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .vertical-navigation {
   background-color: var(--color-accent-g2);

--- a/app/scripts/modules/core/src/ci/components/builds.less
+++ b/app/scripts/modules/core/src/ci/components/builds.less
@@ -1,4 +1,4 @@
-@import (reference) '~coreImports';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .build-detail {
   margin-left: 20px;

--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .server-group {
   input[type='checkbox'] {

--- a/app/scripts/modules/core/src/entityTag/EntityTagEditor.less
+++ b/app/scripts/modules/core/src/entityTag/EntityTagEditor.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .entity-tag-editor-modal {
   .preview {

--- a/app/scripts/modules/core/src/entityTag/notifications/notifications.less
+++ b/app/scripts/modules/core/src/entityTag/notifications/notifications.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .notices-severity-0,
 .notices-severity-1,

--- a/app/scripts/modules/core/src/entityTag/notifications/notifications.popover.less
+++ b/app/scripts/modules/core/src/entityTag/notifications/notifications.popover.less
@@ -1,4 +1,4 @@
-@import '~core/presentation/less/imports/commonImports.less';
+@import '../../presentation/less/imports/commonImports.less';
 
 .popover.notifications-popover {
   padding: 0;

--- a/app/scripts/modules/core/src/healthCounts/healthCounts.less
+++ b/app/scripts/modules/core/src/healthCounts/healthCounts.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .glyphicon,
 .fa {

--- a/app/scripts/modules/core/src/instance/instanceSelection.less
+++ b/app/scripts/modules/core/src/instance/instanceSelection.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .panel-default > .panel-heading {
   background-color: transparent;

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancerPod.less
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancerPod.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .load-balancer-pod {
   .cluster-container {

--- a/app/scripts/modules/core/src/modal/modals.less
+++ b/app/scripts/modules/core/src/modal/modals.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .modal-backdrop {
   z-index: 8999;

--- a/app/scripts/modules/core/src/modal/wizard/modalWizard.less
+++ b/app/scripts/modules/core/src/modal/wizard/modalWizard.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 @indicator-size: 14px;
 @indicator-radius: @indicator-size / 2;

--- a/app/scripts/modules/core/src/navigation/navigation.less
+++ b/app/scripts/modules/core/src/navigation/navigation.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .secondary-panel {
   > div {

--- a/app/scripts/modules/core/src/pagerDuty/pager.less
+++ b/app/scripts/modules/core/src/pagerDuty/pager.less
@@ -1,4 +1,4 @@
-@import (reference) '~coreImports';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .on-call {
   flex-direction: column;

--- a/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.less
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.less
@@ -1,5 +1,5 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
-@import (reference) '~bootstrap/less/variables.less';
+@import (reference) '../../../../presentation/less/imports/commonImports.less';
+@import (reference) 'bootstrap/less/variables.less';
 
 .history-header {
   padding-bottom: 10px;

--- a/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.less
+++ b/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../../presentation/less/imports/commonImports.less';
 
 .pipeline-config-graph {
   svg {

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.less
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .stage-choice {
   .ui-select-highlight {

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.less
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../../../presentation/less/imports/commonImports.less';
 
 execution-windows,
 .execution-windows {

--- a/app/scripts/modules/core/src/pipeline/details/stageExecutionDetails.less
+++ b/app/scripts/modules/core/src/pipeline/details/stageExecutionDetails.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .execution {
   .execution-details {

--- a/app/scripts/modules/core/src/pipeline/executions/execution/execution.less
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/execution.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../../presentation/less/imports/commonImports.less';
 
 @execution-parameters-icon-width: 1.4em;
 

--- a/app/scripts/modules/core/src/pipeline/executions/execution/executionMarker.less
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/executionMarker.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../../presentation/less/imports/commonImports.less';
 
 .execution-marker.stage {
   margin-top: 0;

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/executionGroup.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../../presentation/less/imports/commonImports.less';
 
 .execution-group-container {
   padding: 10px 30px 0;

--- a/app/scripts/modules/core/src/pipeline/executions/executions.less
+++ b/app/scripts/modules/core/src/pipeline/executions/executions.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 [ui-view='pipelines'] {
   padding-top: 0 !important;

--- a/app/scripts/modules/core/src/pipeline/pipeline.less
+++ b/app/scripts/modules/core/src/pipeline/pipeline.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .pipelines {
   overflow-x: hidden;

--- a/app/scripts/modules/core/src/pipeline/status/artifactList.less
+++ b/app/scripts/modules/core/src/pipeline/status/artifactList.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/pipeline/executions/execution/execution.less';
+@import (reference) '../executions/execution/execution.less';
 
 .artifact-list {
   ul {

--- a/app/scripts/modules/core/src/pipeline/status/executionParameters.less
+++ b/app/scripts/modules/core/src/pipeline/status/executionParameters.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/pipeline/executions/execution/execution.less';
+@import (reference) '../executions/execution/execution.less';
 
 .execution-parameters {
   font-size: 0.8em;

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.css
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.css
@@ -1,5 +1,3 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
-
 .HoverablePopover {
   display: inline;
   text-decoration: dotted underline var(--color-dovegray);

--- a/app/scripts/modules/core/src/presentation/details.less
+++ b/app/scripts/modules/core/src/presentation/details.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) './less/imports/commonImports.less';
 
 .details-panel {
   &.health-status-Healthy {

--- a/app/scripts/modules/core/src/presentation/less/imports/commonImports.less
+++ b/app/scripts/modules/core/src/presentation/less/imports/commonImports.less
@@ -1,4 +1,4 @@
 @import './animations.less';
 @import './mixins.less';
-@import '~bootstrap/less/mixins.less';
-@import '~bootstrap/less/variables.less';
+@import 'bootstrap/less/mixins.less';
+@import 'bootstrap/less/variables.less';

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1,4 +1,4 @@
-@import '~core/presentation/less/imports/commonImports.less';
+@import './less/imports/commonImports.less';
 @import 'stickyHeader';
 
 @fixed-header-z-index: 1030;

--- a/app/scripts/modules/core/src/presentation/navPopover.less
+++ b/app/scripts/modules/core/src/presentation/navPopover.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) './less/imports/commonImports.less';
 
 .nav-popover {
   font-weight: 600;

--- a/app/scripts/modules/core/src/presentation/navigation/pageNavigation.less
+++ b/app/scripts/modules/core/src/presentation/navigation/pageNavigation.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../less/imports/commonImports.less';
 
 page-navigator,
 .page-navigator {

--- a/app/scripts/modules/core/src/presentation/stickyHeader.less
+++ b/app/scripts/modules/core/src/presentation/stickyHeader.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) './less/imports/commonImports.less';
 
 .sticky-header {
   position: sticky;

--- a/app/scripts/modules/core/src/projects/dashboard/cluster/projectCluster.less
+++ b/app/scripts/modules/core/src/projects/dashboard/cluster/projectCluster.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../../presentation/less/imports/commonImports.less';
 
 project-cluster {
   .rollup-summary {

--- a/app/scripts/modules/core/src/projects/dashboard/pipeline/projectPipeline.less
+++ b/app/scripts/modules/core/src/projects/dashboard/pipeline/projectPipeline.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../../presentation/less/imports/commonImports.less';
 
 project-pipeline {
   display: block;

--- a/app/scripts/modules/core/src/search/global/globalSearch.less
+++ b/app/scripts/modules/core/src/search/global/globalSearch.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 global-search {
   position: relative;

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.less
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .infrastructure {
   display: flex;

--- a/app/scripts/modules/core/src/search/infrastructure/projectSummaryPod.less
+++ b/app/scripts/modules/core/src/search/infrastructure/projectSummaryPod.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .infrastructure-project {
   display: block;

--- a/app/scripts/modules/core/src/search/searchResult/baseTable.less
+++ b/app/scripts/modules/core/src/search/searchResult/baseTable.less
@@ -1,4 +1,4 @@
-@import (reference) '~coreImports';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .table-search-results {
   width: auto;

--- a/app/scripts/modules/core/src/search/searchResult/searchResults.less
+++ b/app/scripts/modules/core/src/search/searchResult/searchResults.less
@@ -1,7 +1,7 @@
-@import '~bootstrap/less/mixins/vendor-prefixes.less';
-@import (reference) '~core/presentation/main.less';
-@import (reference) '~core/presentation/less/imports/commonImports.less';
-@import '~core/search/searchResult/baseTable.less';
+@import 'bootstrap/less/mixins/vendor-prefixes.less';
+@import (reference) '../../presentation/main.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
+@import './baseTable.less';
 
 .search-results {
   .faded {

--- a/app/scripts/modules/core/src/search/widgets/filterlist.less
+++ b/app/scripts/modules/core/src/search/widgets/filterlist.less
@@ -1,6 +1,6 @@
-@import '~bootstrap/less/mixins/vendor-prefixes.less';
-@import (reference) '~core/presentation/main.less';
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import 'bootstrap/less/mixins/vendor-prefixes.less';
+@import (reference) '../../presentation/main.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .secondary-text() {
   color: var(--color-concrete);

--- a/app/scripts/modules/core/src/search/widgets/search.less
+++ b/app/scripts/modules/core/src/search/widgets/search.less
@@ -1,6 +1,6 @@
-@import '~bootstrap/less/mixins/vendor-prefixes.less';
-@import '~bootstrap/less/variables.less';
-@import (reference) '~core/presentation/main.less';
+@import 'bootstrap/less/mixins/vendor-prefixes.less';
+@import 'bootstrap/less/variables.less';
+@import (reference) '../../presentation/main.less';
 
 .search {
   align-items: center;

--- a/app/scripts/modules/core/src/serverGroup/details/multipleServerGroup.component.less
+++ b/app/scripts/modules/core/src/serverGroup/details/multipleServerGroup.component.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 multiple-server-group {
   display: block;

--- a/app/scripts/modules/core/src/serverGroup/details/scalingActivities/ScalingActivitiesModal.less
+++ b/app/scripts/modules/core/src/serverGroup/details/scalingActivities/ScalingActivitiesModal.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../../presentation/less/imports/commonImports.less';
 
 .ScalingAcivitiesModalBody {
   font-size: 16px;

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.directive.less
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.directive.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 task-monitor {
   display: block;

--- a/app/scripts/modules/core/src/task/tasks.less
+++ b/app/scripts/modules/core/src/task/tasks.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../presentation/less/imports/commonImports.less';
 
 .tasks-wrapper {
   display: flex;

--- a/app/scripts/modules/core/src/task/verification/userVerification.directive.less
+++ b/app/scripts/modules/core/src/task/verification/userVerification.directive.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .user-verification,
 user-verification {

--- a/app/scripts/modules/core/src/widgets/notifier/notifier.component.less
+++ b/app/scripts/modules/core/src/widgets/notifier/notifier.component.less
@@ -1,4 +1,4 @@
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .Toastify__toast-container {
   .Toastify__toast {

--- a/app/scripts/modules/core/src/widgets/tags/taglist.less
+++ b/app/scripts/modules/core/src/widgets/tags/taglist.less
@@ -1,5 +1,5 @@
-@import (reference) '~core/presentation/main.less';
-@import (reference) '~core/presentation/less/imports/commonImports.less';
+@import (reference) '../../presentation/main.less';
+@import (reference) '../../presentation/less/imports/commonImports.less';
 
 .tag-list {
   align-items: center;


### PR DESCRIPTION
This is needed to migrate the build tooling to rollup as it doesn't support alias for less imports.