### PR TITLE
fix(core): fix layout, click-to-scroll on diff view

### DIFF
--- a/packages/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
+++ b/packages/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
@@ -3,12 +3,11 @@ import React from 'react';
 import { Modal } from 'react-bootstrap';
 
 import { DiffSummary } from './DiffSummary';
-import { DiffView } from './DiffView';
 import { IPipeline } from '../../../../domain';
 import { ModalClose } from '../../../../modal';
 import { FormField, IModalComponentProps, ReactSelectInput, useData } from '../../../../presentation';
 import { PipelineConfigService } from '../../services/PipelineConfigService';
-import { IJsonDiff, JsonUtils, timestamp } from '../../../../utils';
+import { IJsonDiff, JsonUtils, timestamp, DiffView } from '../../../../utils';
 import { Spinner } from '../../../../widgets';
 
 import './showHistory.less';
@@ -163,13 +162,11 @@ export function ShowPipelineHistoryModal(props: IShowHistoryModalProps) {
                 </div>
               </div>
               <form role="form" className="form-horizontal show-history">
-                <div className="form-group">
-                  {!isEmpty(history) && (
-                    <div className="diff-view flex-fill">
-                      <DiffView diff={diff} />
-                    </div>
-                  )}
-                </div>
+                {!isEmpty(history) && (
+                  <div className="diff-view flex-fill">
+                    <DiffView diff={diff} />
+                  </div>
+                )}
               </form>
             </>
           )}

--- a/packages/core/src/pipeline/config/actions/history/showHistory.less
+++ b/packages/core/src/pipeline/config/actions/history/showHistory.less
@@ -1,6 +1,3 @@
-@import (reference) '../../../../presentation/less/imports/commonImports.less';
-@import (reference) 'bootstrap/less/variables.less';
-
 .history-header {
   padding-bottom: 10px;
   align-items: stretch;
@@ -9,12 +6,8 @@
 .show-history {
   overflow-x: hidden;
   overflow-y: auto;
-  clear: both;
   max-height: calc(~'100vh - 220px');
-
-  .form-group {
-    margin: 0 -15px;
-  }
+  display: flex;
 }
 
 .diff-section {
@@ -37,84 +30,5 @@
     color: var(--color-danger);
     display: inline-block;
     margin-left: 5px;
-  }
-}
-
-.diff-view {
-  display: block;
-
-  .diff {
-    color: var(--color-black);
-    font-size: 80%;
-    overflow-x: visible;
-    margin: 0;
-    padding-bottom: 0;
-
-    .match,
-    .add,
-    .remove {
-      font-family: @font-family-monospace;
-
-      &::before {
-        position: relative;
-        left: 0;
-      }
-    }
-
-    .match {
-      color: var(--color-dovegray);
-
-      &::before {
-        content: ' ';
-      }
-    }
-
-    .add {
-      background-color: var(--color-github-history-add); // copied from GitHub
-
-      &::before {
-        content: '+';
-      }
-    }
-
-    .remove {
-      background-color: var(--color-github-history-remove); // also copied from GitHub
-
-      &::before {
-        content: '-';
-      }
-    }
-
-    .form-group {
-      margin-bottom: 0;
-    }
-
-    &::-webkit-scrollbar {
-      height: 8px;
-    }
-  }
-
-  .summary-nav {
-    cursor: pointer;
-    z-index: 2;
-    width: 12px;
-    position: absolute;
-    top: 0;
-    right: -7px;
-    height: calc(~'100% - 8px');
-
-    .delta {
-      width: 100%;
-      position: absolute;
-      min-height: 3px;
-
-      &.add {
-        background: var(--color-success);
-      }
-
-      &.remove {
-        background: var(--color-danger);
-      }
-    }
   }
 }

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -1,5 +1,4 @@
 export * from './config/PipelineRegistry';
-export * from './config/actions/history/DiffView';
 export * from './config/services/PipelineConfigService';
 export * from './config/stages/FormikStageConfig';
 export * from './config/stages/FormikStageConfig';

--- a/packages/core/src/snapshot/diff/snapshotDiff.modal.controller.js
+++ b/packages/core/src/snapshot/diff/snapshotDiff.modal.controller.js
@@ -7,7 +7,7 @@ import { SnapshotReader } from '../SnapshotReader';
 import { SnapshotWriter } from '../SnapshotWriter';
 import { ConfirmationModalService } from '../../confirmationModal';
 import { DIFF_SUMMARY_COMPONENT } from '../../pipeline/config/actions/history/diffSummary.component';
-import { DIFF_VIEW_COMPONENT } from '../../pipeline/config/actions/history/diffView.component';
+import { DIFF_VIEW_COMPONENT } from '../../utils/json/diffView.component';
 import { JsonUtils } from '../../utils/json/JsonUtils';
 
 import './snapshotDiff.modal.less';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './clipboard/CopyToClipboard';
 export * from './debug';
 export * from './firstDefined';
 export * from './json/JsonUtils';
+export * from './json/DiffView';
 export * from './json/traverseObject';
 export * from './noop';
 export * from './q';

