### PR TITLE
fix(core): Remove circular dependency of modules

### DIFF
--- a/packages/core/src/application/service/applicationDataSource.ts
+++ b/packages/core/src/application/service/applicationDataSource.ts
@@ -23,7 +23,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 
-import { Application } from '../application.model';
+import type { Application } from '../application.model';
 import { IEntityTags } from '../../domain';
 import { IconNames, robotToHuman } from '../../presentation';
 import { ReactInjector } from '../../reactShims';

--- a/packages/core/src/cloudProvider/providerSelection/ProviderSelectionModal.tsx
+++ b/packages/core/src/cloudProvider/providerSelection/ProviderSelectionModal.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { Modal } from 'react-bootstrap';
 
 import { CloudProviderRegistry } from '../CloudProviderRegistry';
-import { ModalClose } from '../../modal';
-import { IModalComponentProps, ReactModal } from '../../presentation';
+import { ModalClose } from '../../modal/buttons/ModalClose';
+import { ReactModal } from '../../presentation/ReactModal';
+import { IModalComponentProps } from '../../presentation/modal/showModal';
 
 export interface IProviderSelectionModalProps extends IModalComponentProps {
   providerOptions: string[];

--- a/packages/core/src/cluster/filter/ClusterFilterService.ts
+++ b/packages/core/src/cluster/filter/ClusterFilterService.ts
@@ -3,7 +3,7 @@ import { Debounce } from 'lodash-decorators';
 import { $log } from 'ngimport';
 import { Subject } from 'rxjs';
 
-import { Application } from '../../application/application.model';
+import type { Application } from '../../application/application.model';
 import { ICluster, IEntityTags, IInstance, IManagedResourceSummary, IServerGroup } from '../../domain';
 import { FilterModelService, ISortFilter } from '../../filterModel';
 import { ILabelFilter, trueKeyObjectToLabelFilters } from './labelFilterUtils';

--- a/packages/core/src/function/filter/FunctionFilterService.ts
+++ b/packages/core/src/function/filter/FunctionFilterService.ts
@@ -2,7 +2,7 @@ import { chain, Dictionary, forOwn, groupBy, intersection, sortBy, values } from
 import { Debounce } from 'lodash-decorators';
 import { Subject } from 'rxjs';
 
-import { Application } from '../../application/application.model';
+import type { Application } from '../../application/application.model';
 import { IFunction, IFunctionGroup } from '../../domain';
 import { FilterModelService } from '../../filterModel';
 import { FunctionState } from '../../state';

--- a/packages/core/src/loadBalancer/filter/LoadBalancerFilterService.ts
+++ b/packages/core/src/loadBalancer/filter/LoadBalancerFilterService.ts
@@ -3,7 +3,7 @@ import { Debounce } from 'lodash-decorators';
 import { $log } from 'ngimport';
 import { Subject } from 'rxjs';
 
-import { Application } from '../../application/application.model';
+import type { Application } from '../../application/application.model';
 import { IInstance, ILoadBalancer, ILoadBalancerGroup, IServerGroup } from '../../domain';
 import { FilterModelService, ISortFilter } from '../../filterModel';
 import { LoadBalancerState } from '../../state';

--- a/packages/core/src/managed/resourceHistory/ManagedResourceHistoryModal.tsx
+++ b/packages/core/src/managed/resourceHistory/ManagedResourceHistoryModal.tsx
@@ -4,16 +4,10 @@ import React from 'react';
 import { HistoryEventRow } from './HistoryEventRow';
 import { ManagedReader } from '../ManagedReader';
 import { IManagedResourceSummary } from '../../domain';
-import {
-  IModalComponentProps,
-  ModalBody,
-  ModalHeader,
-  showModal,
-  standardGridTableLayout,
-  Table,
-  usePollingData,
-} from '../../presentation';
-import { Spinner } from '../../widgets';
+import { usePollingData } from '../../presentation/hooks/usePollingData.hook';
+import { IModalComponentProps, ModalBody, ModalHeader, showModal } from '../../presentation/modal';
+import { standardGridTableLayout, Table } from '../../presentation/tables';
+import { Spinner } from '../../widgets/spinners/Spinner';
 
 import './ManagedResourceHistoryModal.less';
 

--- a/packages/core/src/modal/wizard/WizardModal.tsx
+++ b/packages/core/src/modal/wizard/WizardModal.tsx
@@ -9,8 +9,9 @@ import { ModalClose } from '../buttons/ModalClose';
 import { SubmitButton } from '../buttons/SubmitButton';
 import { SpinFormik } from '../../presentation';
 import { IModalComponentProps } from '../../presentation';
-import { TaskMonitor, TaskMonitorWrapper } from '../../task';
-import { Spinner } from '../../widgets';
+import { TaskMonitorWrapper } from '../../task/monitor/TaskMonitorWrapper';
+import { TaskMonitor } from '../../task/monitor/TaskMonitor';
+import { Spinner } from '../../widgets/spinners/Spinner';
 
 export interface IWizardPageInjectedProps<T> {
   formik: FormikProps<T>;

--- a/packages/core/src/modal/wizard/WizardStepLabel.tsx
+++ b/packages/core/src/modal/wizard/WizardStepLabel.tsx
@@ -2,7 +2,7 @@ import { isArray, isObject, isString } from 'lodash';
 import React from 'react';
 
 import { WizardPage } from './WizardPage';
-import { Tooltip } from '../../presentation';
+import { Tooltip } from '../../presentation/Tooltip';
 
 interface IWizardStepLabelProps {
   current: boolean;

--- a/packages/core/src/orchestratedItem/orchestratedItem.transformer.ts
+++ b/packages/core/src/orchestratedItem/orchestratedItem.transformer.ts
@@ -3,7 +3,7 @@ import { get, isNil } from 'lodash';
 import { $log } from 'ngimport';
 
 import { IOrchestratedItem, IOrchestratedItemVariable, ITask, ITaskStep } from '../domain';
-import { ReactInjector } from '../reactShims';
+import { ReactInjector } from '../reactShims/react.injector';
 
 export class OrchestratedItemTransformer {
   public static addRunningTime(item: any): void {

--- a/packages/core/src/overrideRegistry/Overridable.tsx
+++ b/packages/core/src/overrideRegistry/Overridable.tsx
@@ -4,9 +4,10 @@ import { of as observableOf, Subject } from 'rxjs';
 import { map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { AccountService, IAccountDetails } from '../account/AccountService';
-import { CloudProviderRegistry } from '../cloudProvider';
-import { AngularJSAdapter, ReactInjector } from '../reactShims';
-import { Spinner } from '../widgets';
+import { CloudProviderRegistry } from '../cloudProvider/CloudProviderRegistry';
+import { ReactInjector } from '../reactShims/react.injector';
+import { AngularJSAdapter } from '../reactShims/AngularJSAdapter';
+import { Spinner } from '../widgets/spinners/Spinner';
 
 export interface IOverridableProps {
   accountId?: string;

--- a/packages/core/src/overrideRegistry/Overrides.tsx
+++ b/packages/core/src/overrideRegistry/Overrides.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CloudProviderRegistry } from '../cloudProvider';
+import { CloudProviderRegistry } from '../cloudProvider/CloudProviderRegistry';
 
 import { OverrideRegistry } from './override.registry';
 

--- a/packages/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/packages/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -3,7 +3,7 @@ import { $q } from 'ngimport';
 
 import { REST } from '../../../api/ApiService';
 import { AuthenticationService } from '../../../authentication/AuthenticationService';
-import { ViewStateCache } from '../../../cache';
+import { ViewStateCache } from '../../../cache/viewStateCache';
 import { IPipeline } from '../../../domain/IPipeline';
 import { IStage } from '../../../domain/IStage';
 

--- a/packages/core/src/pipeline/config/stages/common/AsgActionExecutionDetailsSection.tsx
+++ b/packages/core/src/pipeline/config/stages/common/AsgActionExecutionDetailsSection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from './';
-import { AccountTag } from '../../../../account';
-import { StageExecutionLogs, StageFailureMessage } from '../../../details';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from './ExecutionDetailsSection';
+import { AccountTag } from '../../../../account/AccountTag';
+import { StageExecutionLogs } from '../../../details/StageExecutionLogs';
+import { StageFailureMessage } from '../../../details/StageFailureMessage';
 
 export function AsgActionExecutionDetailsSection(props: IExecutionDetailsSectionProps & { action: string }) {
   const { action, stage } = props;

--- a/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.tsx
+++ b/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.tsx
@@ -6,7 +6,7 @@ import { ExecutionWindowActions } from '../executionWindows/ExecutionWindowActio
 import { HoverablePopover } from '../../../../presentation/HoverablePopover';
 import { ReactInjector } from '../../../../reactShims';
 import { SkipConditionWait } from '../waitForCondition/SkipConditionWait';
-import { Spinner } from '../../../../widgets';
+import { Spinner } from '../../../../widgets/spinners/Spinner';
 
 export interface IExecutionBarLabelProps extends IExecutionStageLabelProps {
   tooltip?: JSX.Element;

--- a/packages/core/src/pipeline/config/triggers/artifacts/custom/CustomArtifactEditor.tsx
+++ b/packages/core/src/pipeline/config/triggers/artifacts/custom/CustomArtifactEditor.tsx
@@ -5,7 +5,7 @@ import { ArtifactEditor } from '../ArtifactEditor';
 import { ArtifactTypePatterns } from '../../../../../artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from '../../../../../domain';
 import { StageConfigField } from '../../../stages/common';
-import { SpelText } from '../../../../../widgets';
+import { SpelText } from '../../../../../widgets/spelText/SpelText';
 
 export const TYPE = 'custom/object';
 export const CUSTOM_ARTIFACT_ACCOUNT = 'custom-artifact';

--- a/packages/core/src/pipeline/config/triggers/artifacts/singleFieldArtifactEditor.tsx
+++ b/packages/core/src/pipeline/config/triggers/artifacts/singleFieldArtifactEditor.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { ArtifactEditor } from './ArtifactEditor';
 import { IArtifact, IArtifactEditorProps } from '../../../../domain';
 import { StageConfigField } from '../../stages/common';
-import { SpelText } from '../../../../widgets';
+import { SpelText } from '../../../../widgets/spelText/SpelText';
 
 export const singleFieldArtifactEditor = (
   fieldKey: keyof IArtifact,

--- a/packages/core/src/pipeline/details/stageSummary.component.ts
+++ b/packages/core/src/pipeline/details/stageSummary.component.ts
@@ -4,7 +4,7 @@ import { HtmlRenderer, Parser } from 'commonmark';
 import { Application } from '../../application';
 import { ConfirmationModalService } from '../../confirmationModal';
 import { IExecution, IExecutionStage, IExecutionStageSummary, IStage } from '../../domain';
-import { Registry } from '../../registry';
+import { Registry } from '../../registry/Registry';
 
 import { ExecutionService } from '../service/execution.service';
 

--- a/packages/core/src/pipeline/executions/execution/ExecutionMarkerInformationModal.tsx
+++ b/packages/core/src/pipeline/executions/execution/ExecutionMarkerInformationModal.tsx
@@ -5,7 +5,7 @@ import { Modal } from 'react-bootstrap';
 import { PipelineGraph } from '../../config/graph/PipelineGraph';
 import { IExecution, IExecutionStageSummary } from '../../../domain';
 import { ExecutionInformationService } from './executionInformation.service';
-import { Spinner } from '../../../index';
+import { Spinner } from '../../../widgets/spinners/Spinner';
 import { ParametersAndArtifacts } from '../../status/ParametersAndArtifacts';
 import { duration, relativeTime, timestamp } from '../../../utils';
 

--- a/packages/core/src/pipeline/filter/executionFilter.service.ts
+++ b/packages/core/src/pipeline/filter/executionFilter.service.ts
@@ -4,7 +4,7 @@ import { DateTime, Duration } from 'luxon';
 import { $log } from 'ngimport';
 import { Subject } from 'rxjs';
 
-import { Application } from '../../application/application.model';
+import type { Application } from '../../application/application.model';
 import { IExecution, IExecutionGroup, IPipeline, IPipelineTag } from '../../domain';
 import { FilterModelService, ISortFilter } from '../../filterModel';
 import { Registry } from '../../registry';

--- a/packages/core/src/plugins/plugin.registry.ts
+++ b/packages/core/src/plugins/plugin.registry.ts
@@ -167,6 +167,6 @@ export class PluginRegistry {
   private loadModuleFromUrl(url: string) {
     // This inline comment is used by webpack to emit a native import() (instead of doing a webpack import)
     // See: https://webpack.js.org/api/module-methods/
-    return import(/* webpackIgnore: true */ url);
+    return import(/* webpackIgnore: true */ /* @vite-ignore */ url);
   }
 }

--- a/packages/core/src/presentation/TabBoundary.tsx
+++ b/packages/core/src/presentation/TabBoundary.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useEventListener } from '../index';
+import { useEventListener } from './hooks/useEventListener.hook';
 
 export const TabBoundary = ({ children }: { children: React.ReactNode }) => {
   const boundaryRef = React.createRef<HTMLDivElement>();

--- a/packages/core/src/presentation/collapsibleSection/CollapsibleSection.tsx
+++ b/packages/core/src/presentation/collapsibleSection/CollapsibleSection.tsx
@@ -1,9 +1,8 @@
 import classnames from 'classnames';
 import React from 'react';
 
-import { IIconProps } from '@spinnaker/presentation';
-import { CollapsibleSectionStateCache } from '../../cache';
-import { Icon } from '../../index';
+import { Icon, IIconProps } from '@spinnaker/presentation';
+import { CollapsibleSectionStateCache } from '../../cache/collapsibleSectionStateCache';
 
 export interface ICollapsibleSectionProps {
   outerDivClassName?: string;

--- a/packages/core/src/task/TrafficGuardHelperLink.tsx
+++ b/packages/core/src/task/TrafficGuardHelperLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ReactInjector } from '../reactShims';
+import { ReactInjector } from '../reactShims/react.injector';
 
 export interface ITrafficGuardHelperLinkProps {
   errorMessage: string;

--- a/packages/core/src/task/monitor/TaskMonitorError.tsx
+++ b/packages/core/src/task/monitor/TaskMonitorError.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { TrafficGuardHelperLink } from '../TrafficGuardHelperLink';
 import { ITask } from '../../domain';
 import { Markdown } from '../../presentation';
-import { ReactInjector } from '../../reactShims';
+import { ReactInjector } from '../../reactShims/react.injector';
 
 export interface ITaskMonitorErrorProps {
   errorMessage: string;

--- a/packages/core/src/task/monitor/TaskMonitorStatus.tsx
+++ b/packages/core/src/task/monitor/TaskMonitorStatus.tsx
@@ -4,9 +4,9 @@ import { StatusGlyph } from '../StatusGlyph';
 import { TaskMonitor } from './TaskMonitor';
 import { displayableTasks } from '../displayableTasks.filter';
 import { robotToHuman, useForceUpdate, useObservable } from '../../presentation';
-import { ReactInjector } from '../../reactShims';
+import { ReactInjector } from '../../reactShims/react.injector';
 import { duration } from '../../utils';
-import { Spinner } from '../../widgets';
+import { Spinner } from '../../widgets/spinners/Spinner';
 
 export const TaskMonitorStatus = ({ monitor }: { monitor: TaskMonitor }) => {
   const forceUpdate = useForceUpdate();

--- a/packages/core/src/widgets/ApplicationsPickerInput.tsx
+++ b/packages/core/src/widgets/ApplicationsPickerInput.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { ApplicationReader } from '../application';
+import { ApplicationReader } from '../application/service/ApplicationReader';
 import {
   asyncMessage,
   errorMessage,


### PR DESCRIPTION
Removing circular dependencies in `core` module to ensure deck loads correctly via `vite`. There are some more occurrences left that aren't affecting deck yet but may need to get fixed soon.