### PR TITLE
Publish packages to NPM

### DIFF
--- a/app/scripts/modules/app/CHANGELOG.md
+++ b/app/scripts/modules/app/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.2.0 (2021-07-27)
+
+
+### Bug Fixes
+
+* **all:** Convert requires to imports ([abf4c75](https://github.com/spinnaker/deck/commit/abf4c7590ee4bf84adfb1624c5aafcaccf829be5))
+* **app:** Move plugin manifest to public folder ([1dc917d](https://github.com/spinnaker/deck/commit/1dc917df39eae663ea62f8bec55ae5ade07804ad))
+* **app:** Remove resolutions from app ([e117619](https://github.com/spinnaker/deck/commit/e1176195b4eb72f049b7901f719a1a9144c4a2b2))
+* **build:** Fix gradle builds ([d4d25f6](https://github.com/spinnaker/deck/commit/d4d25f6a4ec1e615d29942193bfd5ddd6273440f))
+
+
+### Features
+
+* **build:** Exploring vitejs as dev server and build tool ([e2125b1](https://github.com/spinnaker/deck/commit/e2125b189d3e44056a7bce02dabf8cb97c021764))
+
+
+
+
+
 # 1.1.0 (2021-07-26)
 
 

--- a/app/scripts/modules/app/package.json
+++ b/app/scripts/modules/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deck-app",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "@spinnaker/kubernetes": "^0.0.80",
     "@spinnaker/oracle": "^0.0.36",
     "@spinnaker/styleguide": "^1.0.26",
-    "@spinnaker/titus": "^0.2.0",
+    "@spinnaker/titus": "^0.2.1",
     "@uirouter/angularjs": "1.0.26",
     "angular": "1.6.10",
     "graphql": "15.5.0",

--- a/packages/titus/CHANGELOG.md
+++ b/packages/titus/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.1](https://github.com/spinnaker/deck/compare/@spinnaker/titus@0.2.0...@spinnaker/titus@0.2.1) (2021-07-27)
+
+**Note:** Version bump only for package @spinnaker/titus
+
+
+
+
+
 # [0.2.0](https://github.com/spinnaker/deck/compare/@spinnaker/titus@0.1.4...@spinnaker/titus@0.2.0) (2021-07-26)
 
 

--- a/packages/titus/package.json
+++ b/packages/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.

## titus [0.2.1](https://github.com/spinnaker/deck/compare/@spinnaker/titus@0.2.0...@spinnaker/titus@0.2.1) (2021-07-27)

**Note:** Version bump only for package @spinnaker/titus

---

This Pr bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_