### PR TITLE
chore(all): Remove ng template cache for webpack

### DIFF
--- a/app/scripts/modules/amazon/src/aws.module.ts
+++ b/app/scripts/modules/amazon/src/aws.module.ts
@@ -71,14 +71,6 @@ import { VPC_MODULE } from './vpc/vpc.module';
 
 import './logo/aws.logo.less';
 
-/* Start - Rollup Remove */
-// load all templates into the $templateCache
-const templates = require.context('./', true, /\.html$/);
-templates.keys().forEach(function (key) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const AMAZON_MODULE = 'spinnaker.amazon';
 module(AMAZON_MODULE, [
   AWS_REACT_MODULE,

--- a/app/scripts/modules/appengine/src/appengine.module.ts
+++ b/app/scripts/modules/appengine/src/appengine.module.ts
@@ -22,13 +22,6 @@ import './validation/ApplicationNameValidator';
 
 import './logo/appengine.logo.less';
 
-/* Start - Rollup Remove */
-const templates = (require as any).context('./', true, /\.html$/);
-templates.keys().forEach(function (key: string) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const APPENGINE_MODULE = 'spinnaker.appengine';
 
 module(APPENGINE_MODULE, [

--- a/app/scripts/modules/azure/src/azure.module.ts
+++ b/app/scripts/modules/azure/src/azure.module.ts
@@ -28,13 +28,6 @@ import { AZURE_VALIDATION_APPLICATIONNAME_VALIDATOR } from './validation/applica
 
 import './logo/azure.logo.less';
 
-/* Start - Rollup Remove */
-const templates = (require as any).context('./', true, /\.html$/);
-templates.keys().forEach(function (key: string) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const AZURE_MODULE = 'spinnaker.azure';
 module(AZURE_MODULE, [
   AZURE_PIPELINE_STAGES_DESTROYASG_AZUREDESTROYASGSTAGE,

--- a/app/scripts/modules/core/src/core.module.ts
+++ b/app/scripts/modules/core/src/core.module.ts
@@ -91,14 +91,6 @@ import { angularSpinner } from 'angular-spinner';
 import ANGULAR_UI_BOOTSTRAP from 'angular-ui-bootstrap';
 import UI_SELECT from 'ui-select';
 
-/* Start - Rollup Remove */
-// load all templates into the $templateCache
-const templates = require.context('./', true, /\.html$/);
-templates.keys().forEach(function (key) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 const UI_ROUTER_STATE_EVENTS_SHIM = 'ui.router.state.events';
 export const CORE_MODULE = 'spinnaker.core';
 module(CORE_MODULE, [

--- a/app/scripts/modules/ecs/src/ecs.module.ts
+++ b/app/scripts/modules/ecs/src/ecs.module.ts
@@ -45,13 +45,6 @@ import { ECS_SERVER_GROUP_TRANSFORMER } from './serverGroup/serverGroup.transfor
 
 import './logo/ecs.logo.less';
 
-/* Start - Rollup Remove */
-const templates = (require as any).context('./', true, /\.html$/);
-templates.keys().forEach(function (key: string) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const ECS_MODULE = 'spinnaker.ecs';
 module(ECS_MODULE, [
   ECS_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_ECS_CONTROLLER,

--- a/app/scripts/modules/google/src/gce.module.ts
+++ b/app/scripts/modules/google/src/gce.module.ts
@@ -52,13 +52,6 @@ import { GOOGLE_VALIDATION_APPLICATIONNAME_VALIDATOR } from './validation/applic
 
 import './logo/gce.logo.less';
 
-/* Start - Rollup Remove */
-const templates = (require as any).context('./', true, /\.html$/);
-templates.keys().forEach(function (key: string) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const GOOGLE_MODULE = 'spinnaker.gce';
 module(GOOGLE_MODULE, [
   LOAD_BALANCER_SET_TRANSFORMER,

--- a/app/scripts/modules/kubernetes/src/kubernetes.module.ts
+++ b/app/scripts/modules/kubernetes/src/kubernetes.module.ts
@@ -51,13 +51,6 @@ import './validation/applicationName.validator';
 
 import './logo/kubernetes.logo.less';
 
-/* Start - Rollup Remove */
-const templates = (require as any).context('./', true, /\.html$/);
-templates.keys().forEach(function (key: string) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const KUBERNETES_MODULE = 'spinnaker.kubernetes';
 
 const requires = [

--- a/app/scripts/modules/oracle/src/oracle.module.ts
+++ b/app/scripts/modules/oracle/src/oracle.module.ts
@@ -25,13 +25,6 @@ import { ORACLE_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_CONTROLLER } from 
 import { ORACLE_SERVERGROUP_DETAILS_SERVERGROUPDETAILS_CONTROLLER } from './serverGroup/details/serverGroupDetails.controller';
 import { ORACLE_SERVERGROUP_SERVERGROUP_TRANSFORMER } from './serverGroup/serverGroup.transformer';
 
-/* Start - Rollup Remove */
-const templates = (require as any).context('./', true, /\.html$/);
-templates.keys().forEach(function (key: string) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const ORACLE_MODULE = 'spinnaker.oracle';
 module(ORACLE_MODULE, [
   // Pipeline

--- a/app/scripts/modules/tencentcloud/src/tencentcloud.module.ts
+++ b/app/scripts/modules/tencentcloud/src/tencentcloud.module.ts
@@ -16,14 +16,6 @@ import { TENCENTCLOUD_REACT_MODULE } from './reactShims/tencentcloud.react.modul
 import { TENCENTCLOUD_SEARCH_SEARCHRESULTFORMATTER } from './search/searchResultFormatter';
 import './validation/ApplicationNameValidator';
 
-/* Start - Rollup Remove */
-// load all templates into the $templateCache
-const templates = (require as any).context('./', true, /\.html$/);
-templates.keys().forEach(function (key: string) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const TENCENTCLOUD_MODULE = 'spinnaker.tencentcloud';
 module(TENCENTCLOUD_MODULE, [TENCENTCLOUD_REACT_MODULE, TENCENTCLOUD_SEARCH_SEARCHRESULTFORMATTER]).config(() => {
   CloudProviderRegistry.registerProvider('tencentcloud', {

--- a/app/scripts/modules/titus/src/titus.module.ts
+++ b/app/scripts/modules/titus/src/titus.module.ts
@@ -30,14 +30,6 @@ import './validation/ApplicationNameValidator';
 
 import './logo/titus.logo.less';
 
-/* Start - Rollup Remove */
-// load all templates into the $templateCache
-const templates = require.context('./', true, /\.html$/);
-templates.keys().forEach(function (key) {
-  templates(key);
-});
-/* End - Rollup Remove */
-
 export const TITUS_MODULE = 'spinnaker.titus';
 module(TITUS_MODULE, [
   TITUS_REACT_MODULE,

--- a/packages/scripts/config/rollup.config.base.module.js
+++ b/packages/scripts/config/rollup.config.base.module.js
@@ -3,7 +3,6 @@ const path = require('path');
 const baseRollupConfig = require('./rollup.config.base');
 const angularJsTemplateLoader = require('../helpers/rollup-plugin-angularjs-template-loader');
 const externalConfigurer = require('../helpers/rollup-node-auto-external-configurer');
-const stripCode = require('rollup-plugin-strip-code');
 
 const packageJSON = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8'));
 
@@ -11,13 +10,6 @@ module.exports = {
   ...baseRollupConfig,
   input: 'src/index.ts',
   output: [{ dir: 'dist', format: 'es', sourcemap: true }],
-  plugins: [
-    ...baseRollupConfig.plugins,
-    angularJsTemplateLoader({ sourceMap: true }),
-    stripCode({
-      start_comment: 'Start - Rollup Remove',
-      end_comment: 'End - Rollup Remove',
-    }),
-  ],
+  plugins: [...baseRollupConfig.plugins, angularJsTemplateLoader({ sourceMap: true })],
   external: externalConfigurer(packageJSON.dependencies),
 };

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -30,7 +30,6 @@
     "rollup-plugin-external-globals": "0.6.1",
     "rollup-plugin-less": "1.1.3",
     "rollup-plugin-postcss": "3.1.8",
-    "rollup-plugin-strip-code": "^0.2.7",
     "rollup-plugin-terser": "7.0.2",
     "rollup-plugin-visualizer": "5.4.1",
     "yalc": "^1.0.0-pre.53",

--- a/packages/scripts/yarn.lock
+++ b/packages/scripts/yarn.lock
@@ -2553,13 +2553,6 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-magic-string@0.25.3:
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.3.tgz#34b8d2a2c7fec9d9bdf9929a3fd81d271ef35be9"
-  integrity sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==
-  dependencies:
-    sourcemap-codec "^1.4.4"
-
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -3472,14 +3465,6 @@ rollup-plugin-postcss@3.1.8:
     safe-identifier "^0.4.1"
     style-inject "^0.3.0"
 
-rollup-plugin-strip-code@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-strip-code/-/rollup-plugin-strip-code-0.2.7.tgz#cd2763000475018a02faa0a2fca10a3d76281d96"
-  integrity sha512-+5t9u/VrHPSfiRWWKMVin+KOtFwFak337FAZxeTjxYDjB3DDoHBQRkXHQvBn713eAfW81t41mGuysqsMXiuTjw==
-  dependencies:
-    magic-string "0.25.3"
-    rollup-pluginutils "2.8.1"
-
 rollup-plugin-terser@7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
@@ -3499,13 +3484,6 @@ rollup-plugin-visualizer@5.4.1:
     open "^7.4.2"
     source-map "^0.7.3"
     yargs "^16.2.0"
-
-rollup-pluginutils@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
-  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
-  dependencies:
-    estree-walker "^0.6.1"
 
 rollup-pluginutils@^1.5.1:
   version "1.5.2"


### PR DESCRIPTION
Ng template caching was needed for webpack when building locally. But now that all packages are migrated to use workspaces, `app` now depends on the build outputs of each package instead which already contains template cache built using rollup.

So removing custom template building for webpack along with removing custom strip code used in rollup.
