### PR TITLE
feat(md): Preview environments v0

### DIFF
--- a/app/scripts/modules/core/src/managed/graphql/graphql-sdk.ts
+++ b/app/scripts/modules/core/src/managed/graphql/graphql-sdk.ts
@@ -135,6 +135,7 @@ export interface MdEnvironment {
   id: Scalars['String'];
   name: Scalars['String'];
   state: MdEnvironmentState;
+  isPreview?: Maybe<Scalars['Boolean']>;
 }
 
 export interface MdEnvironmentState {
@@ -374,7 +375,7 @@ export type FetchApplicationQuery = { __typename?: 'Query' } & {
   application?: Maybe<
     { __typename?: 'MdApplication' } & Pick<MdApplication, 'id' | 'name' | 'account'> & {
         environments: Array<
-          { __typename?: 'MdEnvironment' } & Pick<MdEnvironment, 'id' | 'name'> & {
+          { __typename?: 'MdEnvironment' } & Pick<MdEnvironment, 'id' | 'name' | 'isPreview'> & {
               state: { __typename?: 'MdEnvironmentState' } & Pick<MdEnvironmentState, 'id'> & {
                   artifacts?: Maybe<
                     Array<
@@ -677,6 +678,7 @@ export const FetchApplicationDocument = gql`
       environments {
         id
         name
+        isPreview
         state {
           id
           artifacts {

--- a/app/scripts/modules/core/src/managed/graphql/schema.graphql
+++ b/app/scripts/modules/core/src/managed/graphql/schema.graphql
@@ -17,6 +17,7 @@ type MdEnvironment {
   id: String!
   name: String!
   state: MdEnvironmentState!
+  isPreview: Boolean
 }
 
 type MdEnvironmentState {

--- a/app/scripts/modules/core/src/managed/overview/EnvironmentOverview.tsx
+++ b/app/scripts/modules/core/src/managed/overview/EnvironmentOverview.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import { CollapsibleSection, ICollapsibleSectionProps, useApplicationContextSafe } from 'core/presentation';
+
+import { Resource } from './Resource';
+import { Artifact } from './artifact/Artifact';
+import { BaseEnvironment } from '../environmentBaseElements/BaseEnvironment';
+import { useFetchResourceStatusQuery } from '../graphql/graphql-sdk';
+import { QueryEnvironment } from './types';
+
+const sectionProps: Partial<ICollapsibleSectionProps> = {
+  outerDivClassName: 'environment-section',
+  headingClassName: 'environment-section-heading',
+  bodyClassName: 'environment-section-body',
+};
+
+interface IEnvironmentProps {
+  environment: QueryEnvironment;
+}
+
+export const EnvironmentOverview = ({ environment }: IEnvironmentProps) => {
+  const app = useApplicationContextSafe();
+  const { data } = useFetchResourceStatusQuery({ variables: { appName: app.name } });
+  const resources = data?.application?.environments.find((env) => env.name === environment.name)?.state.resources;
+  const hasResourcesWithIssues = resources?.some((resource) => resource.state?.status !== 'UP_TO_DATE');
+  const state = environment.state;
+  return (
+    <BaseEnvironment title={environment.name}>
+      <CollapsibleSection heading="Artifacts" {...sectionProps} defaultExpanded enableCaching={false}>
+        {state.artifacts?.length ? (
+          state.artifacts.map((artifact) => <Artifact key={artifact.reference} artifact={artifact} />)
+        ) : (
+          <ErrorMessage>No artifacts found</ErrorMessage>
+        )}
+      </CollapsibleSection>
+      <CollapsibleSection
+        heading="Resources"
+        key={`resources-section-${Boolean(data)}`} // This is used remount the section for defaultExpanded to work
+        {...sectionProps}
+        enableCaching={false}
+        defaultExpanded={hasResourcesWithIssues}
+      >
+        {state.resources?.length ? (
+          state.resources.map((resource) => (
+            <Resource key={resource.id} resource={resource} environment={environment.name} />
+          ))
+        ) : (
+          <ErrorMessage>No resources found</ErrorMessage>
+        )}
+      </CollapsibleSection>
+    </BaseEnvironment>
+  );
+};
+
+const ErrorMessage: React.FC = ({ children }) => (
+  <div className="environment-row-element">
+    <div className="error-message">{children}</div>
+  </div>
+);

--- a/app/scripts/modules/core/src/managed/overview/queries.graphql
+++ b/app/scripts/modules/core/src/managed/overview/queries.graphql
@@ -84,6 +84,7 @@ query fetchApplication($appName: String!, $statuses: [MdArtifactStatusInEnvironm
     environments {
       id
       name
+      isPreview
       state {
         id
         artifacts {

--- a/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
+++ b/app/scripts/modules/core/src/managed/versionsHistory/VersionContent.tsx
@@ -5,7 +5,7 @@ import { useApplicationContextSafe } from 'core/presentation';
 
 import { BaseEnvironment } from '../environmentBaseElements/BaseEnvironment';
 import { EnvironmentItem } from '../environmentBaseElements/EnvironmentItem';
-import { EnvironmentsRender } from '../environmentBaseElements/EnvironmentsRender';
+import { EnvironmentsRender, useOrderedEnvironment } from '../environmentBaseElements/EnvironmentsRender';
 import { useFetchVersionQuery } from '../graphql/graphql-sdk';
 import { ArtifactVersionTasks } from '../overview/artifact/ArtifactVersionTasks';
 import { Constraints } from '../overview/artifact/Constraints';
@@ -95,9 +95,11 @@ interface IVersionContentProps {
 }
 
 export const VersionContent = ({ versionData, pinnedVersions }: IVersionContentProps) => {
+  const ref = React.useRef<HTMLDivElement | null>(null);
+  const { environments, ...renderProps } = useOrderedEnvironment(ref, Object.entries(versionData.environments));
   return (
-    <EnvironmentsRender>
-      {Object.entries(versionData.environments).map(([env, { versions }]) => {
+    <EnvironmentsRender {...renderProps} ref={ref}>
+      {environments.map(([env, { versions }]) => {
         return (
           <BaseEnvironment key={env} title={env} size="small">
             {versions.map((version) => (

--- a/app/scripts/modules/core/src/presentation/hooks/useDimensions.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useDimensions.hook.ts
@@ -7,7 +7,7 @@ const getElementDimensions = (ref: React.RefObject<HTMLElement>) =>
 export const useDimensions = (
   ref: React.RefObject<HTMLElement>,
   {
-    delay = 200,
+    delay = 100,
     isActive = true,
   }: {
     delay?: number;
@@ -17,9 +17,13 @@ export const useDimensions = (
   const [dimension, setDimension] = React.useState(getElementDimensions(ref));
 
   React.useLayoutEffect(() => {
-    const debouncedResizeHandler = debounce(() => {
-      setDimension(getElementDimensions(ref));
-    }, delay);
+    const debouncedResizeHandler = debounce(
+      () => {
+        setDimension(getElementDimensions(ref));
+      },
+      delay,
+      { leading: true },
+    );
 
     if (isActive && ref.current) {
       const observer = new ResizeObserver(debouncedResizeHandler);

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1288,6 +1288,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "isPreview",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fortawesome/fontawesome-free": "^5.4.1",
     "@spinnaker/kayenta": "2.0.0",
     "@spinnaker/presentation": "0.0.8",
-    "@spinnaker/styleguide": "1.0.24",
+    "@spinnaker/styleguide": "1.0.26",
     "@uirouter/react-hybrid": "1.0.2",
     "@uirouter/rx": "0.6.5",
     "@uirouter/visualizer": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3258,10 +3258,10 @@
   dependencies:
     formik "^1.4.1"
 
-"@spinnaker/styleguide@1.0.24":
-  version "1.0.24"
-  resolved "https://registry.yarnpkg.com/@spinnaker/styleguide/-/styleguide-1.0.24.tgz#86d76dbbe5050d423279fe747a72cf3aa4780e39"
-  integrity sha512-TC2B06f9OOR+oqEE4d2YTwtHvMi5vmd+3S8vVKr5lneuqBRygmqbViwhEk38F+yxYQN93+Ent4Iw4O1O0Ss9vQ==
+"@spinnaker/styleguide@1.0.26":
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/@spinnaker/styleguide/-/styleguide-1.0.26.tgz#a0780c8491406881cc4088b379c06618ca446136"
+  integrity sha512-iFUv+qKwiqFYAXi2YRhoyblS4Re+q66ED+slYXMoQzrqLyrp4TV4LqxDgsWdsPi4LbEWOn8JjHbV20KcNFjE4w==
 
 "@storybook/addon-actions@6.0.21":
   version "6.0.21"


### PR DESCRIPTION
This PR adds support for preview environments on the overview page. 
To do that, I refactored the code a bit and added `useOrderedEnvironment` to handle the sorting better. 
I also renamed the directions to `DIRECTIONS = ['listView', 'gridView']`. This means that users will have to set their setting again, but it's not a big deal imo...