### PR TITLE
fix(amazon/securityGroup): Resolve angular/react modal-body conflict

### DIFF
--- a/packages/amazon/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/packages/amazon/src/securityGroup/details/securityGroupDetail.controller.js
@@ -156,20 +156,24 @@ angular
 
       this.editInboundRules = function editInboundRules() {
         confirmNotManaged($scope.securityGroup, application).then((notManaged) => {
-          notManaged &&
-            $uibModal.open({
-              templateUrl: require('../configure/editSecurityGroup.html'),
-              controller: 'awsEditSecurityGroupCtrl as ctrl',
-              size: 'lg',
-              resolve: {
-                securityGroup: function () {
-                  return angular.copy($scope.securityGroup);
+          // Wait for the MD confirmation modal to go away first to avoid react/angular bootstrap fighting over the body.modal-open class
+          return new Promise((resolve) => setTimeout(resolve, 500)).then(() => {
+            if (notManaged) {
+              $uibModal.open({
+                templateUrl: require('../configure/editSecurityGroup.html'),
+                controller: 'awsEditSecurityGroupCtrl as ctrl',
+                size: 'lg',
+                resolve: {
+                  securityGroup: function () {
+                    return angular.copy($scope.securityGroup);
+                  },
+                  application: function () {
+                    return application;
+                  },
                 },
-                application: function () {
-                  return application;
-                },
-              },
-            });
+              });
+            }
+          });
         });
       };
 


### PR DESCRIPTION
The `body.modal-open` class was not being applied to the angular Edit Security Group modal because it was competing with the React MD confirmation modal. This caused the z-index of everything to be thrown off after the user pauses management. 

The fix is a hack that forces a 500ms wait so the react modal actually closes before the angular one opens. We use this hack for both MD managed Titus and AWS server groups. 

**Problem**
![Screen Shot 2021-07-13 at 2 34 28 PM](https://user-images.githubusercontent.com/26560152/125528469-f7c82eab-d71c-4db8-afe3-22458f172a0c.png)