--- a/packages/core/src/utils/json/DiffView.less
+++ b/packages/core/src/utils/json/DiffView.less
@@ -1,0 +1,82 @@
+@import (reference) 'bootstrap/less/variables.less';
+
+.diff-view {
+  width: 100%;
+  display: block;
+  position: relative;
+
+  .diff {
+    color: var(--color-black);
+    font-size: 80%;
+    overflow-x: visible;
+    margin: 0;
+    padding-bottom: 0;
+
+    .match,
+    .add,
+    .remove {
+      font-family: @font-family-monospace;
+
+      &::before {
+        position: relative;
+        left: 0;
+      }
+    }
+
+    .match {
+      color: var(--color-dovegray);
+
+      &::before {
+        content: ' ';
+      }
+    }
+
+    .add {
+      background-color: var(--color-github-history-add); // copied from GitHub
+
+      &::before {
+        content: '+';
+      }
+    }
+
+    .remove {
+      background-color: var(--color-github-history-remove); // also copied from GitHub
+
+      &::before {
+        content: '-';
+      }
+    }
+
+    .form-group {
+      margin-bottom: 0;
+    }
+
+    &::-webkit-scrollbar {
+      height: 8px;
+    }
+  }
+
+  .summary-nav {
+    cursor: pointer;
+    z-index: 2;
+    width: 12px;
+    position: absolute;
+    top: 0;
+    right: 7px;
+    height: calc(~'100% - 8px');
+
+    .delta {
+      width: 100%;
+      position: absolute;
+      min-height: 3px;
+
+      &.add {
+        background: var(--color-success);
+      }
+
+      &.remove {
+        background: var(--color-danger);
+      }
+    }
+  }
+}

--- a/packages/core/src/utils/json/DiffView.tsx
+++ b/packages/core/src/utils/json/DiffView.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { IJsonDiff } from '../../../../utils';
+import { IJsonDiff } from './JsonUtils';
+
+import './DiffView.less';
 
 export interface IDiffViewProps {
   diff: IJsonDiff;
@@ -8,22 +10,25 @@ export interface IDiffViewProps {
 
 export function DiffView(props: IDiffViewProps) {
   const { diff } = props;
+  const preRef = React.useRef<HTMLPreElement>();
 
   function scrollBody(e: any): void {
-    let line = 1;
+    let line;
     const target = e.target as HTMLElement;
     const currentTarget = e.currentTarget as HTMLElement;
+    const lineHeight = (preRef.current.firstChild as HTMLElement).clientHeight;
     if (target.getAttribute('data-attr-block-line')) {
-      line = parseInt(target.getAttribute('data-attr-block-line'), 10);
+      line = Number(target.getAttribute('data-attr-block-line'));
     } else {
-      line = (e.offsetY / currentTarget.clientHeight) * this.diff.summary.total;
+      line = (e.nativeEvent?.offsetY / currentTarget.clientHeight) * diff.summary.total;
     }
-    $('pre.history').animate({ scrollTop: (line - 3) * 15 }, 200);
+    // scroll into view, leaving three lines above
+    preRef.current.scroll({ top: (line - 3) * lineHeight, behavior: 'smooth' });
   }
 
   return (
     <>
-      <pre className="form-control flex-fill diff">
+      <pre ref={preRef} className="form-control flex-fill diff">
         {diff.details.map((line, index) => {
           return (
             <div data-attr-line={index} className={line.type} key={index}>

--- a/packages/core/src/utils/json/diffView.component.ts
+++ b/packages/core/src/utils/json/diffView.component.ts
@@ -2,7 +2,7 @@ import { module } from 'angular';
 import { react2angular } from 'react2angular';
 
 import { DiffView } from './DiffView';
-import { withErrorBoundary } from '../../../../presentation/SpinErrorBoundary';
+import { withErrorBoundary } from '../../presentation/SpinErrorBoundary';
 
 export const DIFF_VIEW_COMPONENT = 'spinnaker.core.pipeline.config.diffView.component';
 module(DIFF_VIEW_COMPONENT, []).component('diffView', react2angular(withErrorBoundary(DiffView, 'diffView'), ['diff']));


### PR DESCRIPTION
I wanted to use the DiffView in a plugin and noticed some things broke, probably when it was converted to React from Angular.

Currently, it looks like this:
<img width="894" alt="Screen Shot 2021-08-03 at 10 05 04 PM" src="https://user-images.githubusercontent.com/73450/128125576-271f223e-ff49-4426-bcb4-11b8ff55deb0.png">

Issues:
* the scrolling nav (the part with clickable colored blocks mapping to changes) is pushed almost entirely out of the modal, and is not clickable, and is also pushed up vertically to the top of the modal body instead of aligned with the diff itself.
* the pre tag wrapping the diff contents does not fit within the modal body.
* the modal itself is too big and the bottom of it is cut off.

With this PR, it looks like this:
<img width="891" alt="Screen Shot 2021-08-03 at 10 05 16 PM" src="https://user-images.githubusercontent.com/73450/128125647-8cff6c82-e1b3-458e-8041-a8b0ae8bc932.png">

It's possible I'm the only person who ever used the click-to-scroll thing so nobody else noticed it was broken. Also, the CSS for this thing is way too finicky and could probably be fixed with a better modal solution than the Bootstrap ones, but that's outside the scope of what I'm trying to do here, which make it a little less janky.