### PR TITLE
feat(build): Remove 'Build Packages' action in github ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     # Meta-job that depends on the other job statuses.  Branch protection then checks this job status.
     name: Deck CI
     if: startsWith(github.repository, 'spinnaker/')
-    needs: [test, build, functional-tests, packages]
+    needs: [test, build, functional-tests]
     runs-on: ubuntu-latest
     steps:
-      - run: echo test, build, packages successful
+      - run: echo test, build successful
 
   test:
     name: Unit tests
@@ -135,45 +135,3 @@ jobs:
       - name: Yarn Build
         if: steps.purebump.outputs.ispurebump != 'true'
         run: yarn build
-
-  packages:
-    name: Build Packages
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        packages:
-          ['core amazon docker titus', 'appengine azure cloudfoundry', 'ecs oracle', 'google huaweicloud kubernetes']
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Ensure package bumps are pure
-        id: purebump
-        run: app/scripts/modules/assert_package_bumps_standalone.sh
-
-      - uses: actions/setup-node@v1
-        if: steps.purebump.outputs.ispurebump != 'true'
-        with:
-          node-version: ${{ env.NODE_VERSION  }}
-
-      - name: Get yarn cache
-        if: steps.purebump.outputs.ispurebump != 'true'
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        if: steps.purebump.outputs.ispurebump != 'true'
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Dependencies
-        if: steps.purebump.outputs.ispurebump != 'true'
-        run: yarn --frozen-lockfile
-
-      - name: Build NPM Packages
-        if: steps.purebump.outputs.ispurebump != 'true'
-        run: app/scripts/modules/build_modules.sh ${{ matrix.packages }}


### PR DESCRIPTION
With the integration of yarn workspaces, spinnaker package builds are done as part of 'Production Build' github action already and 'Build Packages' action is redundant.

