### PR TITLE
feat(managed-delivery): Add resource deleting status and icon

### DIFF
--- a/app/scripts/modules/core/src/managed/graphql/graphql-sdk.ts
+++ b/app/scripts/modules/core/src/managed/graphql/graphql-sdk.ts
@@ -285,7 +285,7 @@ export interface MdResourceActuationState {
   tasks?: Maybe<Array<MdResourceTask>>;
 }
 
-export type MdResourceActuationStatus = 'PROCESSING' | 'UP_TO_DATE' | 'ERROR' | 'WAITING' | 'NOT_MANAGED';
+export type MdResourceActuationStatus = 'PROCESSING' | 'UP_TO_DATE' | 'ERROR' | 'WAITING' | 'NOT_MANAGED' | 'DELETING';
 
 export interface MdResourceTask {
   __typename?: 'MdResourceTask';

--- a/app/scripts/modules/core/src/managed/graphql/schema.graphql
+++ b/app/scripts/modules/core/src/managed/graphql/schema.graphql
@@ -1,7 +1,7 @@
 scalar InstantTime
 scalar JSON
 
-type Query {
+type Query @extends {
   application(appName: String!): MdApplication
 }
 
@@ -53,11 +53,7 @@ type MdArtifact {
   name: String!
   type: String!
   reference: String!
-  versions(
-    statuses: [MdArtifactStatusInEnvironment!]
-    versions: [String!]
-    limit: Int
-  ): [MdArtifactVersionInEnvironment!]
+  versions(statuses: [MdArtifactStatusInEnvironment!], versions: [String!], limit: Int): [MdArtifactVersionInEnvironment!]
   pinnedVersion: MdPinnedVersion
 }
 
@@ -91,16 +87,16 @@ enum MdLifecycleEventScope {
 }
 
 enum MdLifecycleEventType {
-  BAKE
+  BAKE,
   BUILD
 }
 
 enum MdLifecycleEventStatus {
-  NOT_STARTED
-  RUNNING
-  SUCCEEDED
-  FAILED
-  ABORTED
+  NOT_STARTED,
+  RUNNING,
+  SUCCEEDED,
+  FAILED,
+  ABORTED,
   UNKNOWN
 }
 
@@ -166,6 +162,7 @@ enum MdResourceActuationStatus {
   ERROR
   WAITING
   NOT_MANAGED
+  DELETING
 }
 
 type MdResourceActuationState {
@@ -210,12 +207,12 @@ enum MdConstraintStatus {
 }
 
 enum MdArtifactStatusInEnvironment {
-  PENDING
-  APPROVED
-  DEPLOYING
-  CURRENT
+  PENDING,
+  APPROVED,
+  DEPLOYING,
+  CURRENT,
   PREVIOUS
-  VETOED
+  VETOED,
   SKIPPED
 }
 
@@ -253,7 +250,7 @@ type MdAction {
   actionType: MdActionType!
 }
 
-type Mutation {
+type Mutation @extends {
   updateConstraintStatus(payload: MdConstraintStatusPayload!): Boolean
   toggleManagement(application: String!, isPaused: Boolean!, comment: String): Boolean
   pinArtifactVersion(payload: MdArtifactVersionActionPayload!): Boolean
@@ -317,10 +314,7 @@ type MdNotification {
 }
 
 enum MdEventLevel {
-  SUCCESS
-  INFO
-  WARNING
-  ERROR
+  SUCCESS, INFO, WARNING, ERROR
 }
 
 input MdDismissNotificationPayload {

--- a/app/scripts/modules/core/src/managed/overview/Resource.tsx
+++ b/app/scripts/modules/core/src/managed/overview/Resource.tsx
@@ -25,6 +25,7 @@ const statusUtils: {
   NOT_MANAGED: { color: 'var(--color-status-warning)', icon: 'fas fa-pause', defaultReason: 'Resource is not managed' },
   WAITING: { icon: 'far fa-hourglass', defaultReason: 'Resource is currently locked and can not be updated' },
   PROCESSING: { icon: 'far fa-hourglass', defaultReason: 'Resource is being updated' },
+  DELETING: { icon: 'fas fa-trash-o', defaultReason: 'Resource is being deleted' },
 };
 
 const Status = ({

--- a/app/scripts/modules/core/src/managed/overview/Resource.tsx
+++ b/app/scripts/modules/core/src/managed/overview/Resource.tsx
@@ -25,7 +25,7 @@ const statusUtils: {
   NOT_MANAGED: { color: 'var(--color-status-warning)', icon: 'fas fa-pause', defaultReason: 'Resource is not managed' },
   WAITING: { icon: 'far fa-hourglass', defaultReason: 'Resource is currently locked and can not be updated' },
   PROCESSING: { icon: 'far fa-hourglass', defaultReason: 'Resource is being updated' },
-  DELETING: { icon: 'fas fa-trash-o', defaultReason: 'Resource is being deleted' },
+  DELETING: { icon: 'far fa-trash-can', defaultReason: 'Resource is being deleted' },
 };
 
 const Status = ({


### PR DESCRIPTION
Adds a new `MdResourceActuationStatus` and corresponding icon to represent a resource currently being deleted.