### PR TITLE
fix(all): Convert requires to imports

### DIFF
--- a/app/scripts/modules/app/src/canary/canary/canaryScore.component.less
+++ b/app/scripts/modules/app/src/canary/canary/canaryScore.component.less
@@ -1,4 +1,4 @@
-@import (reference) '~coreImports';
+@import (reference) 'coreImports';
 
 .score.label {
   font-size: 110%;

--- a/packages/core/src/config/VersionChecker.tsx
+++ b/packages/core/src/config/VersionChecker.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { IScheduler, SchedulerFactory } from '../scheduler/SchedulerFactory';
 import { timestamp } from '../utils/timeFormatters';
 import { NotifierService } from '../widgets/notifier/notifier.service';
+// @ts-ignore
+import version from 'root/version.json';
 
 export interface IDeckVersion {
   version: string;
@@ -11,7 +13,7 @@ export interface IDeckVersion {
 }
 
 export class VersionChecker {
-  private static currentVersion: IDeckVersion = require('root/version.json');
+  private static currentVersion: IDeckVersion = version;
   private static newVersionSeenCount = 0;
   private static scheduler: IScheduler;
 

--- a/packages/core/src/modal/modalPage.directive.js
+++ b/packages/core/src/modal/modalPage.directive.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { module } from 'angular';
-const $ = require('jquery');
+import $ from 'jquery';
 
 export const CORE_MODAL_MODALPAGE_DIRECTIVE = 'spinnaker.core.modal.modalPage.directive';
 export const name = CORE_MODAL_MODALPAGE_DIRECTIVE; // for backwards compatibility

--- a/packages/core/src/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
+++ b/packages/core/src/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
+import angular from 'angular';
 import _ from 'lodash';
 import { Duration } from 'luxon';
 
@@ -11,8 +12,6 @@ import { NameUtils } from '../../../../naming';
 import { UrlBuilder } from '../../../../navigation';
 import { ServerGroupReader } from '../../../../serverGroup/serverGroupReader.service';
 import { ClusterState } from '../../../../state';
-
-const angular = require('angular');
 
 export const CORE_PIPELINE_CONFIG_STAGES_DEPLOY_DEPLOYEXECUTIONDETAILS_CONTROLLER =
   'spinnaker.core.pipeline.stage.deploy.details.controller';

--- a/packages/core/src/utils/json/JsonUtils.ts
+++ b/packages/core/src/utils/json/JsonUtils.ts
@@ -1,6 +1,6 @@
 import { isArray, isNumber, isPlainObject, isString } from 'lodash';
-
-const DiffMatchPatch = require('expose-loader?diff_match_patch!diff-match-patch');
+// @ts-ignore
+import DiffMatchPatch from 'diff-match-patch';
 
 export interface IDiffDetails {
   type: string;

--- a/packages/core/src/widgets/spelText/spelText.decorator.js
+++ b/packages/core/src/widgets/spelText/spelText.decorator.js
@@ -1,12 +1,11 @@
 'use strict';
 
 import { module } from 'angular';
+import 'jquery-textcomplete';
 
 import { CORE_WIDGETS_SPELTEXT_SPELAUTOCOMPLETE_SERVICE } from './spelAutocomplete.service';
 
 import './spel.less';
-
-require('jquery-textcomplete');
 
 decorateFn.$inject = ['$delegate', 'spelAutocomplete'];
 function decorateFn($delegate, spelAutocomplete) {

--- a/packages/dcos/src/search/resultFormatter.js
+++ b/packages/dcos/src/search/resultFormatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const angular = require('angular');
+import angular from 'angular';
 
 export const DCOS_SEARCH_RESULTFORMATTER = 'spinnaker.dcos.search.formatter';
 export const name = DCOS_SEARCH_RESULTFORMATTER; // for backwards compatibility

--- a/packages/oracle/src/pipeline/disableAsg/disableAsgStage.js
+++ b/packages/oracle/src/pipeline/disableAsg/disableAsgStage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const angular = require('angular');
+import angular from 'angular';
 
 import { AccountService, Registry, StageConstants } from '@spinnaker/core';
 


### PR DESCRIPTION
As we are slowly migrating towards using `vite` as our dev server, we need to convert all our existing require calls to imports. 