### PR TITLE
fix(core): Remove string interpolation token from ng template for rollup

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.html
@@ -1,7 +1,15 @@
 <div class="form-horizontal">
   <stage-config-field label="Application">
-    <input ng-model="stage.application" class="form-control input-sm" ng-if="stage.application.includes('${')" />
-    <ui-select ng-model="stage.application" class="form-control input-sm" ng-if="!stage.application.includes('${')">
+    <input
+      ng-model="stage.application"
+      class="form-control input-sm"
+      ng-if="pipelineStageCtrl.hasSpel(stage.application)"
+    />
+    <ui-select
+      ng-model="stage.application"
+      class="form-control input-sm"
+      ng-if="!pipelineStageCtrl.hasSpel(stage.application)"
+    >
       <ui-select-match placeholder="None">{{$select.selected}}</ui-select-match>
 
       <ui-select-choices
@@ -17,10 +25,10 @@
     <input
       ng-model="stage.pipeline"
       class="form-control input-sm"
-      ng-if="stage.pipeline.includes('${') || stage.application.includes('${')"
+      ng-if="pipelineStageCtrl.hasSpel(stage.pipeline) || pipelineStageCtrl.hasSpel(stage.application)"
     />
     <div
-      ng-if="stage.application && viewState.pipelinesLoaded && stage !== null && !stage.pipeline.includes('${') && !stage.application.includes('${')"
+      ng-if="stage.application && viewState.pipelinesLoaded && stage !== null && !pipelineStageCtrl.hasSpel(stage.pipeline) && !pipelineStageCtrl.hasSpel(stage.application)"
     >
       <ui-select class="form-control input-sm" ng-model="stage.pipeline">
         <ui-select-match placeholder="Select a pipeline...">{{$select.selected.name}}</ui-select-match>

--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
@@ -60,6 +60,9 @@ module(CORE_PIPELINE_CONFIG_STAGES_PIPELINE_PIPELINESTAGE, [])
         },
       };
 
+      this.hasSpel = function (string) {
+        return string && string.includes('${');
+      };
       this.addMoreItems = function () {
         $scope.viewState.infiniteScroll.currentItems += $scope.viewState.infiniteScroll.numToAdd;
       };


### PR DESCRIPTION
Rollup has some trouble bundling ng templates that have string interpolation token `${` in them. So fixing it by removing some occurrences in `core`.
