### PR TITLE
fix(md): only show messages section if not empty

### DIFF
--- a/app/scripts/modules/core/src/managed/config/ManagementWarning.tsx
+++ b/app/scripts/modules/core/src/managed/config/ManagementWarning.tsx
@@ -4,7 +4,7 @@ import { showModal } from 'core/presentation';
 
 import { ResumeManagementModal } from './Configuration';
 import { useFetchApplicationManagementStatusQuery, useToggleManagementMutation } from '../graphql/graphql-sdk';
-import { MessageBox } from '../messages/MessageBox';
+import { MessageBox, MessagesSection } from '../messages/MessageBox';
 import { MODAL_MAX_WIDTH } from '../utils/defaults';
 
 export const ManagementWarning = ({ appName }: { appName: string }) => {
@@ -30,18 +30,20 @@ export const ManagementWarning = ({ appName }: { appName: string }) => {
 
   if (data?.application?.isPaused) {
     return (
-      <MessageBox type="WARNING">
-        Application management is disabled.{' '}
-        <a
-          href="#"
-          onClick={(e) => {
-            e.preventDefault();
-            onClick();
-          }}
-        >
-          Click here to enable
-        </a>
-      </MessageBox>
+      <MessagesSection sticky>
+        <MessageBox type="WARNING">
+          Application management is disabled.{' '}
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              onClick();
+            }}
+          >
+            Click here to enable
+          </a>
+        </MessageBox>
+      </MessagesSection>
     );
   }
   return null;

--- a/app/scripts/modules/core/src/managed/messages/Messages.tsx
+++ b/app/scripts/modules/core/src/managed/messages/Messages.tsx
@@ -44,9 +44,7 @@ export const Messages = () => {
   return (
     <>
       <AppNotifications />
-      <MessagesSection sticky>
-        <ManagementWarning appName={app.name} />
-      </MessagesSection>
+      <ManagementWarning appName={app.name} />
     </>
   );
 };


### PR DESCRIPTION
The previous implementation was showing the bottom border even when there is no warning 