### PR TITLE
docs(webhook): Help text clarifying that webhook calls must be idempotent

### DIFF
--- a/packages/core/src/help/help.contents.ts
+++ b/packages/core/src/help/help.contents.ts
@@ -480,6 +480,7 @@ const helpContents: { [key: string]: string } = {
   'markdown.examples': `
     Some examples of markdown syntax: <br/> \`*italic*\` <br/> \`**bold**\` <br/> \`[link text](http://url-goes-here)\`
   `,
+  'pipeline.config.webhook.url': 'This webhook call must be idempotent, as certain failed requests will be automatically retried.',
   'pipeline.config.webhook.payload': 'JSON payload to be added to the webhook call.',
   'pipeline.config.webhook.cancelPayload':
     'JSON payload to be added to the webhook call when it is called in response to a cancellation.',

--- a/packages/core/src/pipeline/config/stages/webhook/webhookStage.html
+++ b/packages/core/src/pipeline/config/stages/webhook/webhookStage.html
@@ -3,7 +3,7 @@
     <strong>Note:</strong> {{$ctrl.noUserConfigurableFields ? 'All' : 'Some'}} of the settings of this stage are
     preconfigured, and cannot be changed.
   </div>
-  <stage-config-field label="Webhook URL" ng-if="$ctrl.displayField('url')">
+  <stage-config-field label="Webhook URL" help-key="pipeline.config.webhook.url" ng-if="$ctrl.displayField('url')">
     <input type="text" class="form-control input-sm" ng-model="$ctrl.stage.url" />
   </stage-config-field>
   <stage-config-field label="Method" ng-if="$ctrl.displayField('method')">


### PR DESCRIPTION
Setting some expectations for webhook users.