### PR TITLE
fix(scripts): Handle double quotes in require calls

### DIFF
--- a/packages/scripts/helpers/rollup-plugin-angularjs-template-loader.js
+++ b/packages/scripts/helpers/rollup-plugin-angularjs-template-loader.js
@@ -15,7 +15,7 @@ module.exports = function angularJsTemplateLoader(options = {}) {
       const templateRegex = /require\(['"]([^'"]+\.html)['"]\)/g;
 
       // look for things like require('./template.html')
-      if (!code.includes("require('") || id.includes('node_modules')) {
+      if ((!code.includes("require('") && !code.includes(`require("`)) || id.includes('node_modules')) {
         return;
       }
 


### PR DESCRIPTION
While using rollup plugins with vite, the files are first transpiled using esbuild and then passed to plugin transformation. It looks like esbuild converts single quotes to double quotes in require calls and that breaks the rollup plugin.