### PR TITLE
fix(release-please): use separate source branch names for app and tools (git symbolic-ref refs/heads/release-please-app refs/head/smaster)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
           release-type: node
           monorepo-tags: true
           command: manifest
+          default-branch: 'release-please-app'
           config-file: '.github/release-please-config.app.json'
           manifest-file: '.github/release-please-manifest.app.json'
           pull-request-title: 'chore${scope}: release${component} app packages ${version}.'
@@ -27,6 +28,7 @@ jobs:
           release-type: node
           monorepo-tags: true
           command: manifest
+          default-branch: 'release-please-tools'
           config-file: '.github/release-please-config.tools.json'
           manifest-file: '.github/release-please-manifest.tools.json'
           pull-request-title: 'chore${scope}: release${component} deck tooling ${version}.'


### PR DESCRIPTION
Release please doesn't support creation of two PRs from the same source branch (master).  I created two aliases to the master branch: `release-please-app` and `release-please-tools` to allow release please to open two separate PRs.

These aliases are [git symbolic refs](https://git-scm.com/docs/git-symbolic-ref) created with the following commands:

```
git symbolic-ref refs/heads/release-please-app refs/heads/master
git symbolic-ref refs/heads/release-please-tools refs/heads/master
git push upstream release-please-app
git push upstream release-please-tools
```

