### PR TITLE
feat(md): improve error handling for non-managed applications

### DIFF
--- a/app/scripts/modules/core/src/managed/ApplicationQueryError.tsx
+++ b/app/scripts/modules/core/src/managed/ApplicationQueryError.tsx
@@ -1,0 +1,21 @@
+import { ApolloError } from '@apollo/client';
+import React from 'react';
+import { UnmanagedMessage } from './UnmanagedMessage';
+
+interface IApplicationQueryErrorProps {
+  hasApplicationData: boolean;
+  error: ApolloError;
+}
+
+export const ApplicationQueryError = ({ hasApplicationData, error }: IApplicationQueryErrorProps) => {
+  if (!hasApplicationData) {
+    return <UnmanagedMessage />;
+  }
+  console.warn(error);
+  return (
+    <div style={{ width: '100%' }}>
+      Failed to load environments data, please refresh and try again.
+      <p>{error.message}</p>
+    </div>
+  );
+};

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -3,13 +3,13 @@ import { isEqual, keyBy, pick } from 'lodash';
 import React, { useMemo } from 'react';
 import { animated, useTransition } from 'react-spring';
 
-import { SETTINGS } from 'core/config/settings';
 import { Spinner } from 'core/widgets';
 
 import { ColumnHeader } from './ColumnHeader';
 import { Environments2, getIsNewUI, UISwitcher } from './Environments2';
 import { EnvironmentsHeader } from './EnvironmentsHeader';
 import { EnvironmentsList } from './EnvironmentsList';
+import { UnmanagedMessage } from './UnmanagedMessage';
 import { Application, ApplicationDataSource } from '../application';
 import { ArtifactDetail } from './artifactDetail/ArtifactDetail';
 import { ArtifactsList } from './artifactsList/ArtifactsList';
@@ -17,8 +17,6 @@ import { IManagedApplicationEnvironmentSummary, IManagedResourceSummary } from '
 import { useDataSource } from '../presentation/hooks';
 
 import './Environments.less';
-
-const defaultGettingStartedUrl = 'https://www.spinnaker.io/guides/user/managed-delivery/getting-started/';
 
 const paneSpring = { mass: 1, tension: 400, friction: 40 };
 
@@ -136,17 +134,8 @@ export const EnvironmentsOld: React.FC<IEnvironmentsProps> = ({ app }) => {
   }
 
   const unmanaged = loaded && artifacts.length == 0 && resources.length == 0;
-  const gettingStartedLink = SETTINGS.managedDelivery?.gettingStartedUrl || defaultGettingStartedUrl;
   if (unmanaged) {
-    return (
-      <div style={{ width: '100%' }}>
-        Welcome! This application does not have any environments or artifacts. Check out the{' '}
-        <a href={gettingStartedLink} target="_blank">
-          getting started guide
-        </a>{' '}
-        to set some up!
-      </div>
-    );
+    return <UnmanagedMessage />;
   }
 
   return (

--- a/app/scripts/modules/core/src/managed/UnmanagedMessage.tsx
+++ b/app/scripts/modules/core/src/managed/UnmanagedMessage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { SETTINGS } from 'core/config';
+
+const defaultGettingStartedUrl = 'https://www.spinnaker.io/guides/user/managed-delivery/getting-started/';
+
+export const UnmanagedMessage = () => {
+  const gettingStartedLink = SETTINGS.managedDelivery?.gettingStartedUrl || defaultGettingStartedUrl;
+  return (
+    <div style={{ width: '100%' }}>
+      Welcome! This application does not have any environments or artifacts. Check out the{' '}
+      <a href={gettingStartedLink} target="_blank">
+        getting started guide
+      </a>{' '}
+      to set some up!
+    </div>
+  );
+};

--- a/app/scripts/modules/core/src/managed/config/Configuration.tsx
+++ b/app/scripts/modules/core/src/managed/config/Configuration.tsx
@@ -5,6 +5,7 @@ import { Illustration } from '@spinnaker/presentation';
 import { showModal, useApplicationContextSafe } from 'core/presentation';
 import { Spinner } from 'core/widgets';
 
+import { ApplicationQueryError } from '../ApplicationQueryError';
 import { DeliveryConfig } from './DeliveryConfig';
 import { useFetchApplicationManagementStatusQuery, useToggleManagementMutation } from '../graphql/graphql-sdk';
 import spinner from '../overview/loadingIndicator.svg';
@@ -40,7 +41,7 @@ const ManagementToggle = () => {
   const app = useApplicationContextSafe();
   const appName = app.name;
   const logEvent = useLogEvent('Management');
-  const { data, loading, refetch } = useFetchApplicationManagementStatusQuery({ variables: { appName } });
+  const { data, error, loading, refetch } = useFetchApplicationManagementStatusQuery({ variables: { appName } });
   const [toggleManagement, { loading: mutationInFlight }] = useToggleManagementMutation();
 
   const onShowToggleManagementModal = React.useCallback((shouldPause: boolean) => {
@@ -64,11 +65,12 @@ const ManagementToggle = () => {
   if (loading) {
     return <Spinner {...spinnerProps} message="Loading settings..." />;
   }
-  if (!data) {
-    return <div>Failed to load app config</div>;
+
+  if (error) {
+    return <ApplicationQueryError hasApplicationData={Boolean(data?.application)} error={error} />;
   }
 
-  const isPaused = Boolean(data.application?.isPaused);
+  const isPaused = Boolean(data?.application?.isPaused);
   const state = managementStatusToContent[isPaused ? 'PAUSED' : 'ENABLED'];
 
   return (

--- a/app/scripts/modules/core/src/managed/overview/EnvironmentsOverview.tsx
+++ b/app/scripts/modules/core/src/managed/overview/EnvironmentsOverview.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useApplicationContextSafe } from 'core/presentation';
 import { Spinner } from 'core/widgets';
 
+import { ApplicationQueryError } from '../ApplicationQueryError';
 import { EnvironmentOverview } from './EnvironmentOverview';
 import { ManagementWarning } from '../config/ManagementWarning';
 import { EnvironmentsRender, useOrderedEnvironment } from '../environmentBaseElements/EnvironmentsRender';
@@ -35,12 +36,7 @@ export const EnvironmentsOverview = () => {
     content = <Spinner {...spinnerProps} message="Loading environments..." />;
   } else if (error) {
     console.error(error);
-    content = (
-      <div style={{ width: '100%' }}>
-        Failed to load environments data, please refresh and try again.
-        <p>{error.message}</p>
-      </div>
-    );
+    content = <ApplicationQueryError hasApplicationData={Boolean(data?.application)} error={error} />;
   } else {
     content = (
       <>

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionsHistory.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { CollapsibleSection, useApplicationContextSafe } from 'core/presentation';
 import { Spinner } from 'core/widgets';
 
+import { ApplicationQueryError } from '../ApplicationQueryError';
 import { VersionContent } from './VersionContent';
 import { VersionHeading } from './VersionHeading';
 import { ManagementWarning } from '../config/ManagementWarning';
@@ -116,8 +117,7 @@ export const VersionsHistory = () => {
   }
 
   if (error) {
-    console.warn(error);
-    return <div style={{ width: '100%' }}>Failed to load history, please refresh and try again.</div>;
+    return <ApplicationQueryError hasApplicationData={Boolean(data?.application)} error={error} />;
   }
 
   const groupedVersions = groupVersionsByShaOrBuild(data?.application?.environments || [], params);


### PR DESCRIPTION
I originally wanted to consolidate this error handling to the `Environments` component, but I had some issues with removing the `UIView`, and this solution gives us more flexibility anyway. We might want to revisit it again in the future 