### PR TITLE
feat(build): Add support for stripping during bundling

### DIFF
--- a/packages/scripts/config/rollup.config.base.module.js
+++ b/packages/scripts/config/rollup.config.base.module.js
@@ -3,6 +3,7 @@ const path = require('path');
 const baseRollupConfig = require('./rollup.config.base');
 const angularJsTemplateLoader = require('../helpers/rollup-plugin-angularjs-template-loader');
 const externalConfigurer = require('../helpers/rollup-node-auto-external-configurer');
+const stripCode = require('rollup-plugin-strip-code');
 
 const packageJSON = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8'));
 
@@ -10,6 +11,13 @@ module.exports = {
   ...baseRollupConfig,
   input: 'src/index.ts',
   output: [{ dir: 'dist', format: 'es', sourcemap: true }],
-  plugins: [...baseRollupConfig.plugins, angularJsTemplateLoader({ sourceMap: true })],
+  plugins: [
+    ...baseRollupConfig.plugins,
+    angularJsTemplateLoader({ sourceMap: true }),
+    stripCode({
+      start_comment: 'Start - Rollup Remove',
+      end_comment: 'End - Rollup Remove',
+    }),
+  ],
   external: externalConfigurer(packageJSON.dependencies),
 };

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/scripts",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "",
   "main": "index.js",
   "bin": {
@@ -23,13 +23,14 @@
     "autoprefixer": "^7.1.2",
     "chalk": "^4.1.1",
     "ora": "^5.4.0",
-    "postcss-colorfix": "0.0.4",
+    "postcss-colorfix": "0.0.5",
     "postcss-nested": "^4.2.1",
     "postcss-url": "9.0.0",
     "rollup": "^2.35.1",
     "rollup-plugin-external-globals": "0.6.1",
     "rollup-plugin-less": "1.1.3",
     "rollup-plugin-postcss": "3.1.8",
+    "rollup-plugin-strip-code": "^0.2.7",
     "rollup-plugin-terser": "7.0.2",
     "rollup-plugin-visualizer": "5.4.1",
     "yalc": "^1.0.0-pre.53",

--- a/packages/scripts/yarn.lock
+++ b/packages/scripts/yarn.lock
@@ -2553,6 +2553,13 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+magic-string@0.25.3:
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.3.tgz#34b8d2a2c7fec9d9bdf9929a3fd81d271ef35be9"
+  integrity sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -2875,10 +2882,10 @@ postcss-calc@^7.0.1:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.0.2"
 
-postcss-colorfix@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-colorfix/-/postcss-colorfix-0.0.4.tgz#8ba1476eee8a6eefbb7cbc019cd8c504d52acd5a"
-  integrity sha1-i6FHbu6Kbu+7fLwBnNjFBNUqzVo=
+postcss-colorfix@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-colorfix/-/postcss-colorfix-0.0.5.tgz#85dc6a8554a63a945668b5c732822f461d60c01d"
+  integrity sha512-DfHF1Tq/3bQxny1/XoDU/IanSEo3abv8YywQUtuIcL6r5NjQKBknQAwQ9IYx3pbRq6iY8Gw2uoHf2kyIoS6dMA==
   dependencies:
     chalk "^2.1.0"
     cssstats "^3.1.0"
@@ -3465,6 +3472,14 @@ rollup-plugin-postcss@3.1.8:
     safe-identifier "^0.4.1"
     style-inject "^0.3.0"
 
+rollup-plugin-strip-code@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-strip-code/-/rollup-plugin-strip-code-0.2.7.tgz#cd2763000475018a02faa0a2fca10a3d76281d96"
+  integrity sha512-+5t9u/VrHPSfiRWWKMVin+KOtFwFak337FAZxeTjxYDjB3DDoHBQRkXHQvBn713eAfW81t41mGuysqsMXiuTjw==
+  dependencies:
+    magic-string "0.25.3"
+    rollup-pluginutils "2.8.1"
+
 rollup-plugin-terser@7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
@@ -3484,6 +3499,13 @@ rollup-plugin-visualizer@5.4.1:
     open "^7.4.2"
     source-map "^0.7.3"
     yargs "^16.2.0"
+
+rollup-pluginutils@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
+  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup-pluginutils@^1.5.1:
   version "1.5.2"


### PR DESCRIPTION
There's some webpack related code in spinnaker packages that are still needed as the codebase is being migrated, but needs to be stripped when bundled through rollup, so adding support for that.