### PR TITLE
fix(md): properly redirect the old ui links to the new ui

### DIFF
--- a/app/scripts/modules/core/src/managed/managed.states.ts
+++ b/app/scripts/modules/core/src/managed/managed.states.ts
@@ -80,12 +80,7 @@ module(MANAGED_STATES, [APPLICATION_STATE_PROVIDER]).config([
         children: [],
         redirectTo: (transition) => {
           if (isNewUI()) {
-            return {
-              state: 'home.applications.application.environments.history',
-              params: {
-                version: transition.params().version,
-              },
-            };
+            return transition.targetState().withState('home.applications.application.environments.history');
           }
           return undefined;
         },
@@ -103,9 +98,9 @@ module(MANAGED_STATES, [APPLICATION_STATE_PROVIDER]).config([
           },
         },
         children: [artifactVersion, ...routes],
-        redirectTo: () => {
+        redirectTo: (transition) => {
           if (isNewUI()) {
-            return 'home.applications.application.environments.overview';
+            return transition.targetState().withState('home.applications.application.environments.overview');
           }
           return undefined;
         },


### PR DESCRIPTION
The previous solution was dropping the application param and therefore failed to work in some cases