### PR TITLE
Publish packages to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: '${{ secrets.SPINNAKERBOT_PERSONAL_ACCESS_TOKEN }}'
 
       - name: Use Node.js 12.16.0
         uses: actions/setup-node@v1
@@ -23,8 +24,6 @@ jobs:
 
       - name: git - tag bumped packages
         id: tag
-        env:
-          GITHUB_TOKEN: '${{ secrets.SPINNAKERBOT_PERSONAL_ACCESS_TOKEN }}'
         run: |
           git config user.name spinnakerbot
           git config user.email spinnakerbot@spinnaker.io


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.



---

This Pr bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_