### PR TITLE
feat(release-please): Consolidate all releases into a single PR

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "bootstrap-sha": "dc32d0249bde99a124787baa40740bd78e9de3a3",
+  "plugins": ["node-workspace"],
   "packages": {
     "packages/amazon": {},
     "packages/appengine": {},
@@ -9,11 +10,15 @@
     "packages/dcos": {},
     "packages/docker": {},
     "packages/ecs": {},
+    "packages/eslint-plugin": {},
     "packages/google": {},
     "packages/huaweicloud": {},
     "packages/kubernetes": {},
     "packages/oracle": {},
+    "packages/pluginsdk": {},
+    "packages/pluginsdk-peerdeps": {},
     "packages/presentation": {},
+    "packages/scripts": {},,
     "packages/tencentcloud": {},
     "packages/titus": {}
   }

--- a/.github/release-please-config.tools.json
+++ b/.github/release-please-config.tools.json
@@ -1,9 +1,0 @@
-{
-  "bootstrap-sha": "dc32d0249bde99a124787baa40740bd78e9de3a3",
-  "packages": {
-    "packages/eslint-plugin": {},
-    "packages/pluginsdk": {},
-    "packages/pluginsdk-peerdeps": {},
-    "packages/scripts": {}
-  }
-}

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -7,11 +7,15 @@
   "packages/dcos": "0.0.2",
   "packages/docker": "0.0.83",
   "packages/ecs": "0.0.292",
+  "packages/eslint-plugin": "1.0.13",
   "packages/google": "0.0.41",
   "packages/huaweicloud": "0.0.14",
   "packages/kubernetes": "0.0.70",
   "packages/oracle": "0.0.26",
+  "packages/pluginsdk": "0.0.32",
+  "packages/pluginsdk-peerdeps": "0.0.16",
   "packages/presentation": "0.0.8",
+  "packages/scripts": "0.0.14",
   "packages/tencentcloud": "0.0.20",
   "packages/titus": "0.0.191"
 }

--- a/.github/release-please-manifest.tools.json
+++ b/.github/release-please-manifest.tools.json
@@ -1,6 +1,0 @@
-{
-  "packages/eslint-plugin": "1.0.13",
-  "packages/pluginsdk": "0.0.32",
-  "packages/pluginsdk-peerdeps": "0.0.16",
-  "packages/scripts": "0.0.14"
-}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,6 @@ on:
       - master
 name: release-please
 jobs:
-
   release-please-app:
     runs-on: ubuntu-latest
     steps:
@@ -14,21 +13,6 @@ jobs:
           release-type: node
           monorepo-tags: true
           command: manifest
-          default-branch: 'release-please-app'
-          config-file: '.github/release-please-config.app.json'
-          manifest-file: '.github/release-please-manifest.app.json'
-          pull-request-title-pattern: 'chore${scope}: release${component} app packages ${version}.'
-
-  release-please-tools:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: node
-          monorepo-tags: true
-          command: manifest
-          default-branch: 'release-please-tools'
-          config-file: '.github/release-please-config.tools.json'
-          manifest-file: '.github/release-please-manifest.tools.json'
-          pull-request-title-pattern: 'chore${scope}: release${component} deck tooling ${version}.'
+          config-file: '.github/release-please-config.json'
+          manifest-file: '.github/release-please-manifest.json'
+          pull-request-title-pattern: 'chore${scope}: release${component} packages ${version}.'


### PR DESCRIPTION
I couldn't get release-please to generate separate PRs for app packages (core/amazon/kubernetes, etc) and tooling (eslint-plugin, plugins, etc)
