### PR TITLE
chore(verbiage): Change verbiage from 'Enable IMDSv2' -> 'Require IMDSv2'

### DIFF
--- a/packages/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettingsCommon.tsx
+++ b/packages/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettingsCommon.tsx
@@ -216,7 +216,7 @@ export class ServerGroupAdvancedSettingsCommon extends React.Component<IServerGr
                   checked={values.requireIMDSv2 === true}
                   onChange={(e) => setFieldValue('requireIMDSv2', e.target.checked)}
                 />{' '}
-                Enable IMDSv2{' '}
+                Require IMDSv2{' '}
               </label>
             </div>
           </div>


### PR DESCRIPTION
Small PR to change IMDSv2 verbiage from "Enable IMDSv2" to "Require IMDSv2"

Context: IMDSv2 is already enabled by default on EC2 instances. Requiring IMDSv2 prevents legacy IMDSv1 calls from being made.