### PR TITLE
fix(core): properly load ReactGA 

### DIFF
--- a/app/scripts/modules/core/src/core.module.ts
+++ b/app/scripts/modules/core/src/core.module.ts
@@ -58,6 +58,8 @@ import { PIPELINE_MODULE } from './pipeline/pipeline.module';
 import { PIPELINE_TEMPLATE_MODULE } from './pipeline/config/templates/pipelineTemplate.module';
 import { PLUGINS_MODULE } from './plugins';
 import { REACT_MODULE } from './reactShims';
+import { initGoogleAnalytics } from './reactShims/react.ga';
+
 import { REGION_MODULE } from './region/region.module';
 import { SERVERGROUP_MODULE } from './serverGroup/serverGroup.module';
 import { SERVER_GROUP_MANAGER_MODULE } from './serverGroupManager/serverGroupManager.module';
@@ -90,6 +92,8 @@ import ANGULAR_SANITIZE from 'angular-sanitize';
 import { angularSpinner } from 'angular-spinner';
 import ANGULAR_UI_BOOTSTRAP from 'angular-ui-bootstrap';
 import UI_SELECT from 'ui-select';
+
+initGoogleAnalytics();
 
 const UI_ROUTER_STATE_EVENTS_SHIM = 'ui.router.state.events';
 export const CORE_MODULE = 'spinnaker.core';

--- a/app/scripts/modules/core/src/reactShims/react.ga.ts
+++ b/app/scripts/modules/core/src/reactShims/react.ga.ts
@@ -3,12 +3,13 @@ import ReactGA from 'react-ga';
 import { SETTINGS } from 'core/config/settings';
 import { logger } from 'core/utils';
 
-if (SETTINGS.analytics.ga) {
-  ReactGA.initialize(SETTINGS.analytics.ga, {});
+export const initGoogleAnalytics = () => {
+  if (!SETTINGS.analytics.ga) return;
+  ReactGA.initialize(SETTINGS.analytics.ga, {}); // We're loading GA twice - here and in angular - but it shouldn't cause any problems
   logger.subscribe({
     key: 'googleAnalytics',
     onEvent: (event) => {
       ReactGA.event({ category: event.category, action: event.action, label: event.data?.label });
     },
   });
-}
+};


### PR DESCRIPTION
We weren't loading ReactGA and relied on angular. As a result, we also skipped subscribing GA to the main logger. 
This means that we load GA twice now - in React and Angular - but it should cause any issues afaik. 

