### PR TITLE
Publish packages to NPM

### DIFF
--- a/.github/workflows/package-bump-pr.yml
+++ b/.github/workflows/package-bump-pr.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: master
 
       - name: git - configure commit user
         run: |


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.



---

This Pr bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_