### PR TITLE
feat(md): ignore allowed-time window

### DIFF
--- a/app/scripts/modules/core/src/managed/constraints/registry.tsx
+++ b/app/scripts/modules/core/src/managed/constraints/registry.tsx
@@ -99,7 +99,7 @@ const baseHandlers: Array<IConstraintHandler<IConstraint['type']>> = [
     overrideActions: {
       FAIL: [
         {
-          title: 'Ignore time window',
+          title: 'Skip constraint',
           pass: true,
         },
       ],

--- a/app/scripts/modules/core/src/managed/constraints/registry.tsx
+++ b/app/scripts/modules/core/src/managed/constraints/registry.tsx
@@ -96,6 +96,14 @@ const baseHandlers: Array<IConstraintHandler<IConstraint['type']>> = [
     iconName: { DEFAULT: 'mdConstraintAllowedTimes' },
     titleRender: AllowedTimesTitle,
     descriptionRender: AllowedTimesDescription,
+    overrideActions: {
+      FAIL: [
+        {
+          title: 'Ignore time window',
+          pass: true,
+        },
+      ],
+    },
   },
   {
     kind: 'depends-on',


### PR DESCRIPTION
Since the `allowed-times` constraint is now stateful, you can override the judgment. This PR adds a little button to the constraint to let you ignore the window. 

Wording options:
`Ignore time window`
`Skip time window`
`Override time window`
`Skip constraint`

Here is what it looks like when it's visible, and when it was overridden.



<img width="677" alt="Screen Shot 2021-06-15 at 1 37 41 PM" src="https://user-images.githubusercontent.com/8454927/122120491-59078c00-cddf-11eb-85a9-74228e9ab969.png">
<img width="688" alt="Screen Shot 2021-06-15 at 1 39 13 PM" src="https://user-images.githubusercontent.com/8454927/122120496-5a38b900-cddf-11eb-9f51-2a04fead4969.png">
