### PR TITLE
chore(package): amazon@0.0.319 core@0.0.599 docker@0.0.80 titus@0.0.187

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.318",
+  "version": "0.0.319",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.598",
+  "version": "0.0.599",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/docker",
   "license": "Apache-2.0",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.186",
+  "version": "0.0.187",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.319

db9f47df6eae4e87319586721c1dc95cc86290a9 chore(bump): Upgrade @spinnaker/scripts

## core@0.0.599

db9f47df6eae4e87319586721c1dc95cc86290a9 chore(bump): Upgrade @spinnaker/scripts
78497fd7e1f948e2310e3588aa7e5b606c337677 feat(md): remove loadingIndicator.svg and use Spinner instead (#9338)

## docker@0.0.80

db9f47df6eae4e87319586721c1dc95cc86290a9 chore(bump): Upgrade @spinnaker/scripts

## titus@0.0.187

db9f47df6eae4e87319586721c1dc95cc86290a9 chore(bump): Upgrade @spinnaker/scripts

PR created via `modules/publish.js`