### PR TITLE
fix(docker/image): Update rules for generating image name

### DIFF
--- a/packages/docker/src/image/DockerImageUtils.spec.ts
+++ b/packages/docker/src/image/DockerImageUtils.spec.ts
@@ -132,7 +132,7 @@ describe('imageId generating', () => {
         digest: 'sha256:28f82eba',
         tag: undefined,
       }),
-    ).toEqual('gcr.io/project/my-image@sha256:28f82eba');
+    ).toEqual('gcr.io/project/my-image:sha256:28f82eba');
   });
 
   it('generate imageId with tag', () => {

--- a/packages/docker/src/image/DockerImageUtils.ts
+++ b/packages/docker/src/image/DockerImageUtils.ts
@@ -39,14 +39,6 @@ export class DockerImageUtils {
       return undefined;
     }
 
-    let imageId: string;
-
-    if (parts.digest) {
-      imageId = `${parts.repository}@${parts.digest}`;
-    } else {
-      imageId = `${parts.repository}:${parts.tag}`;
-    }
-
-    return imageId;
+    return `${parts.repository}:${parts.digest || parts.tag}`
   }
 }


### PR DESCRIPTION
The format of the `imageId` should be `organization/image:digest`  and not `organization/image@digest`