### PR TITLE
fix(style): shrink padding on stage details tabs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/details/stageExecutionDetails.less
+++ b/app/scripts/modules/core/src/pipeline/details/stageExecutionDetails.less
@@ -36,8 +36,9 @@
     .nav.nav-pills {
       background-color: transparent;
       border: 0;
-      padding-left: 0;
       width: auto;
+      margin: 0;
+      padding: 0;
       a {
         margin: 10px 0 0;
         border-radius: 0;


### PR DESCRIPTION
I think this was a side effect of the navigation overhaul from last summer. It inadvertently added a bunch of padding around the tabs in the stage details section.

Currently, it looks like this:
<img width="508" alt="Screen Shot 2021-06-01 at 4 51 25 PM" src="https://user-images.githubusercontent.com/73450/120403921-12536580-c2fa-11eb-850e-d402d4092872.png">

With this PR, it looks like this, which is what I think it looked like before:
<img width="506" alt="Screen Shot 2021-06-01 at 4 51 12 PM" src="https://user-images.githubusercontent.com/73450/120403934-1bdccd80-c2fa-11eb-8adb-9d3115ecb6e0.png">

This is minor (guessing nobody else noticed and it's been like this for ~11 months now) and CSS is a nightmare, so it's understandable it broke.