### PR TITLE
fix(build): Emit assets directly to dist folder

### DIFF
--- a/packages/scripts/config/rollup.config.base.js
+++ b/packages/scripts/config/rollup.config.base.js
@@ -29,7 +29,8 @@ const plugins = [
   json(),
   url({
     include: ['**/*.html', '**/*.svg', '**/*.png', '**/*.jp(e)?g', '**/*.gif', '**/*.webp'],
-    fileName: '[dirname][hash][extname]',
+    fileName: '[name][hash][extname]',
+    limit: 24000,
   }),
   // Replace literal string 'process.env.NODE_ENV' with the current NODE_ENV
   replace({

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/scripts",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Having `[dirname]` specified in the output `filename` puts the asset in a new directory named `[dirname]` under the `dist` folder. This gets copied over to the bundled output in netflix's deck distribution, but doesn't get served correctly. In this commit, this is changed so that the asset is emitted directly under `dist` folder.

The `limit` is also increased to allow inlining of images for plugins.