### PR TITLE
Publish packages to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: git - tag bumped packages
         id: tag
+        with:
+          token: '${{ secrets.SPINNAKERBOT_PERSONAL_ACCESS_TOKEN }}'
         run: |
           git config user.name spinnakerbot
           git config user.email spinnakerbot@spinnaker.io


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.

It bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes
using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor bump
  - BREAKING CHANGE: major bump


It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

---




_Auto-generated by `.github/workflows/package-bump-pr.yml`_