### PR TITLE
refactor(build): Fix paths for rollup

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/multipleInstanceTypesSubSection.less
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/multipleInstanceTypesSubSection.less
@@ -1,4 +1,4 @@
-@import '~bootstrap/less/mixins/clearfix.less';
+@import 'bootstrap/less/mixins/clearfix.less';
 
 .multiple-instance-types-subsection {
   a.subsection-heading {

--- a/app/scripts/modules/core/src/pipeline/config/stages/templates/index.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/templates/index.ts
@@ -1,3 +1,3 @@
 export const PipelineTemplates = {
-  addExtendedAttributes: require('core/pipeline/config/stages/bake/modal/addExtendedAttribute.html'),
+  addExtendedAttributes: require('../bake/modal/addExtendedAttribute.html'),
 };

--- a/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -155,7 +155,7 @@ export class TitusServerGroupConfigurationService {
     };
   }
 
-  public configureCommand(cmd: ITitusServerGroupCommand) {
+  public configureCommand(cmd: ITitusServerGroupCommand): PromiseLike<void> {
     cmd.viewState.accountChangedStream = new Subject();
     cmd.viewState.regionChangedStream = new Subject();
     cmd.viewState.groupsRemovedStream = new Subject();


### PR DESCRIPTION
There's some issues when migrating packages to have their own dependency and using rollup. This fix is going to make it smoother to introduce rollup and other changes in a much simpler PR.
