### PR TITLE
fix(imports): Convert requires to imports

### DIFF
--- a/app/scripts/modules/azure/src/azure.module.ts
+++ b/app/scripts/modules/azure/src/azure.module.ts
@@ -6,6 +6,7 @@ import './help/azure.help';
 import { AZURE_IMAGE_IMAGE_READER } from './image/image.reader';
 import { AZURE_INSTANCE_AZUREINSTANCETYPE_SERVICE } from './instance/azureInstanceType.service';
 import { AZURE_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER } from './instance/details/instance.details.controller';
+import { AzureLoadBalancerChoiceModal } from './loadBalancer/configure/AzureLoadBalancerChoiceModal';
 import { AZURE_LOADBALANCER_CONFIGURE_CREATELOADBALANCER_CONTROLLER } from './loadBalancer/configure/createLoadBalancer.controller';
 import { AZURE_LOADBALANCER_DETAILS_LOADBALANCERDETAIL_CONTROLLER } from './loadBalancer/details/loadBalancerDetail.controller';
 import { AZURE_LOADBALANCER_LOADBALANCER_TRANSFORMER } from './loadBalancer/loadBalancer.transformer';
@@ -85,8 +86,7 @@ module(AZURE_MODULE, [
       detailsController: 'azureLoadBalancerDetailsCtrl',
       createLoadBalancerTemplateUrl: require('./loadBalancer/configure/createLoadBalancer.html'),
       createLoadBalancerController: 'azureCreateLoadBalancerCtrl',
-      CreateLoadBalancerModal: require('./loadBalancer/configure/AzureLoadBalancerChoiceModal')
-        .AzureLoadBalancerChoiceModal,
+      CreateLoadBalancerModal: AzureLoadBalancerChoiceModal,
     },
     securityGroup: {
       transformer: 'azureSecurityGroupTransformer',

--- a/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/azure/src/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -2,12 +2,11 @@
 
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 import { module } from 'angular';
+import _ from 'lodash';
 
 import { AccountService, FirewallLabels, NetworkReader, TaskMonitor } from '@spinnaker/core';
 
 import { AZURE_SECURITYGROUP_SECURITYGROUP_WRITE_SERVICE } from '../securityGroup.write.service';
-
-const _ = require('lodash');
 
 export const AZURE_SECURITYGROUP_CONFIGURE_CREATESECURITYGROUPCTRL = 'spinnaker.azure.securityGroup.create.controller';
 export const name = AZURE_SECURITYGROUP_CONFIGURE_CREATESECURITYGROUPCTRL; // for backwards compatibility

--- a/app/scripts/modules/azure/src/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/azure/src/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const _ = require('lodash');
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 import { module } from 'angular';
+import _ from 'lodash';
 
 import {
   CACHE_INITIALIZER_SERVICE,

--- a/app/scripts/modules/azure/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/azure/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as angular from 'angular';
-const _ = require('lodash');
+import _ from 'lodash';
 
 import { NameUtils } from '@spinnaker/core';
 import { AZURE_IMAGE_IMAGE_READER } from '../../image/image.reader';

--- a/app/scripts/modules/azure/src/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
+++ b/app/scripts/modules/azure/src/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
@@ -7,8 +7,7 @@ import { FirewallLabels, ModalWizard, SERVER_GROUP_WRITER, TaskMonitor } from '@
 
 import { AZURE_SERVERGROUP_SERVERGROUP_TRANSFORMER } from '../../serverGroup.transformer';
 import { AZURE_SERVERGROUP_CONFIGURE_SERVERGROUPCONFIGURATION_SERVICE } from '../serverGroupConfiguration.service';
-
-const Utility = require('../../../utility').default;
+import Utility from '../../../utility';
 
 export const AZURE_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_AZURE_CONTROLLER =
   'spinnaker.azure.cloneServerGroup.controller';

--- a/app/scripts/modules/azure/src/serverGroup/configure/wizard/tags/tagsSelector.directive.js
+++ b/app/scripts/modules/azure/src/serverGroup/configure/wizard/tags/tagsSelector.directive.js
@@ -1,7 +1,8 @@
 'use strict';
 
 import { module } from 'angular';
-const Utility = require('../../../../utility').default;
+
+import Utility from '../../../../utility';
 
 export const AZURE_SERVERGROUP_CONFIGURE_WIZARD_TAGS_TAGSSELECTOR_DIRECTIVE =
   'spinnaker.azure.serverGroup.configure.wizard.tags.directive';

--- a/app/scripts/modules/azure/src/serverGroup/details/serverGroupDetails.azure.controller.js
+++ b/app/scripts/modules/azure/src/serverGroup/details/serverGroupDetails.azure.controller.js
@@ -12,10 +12,9 @@ import {
   ServerGroupWarningMessageService,
 } from '@spinnaker/core';
 
+import '../configure/serverGroup.configure.azure.module';
 import { AZURE_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER_SERVICE } from '../configure/serverGroupCommandBuilder.service';
 import { AzureRollbackServerGroupModal } from './rollback/RollbackServerGroupModal';
-
-require('../configure/serverGroup.configure.azure.module');
 
 export const AZURE_SERVERGROUP_DETAILS_SERVERGROUPDETAILS_AZURE_CONTROLLER =
   'spinnaker.azure.serverGroup.details.controller';

--- a/app/scripts/modules/azure/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/azure/src/serverGroup/serverGroup.transformer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { module } from 'angular';
-const _ = require('lodash');
+import _ from 'lodash';
 
 export const AZURE_SERVERGROUP_SERVERGROUP_TRANSFORMER = 'spinnaker.azure.serverGroup.transformer';
 export const name = AZURE_SERVERGROUP_SERVERGROUP_TRANSFORMER; // for backwards compatibility

--- a/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -19,13 +19,12 @@ import { GOOGLE_COMMON_XPNNAMING_GCE_SERVICE } from 'google/common/xpnNaming.gce
 
 import { GOOGLE_SERVERGROUP_DETAILS_AUTOSCALINGPOLICY_ADDAUTOSCALINGPOLICYBUTTON_COMPONENT } from './autoscalingPolicy/addAutoscalingPolicyButton.component';
 import { GOOGLE_SERVERGROUP_DETAILS_AUTOSCALINGPOLICY_AUTOSCALINGPOLICY_DIRECTIVE } from './autoscalingPolicy/autoscalingPolicy.directive';
+import '../configure/serverGroup.configure.gce.module';
 import { GOOGLE_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER_SERVICE } from '../configure/serverGroupCommandBuilder.service';
 import { GOOGLE_SERVERGROUP_DETAILS_RESIZE_RESIZESERVERGROUP_CONTROLLER } from './resize/resizeServerGroup.controller';
 import { GOOGLE_SERVERGROUP_DETAILS_ROLLBACK_ROLLBACKSERVERGROUP_CONTROLLER } from './rollback/rollbackServerGroup.controller';
 
 import './serverGroupDetails.less';
-
-require('../configure/serverGroup.configure.gce.module');
 
 export const GOOGLE_SERVERGROUP_DETAILS_SERVERGROUPDETAILS_GCE_CONTROLLER =
   'spinnaker.serverGroup.details.gce.controller';

--- a/app/scripts/modules/tencentcloud/src/search/searchResultFormatter.js
+++ b/app/scripts/modules/tencentcloud/src/search/searchResultFormatter.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const angular = require('angular');
+import { module } from 'angular';
 
 export const TENCENTCLOUD_SEARCH_SEARCHRESULTFORMATTER = 'spinnaker.tencentcloud.search.searchResultFormatter';
-angular.module(TENCENTCLOUD_SEARCH_SEARCHRESULTFORMATTER, []).factory('tencentcloudSearchResultFormatter', function () {
+module(TENCENTCLOUD_SEARCH_SEARCHRESULTFORMATTER, []).factory('tencentcloudSearchResultFormatter', function () {
   return {
     securityGroups: function (entry) {},
   };


### PR DESCRIPTION
The build tooling is now changed to rollup and we now prefer using imports over requires for modules. So updating the existing call sites that still use requires.