### PR TITLE
feat(build): Add custom rollup config for core

### DIFF
--- a/app/scripts/modules/core/rollup.config.js
+++ b/app/scripts/modules/core/rollup.config.js
@@ -1,0 +1,48 @@
+import alias from '@rollup/plugin-alias';
+import fs from 'fs';
+import path from 'path';
+import copy from 'rollup-plugin-copy';
+
+import baseRollupConfig from '@spinnaker/scripts/config/rollup.config.base.module';
+import externalConfigurer from '@spinnaker/scripts/helpers/rollup-node-auto-external-configurer';
+
+const packageJSON = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+const externals = {
+  ...packageJSON.dependencies,
+  'root/version': true,
+};
+
+// In index.ts, the triple slash reference to global namespace types get re-written to match the 'core' alias
+// This kludge re-re-writes them back to a relative path
+// Likely related to https://github.com/microsoft/TypeScript/issues/36763
+const fixTSPathRewrite = () => {
+  return {
+    name: 'fixTSPathRewrite',
+    writeBundle: () => {
+      const dts = path.join(__dirname, 'dist', 'index.d.ts');
+      const fixed = fs
+        .readFileSync(dts)
+        .toString()
+        .replace(/types="core\/types"/, 'types="./types"');
+      fs.writeFileSync(dts, fixed);
+    },
+  };
+};
+
+export default {
+  ...baseRollupConfig,
+  plugins: [
+    ...baseRollupConfig.plugins,
+    alias({
+      entries: [{ find: 'root', replacement: path.join(__dirname, '../../../../') }],
+    }),
+    // `core` has some custom type declarations for `promise` and `svg` that needs to be bundled together in the
+    // distribution. These custom type declarations are not automatically copied over by typescript, so needs to be
+    // explicitly copied here.
+    copy({
+      targets: [{ src: 'src/types/**/*', dest: 'dist/types' }],
+    }),
+    fixTSPathRewrite(),
+  ],
+  external: externalConfigurer(externals),
+};


### PR DESCRIPTION
Depends on https://github.com/spinnaker/deck/pull/9295

The `core` package has some unique characteristics that need a custom rollup config file rather than using the generic one from `@spinnaker/scripts`. This includes

- copying over typescript definition files
- defining an alias mapping for `root`
- a plugin to fix typescript's path auto-rewrites.