### PR TITLE
feat(md): Display the raw delivery config instead of the processed one

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -86,8 +86,12 @@ export class ManagedReader {
     return REST('/managed/application').path(app).query({ entities: 'resources' }).get().then(this.decorateResources);
   }
 
-  public static getDeliveryConfig(app: string): PromiseLike<string> {
+  public static getProcessedDeliveryConfig(app: string): PromiseLike<string> {
     return REST('/managed/application').path(app).path('config').headers({ Accept: 'application/x-yaml' }).get();
+  }
+
+  public static getRawDeliveryConfig(app: string): PromiseLike<string> {
+    return REST('/managed/application').path(app).path('config', 'raw').headers({ Accept: 'application/x-yaml' }).get();
   }
 
   public static getEnvironmentsSummary(app: string): PromiseLike<IManagedApplicationSummary> {

--- a/app/scripts/modules/core/src/managed/config/DeliveryConfig.tsx
+++ b/app/scripts/modules/core/src/managed/config/DeliveryConfig.tsx
@@ -6,9 +6,39 @@ import { useApplicationContextSafe, useData } from 'core/presentation';
 import { ManagedReader } from '..';
 import { useLogEvent } from '../utils/logging';
 
+const DeliveryConfigContentRenderer = ({ content }: { content: string }) => {
+  return (
+    <AceEditor
+      mode="yaml"
+      theme="textmate"
+      readOnly
+      fontSize={12}
+      cursorStart={0}
+      showPrintMargin={false}
+      highlightActiveLine={true}
+      maxLines={Infinity}
+      value={content}
+      setOptions={{
+        firstLineNumber: 1,
+        tabSize: 2,
+        showLineNumbers: true,
+        showFoldWidgets: true,
+      }}
+      style={{ width: 'auto' }}
+      className="ace-editor sp-margin-s-top"
+      editorProps={{ $blockScrolling: true }}
+      onLoad={(editor) => {
+        // This removes the built-in search box (as it doesn't scroll properly to matches)
+        // commands is missing in the type def and therefore we have to cast as any
+        (editor as any).commands?.removeCommand('find');
+      }}
+    />
+  );
+};
+
 export const DeliveryConfig = () => {
   const app = useApplicationContextSafe();
-  const { result, error, status } = useData(() => ManagedReader.getDeliveryConfig(app.name), undefined, [app]);
+  const { result, error, status } = useData(() => ManagedReader.getRawDeliveryConfig(app.name), undefined, [app]);
   const logError = useLogEvent('DeliveryConfig');
   React.useEffect(() => {
     if (error) {
@@ -24,35 +54,7 @@ export const DeliveryConfig = () => {
           <div>
             <h4>Delivery Config</h4>
           </div>
-          <small>
-            Note: The information below is derived from the delivery config that was sent to Spinnaker and is not
-            necessarily identical to it.
-          </small>
-          <AceEditor
-            mode="yaml"
-            theme="textmate"
-            readOnly
-            fontSize={12}
-            cursorStart={0}
-            showPrintMargin={false}
-            highlightActiveLine={true}
-            maxLines={Infinity}
-            value={result}
-            setOptions={{
-              firstLineNumber: 1,
-              tabSize: 2,
-              showLineNumbers: true,
-              showFoldWidgets: true,
-            }}
-            style={{ width: 'auto' }}
-            className="ace-editor sp-margin-s-top"
-            editorProps={{ $blockScrolling: true }}
-            onLoad={(editor) => {
-              // This removes the built-in search box (as it doesn't scroll properly to matches)
-              // commands is missing in the type def and therefore we have to cast as any
-              (editor as any).commands?.removeCommand('find');
-            }}
-          />
+          <DeliveryConfigContentRenderer content={result} />
         </>
       )}
     </div>


### PR DESCRIPTION
The new endpoint returns the delivery config from the app repo instead of the one processed by keel