### PR TITLE
Publish packages to NPM

### DIFF
--- a/app/scripts/modules/app/CHANGELOG.md
+++ b/app/scripts/modules/app/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.4.0 (2021-07-30)
+
+
+### Bug Fixes
+
+* **all:** Convert requires to imports ([abf4c75](https://github.com/spinnaker/deck/commit/abf4c7590ee4bf84adfb1624c5aafcaccf829be5))
+* **app:** Fix favicon in vite dev server ([71ec894](https://github.com/spinnaker/deck/commit/71ec8943bdd8cb30b92dbfd919ce7320725134c1))
+* **app:** Move plugin manifest to public folder ([1dc917d](https://github.com/spinnaker/deck/commit/1dc917df39eae663ea62f8bec55ae5ade07804ad))
+* **app:** Remove resolutions from app ([e117619](https://github.com/spinnaker/deck/commit/e1176195b4eb72f049b7901f719a1a9144c4a2b2))
+* **build:** Fix gradle builds ([d4d25f6](https://github.com/spinnaker/deck/commit/d4d25f6a4ec1e615d29942193bfd5ddd6273440f))
+* **build:** Use the right yarn.lock file ([4dac13e](https://github.com/spinnaker/deck/commit/4dac13e31b5f3d6e997bf41707a566c3e7977c26))
+* **vite:** Add vite fixes ([8e0840a](https://github.com/spinnaker/deck/commit/8e0840a647944d9f90ad51c6568c320b096730d6))
+
+
+### Features
+
+* **build:** Exploring vitejs as dev server and build tool ([e2125b1](https://github.com/spinnaker/deck/commit/e2125b189d3e44056a7bce02dabf8cb97c021764))
+
+
+
+
+
 # 1.3.0 (2021-07-30)
 
 

--- a/app/scripts/modules/app/package.json
+++ b/app/scripts/modules/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deck-app",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.



---

This Pr bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_