### PR TITLE
chore(core): Export TaskMonitorWrapper

### DIFF
--- a/app/scripts/modules/core/src/confirmationModal/ConfirmModal.tsx
+++ b/app/scripts/modules/core/src/confirmationModal/ConfirmModal.tsx
@@ -4,8 +4,7 @@ import { Modal } from 'react-bootstrap';
 import { PlatformHealthOverride } from 'core/application/modal/PlatformHealthOverride';
 import { ModalClose } from 'core/modal';
 import { IModalComponentProps, Markdown, useEscapeKeyPressed } from 'core/presentation';
-import { NgReact } from 'core/reactShims';
-import { TaskMonitor, TaskReason, UserVerification } from 'core/task';
+import { TaskMonitor, TaskMonitorWrapper, TaskReason, UserVerification } from 'core/task';
 import { MultiTaskMonitor } from 'core/task/monitor/MultiTaskMonitor';
 import { Spinner } from 'core/widgets/spinners/Spinner';
 
@@ -78,7 +77,6 @@ export const ConfirmModal = (props: IConfirmModalProps) => {
     }
   };
 
-  const { TaskMonitorWrapper } = NgReact;
   const showReasonInput = ((taskMonitor || taskMonitors) && props.askForReason) || props.submitJustWithReason;
   const showBody =
     (isRetry && props.retryBody) ||

--- a/app/scripts/modules/core/src/entityTag/EntityTagEditor.tsx
+++ b/app/scripts/modules/core/src/entityTag/EntityTagEditor.tsx
@@ -15,8 +15,7 @@ import {
   SpinFormik,
   TextAreaInput,
 } from 'core/presentation';
-import { NgReact } from 'core/reactShims';
-import { TaskMonitor } from 'core/task';
+import { TaskMonitor, TaskMonitorWrapper } from 'core/task';
 import { noop, UUIDGenerator } from 'core/utils';
 
 import { EntityRefBuilder } from './entityRef.builder';
@@ -137,8 +136,6 @@ export class EntityTagEditor extends React.Component<IEntityTagEditorProps, IEnt
     const ownerOptions = opts || [];
 
     const submitLabel = `${isNew ? ' Create' : ' Update'} ${tag.value.type}`;
-
-    const { TaskMonitorWrapper } = NgReact;
 
     return (
       <div>

--- a/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 import { Modal } from 'react-bootstrap';
 
 import { SpinFormik } from 'core/presentation';
-import { NgReact } from 'core/reactShims';
-import { TaskMonitor } from 'core/task';
+import { TaskMonitor, TaskMonitorWrapper } from 'core/task';
 import { Spinner } from 'core/widgets';
 
 import { WizardPage } from './WizardPage';
@@ -133,7 +132,6 @@ export class WizardModal<T = {}>
       dismissModal,
     } = this.props;
     const { currentPage, initialized, pages } = this.state;
-    const { TaskMonitorWrapper } = NgReact;
 
     const spinner = (
       <div className="row">

--- a/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
@@ -5,8 +5,8 @@ import { Button, Modal } from 'react-bootstrap';
 import { Application, ApplicationModelBuilder } from 'core/application';
 import { SETTINGS } from 'core/config';
 import { SubmitButton } from 'core/modal';
-import { NgReact, ReactInjector } from 'core/reactShims';
-import { TaskMonitor } from 'core/task';
+import { ReactInjector } from 'core/reactShims';
+import { TaskMonitor, TaskMonitorWrapper } from 'core/task';
 
 import { IPageButtonProps } from './PageButton';
 import { IPagerDutyService } from './pagerDuty.read.service';
@@ -111,8 +111,6 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
 
   public render() {
     const formValid = true;
-
-    const { TaskMonitorWrapper } = NgReact;
     const { services } = this.props;
     const { accountName, details, pageCount, subject, submitting, taskMonitor } = this.state;
 

--- a/app/scripts/modules/core/src/task/index.ts
+++ b/app/scripts/modules/core/src/task/index.ts
@@ -1,5 +1,6 @@
 export * from './PlatformHealthOverrideMessage';
 export * from './monitor/TaskMonitor';
+export * from './monitor/TaskMonitorWrapper';
 export * from './modal/TaskReason';
 export * from './modal/TaskMonitorModal';
 export * from './task.read.service';

--- a/app/scripts/modules/core/src/task/modal/TaskMonitorModal.tsx
+++ b/app/scripts/modules/core/src/task/modal/TaskMonitorModal.tsx
@@ -5,9 +5,9 @@ import { Modal } from 'react-bootstrap';
 import { Application } from 'core/application';
 import { ModalClose, SubmitButton } from 'core/modal';
 import { IModalComponentProps, LayoutProvider, ResponsiveFieldLayout, SpinFormik } from 'core/presentation';
-import { NgReact } from 'core/reactShims';
 
 import { TaskMonitor } from '../monitor/TaskMonitor';
+import { TaskMonitorWrapper } from '../monitor/TaskMonitorWrapper';
 import { ITaskCommand, TaskExecutor } from '../taskExecutor';
 
 interface ITaskMonitorModalProps<T> extends IModalComponentProps {
@@ -66,7 +66,6 @@ export class TaskMonitorModal<T> extends React.Component<ITaskMonitorModalProps<
 
   public render() {
     const { isSubmitting } = this.state;
-    const { TaskMonitorWrapper } = NgReact;
 
     return (
       <div>


### PR DESCRIPTION
- Exports `TaskMonitorWrapper`
- Moves `core` imports of this component from NgReact to the new import
