### PR TITLE
fix(core/modal): Make SubmitButton compatible with flex display

### DIFF
--- a/app/scripts/modules/core/src/modal/buttons/SubmitButton.tsx
+++ b/app/scripts/modules/core/src/modal/buttons/SubmitButton.tsx
@@ -28,9 +28,10 @@ export class SubmitButton extends React.Component<ISubmitButtonProps> {
 
     return (
       <button className={className} disabled={isDisabled} onClick={onClick} type={type}>
-        {(!submitting && <i className="far fa-check-circle" />) || <Spinner mode="circular" />}
-        &nbsp;
-        {label || (isNew ? 'Create' : 'Update')}
+        <div className="flex-container-h horizontal middle">
+          {(!submitting && <i className="far fa-check-circle" />) || <Spinner mode="circular" />}
+          <span className="sp-margin-xs-left">{label || (isNew ? 'Create' : 'Update')}</span>
+        </div>
       </button>
     );
   }


### PR DESCRIPTION
Fixing this issue: 
![Screen Shot 2021-06-22 at 12 21 10 PM](https://user-images.githubusercontent.com/26560152/122986526-68915280-d354-11eb-91b3-4dc9b4afb267.png)

Adding `flex-container-h` directly to the `button` really messes up all the angular modal footers. Instead I made a new container within the button that allows the button to be flex and the footer to be compatible with the rest of the modal.
