### PR TITLE
refactor(amazon/scalingPolicy): Reactify step policy actions

### DIFF
--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.less
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.less
@@ -10,7 +10,7 @@
     .adjustment-type-input {
       width: 110px;
     }
-    
+
     .remove-step-action-icon {
       margin-left: auto;
     }

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.less
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.less
@@ -1,0 +1,18 @@
+.StepPolicyAction {
+  .step-policy-row {
+    padding: 5px 0;
+    border-bottom: 1px solid var(--color-seashell);
+
+    .action-input {
+      width: 65px !important;
+    }
+
+    .adjustment-type-input {
+      width: 110px;
+    }
+    
+    .remove-step-action-icon {
+      margin-left: auto;
+    }
+  }
+}

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
@@ -18,35 +18,34 @@ export interface IStepPolicyActionProps {
   stepsChanged: (steps: IStepAdjustment[]) => void;
 }
 
-export const StepPolicyAction = ({ 
+export const StepPolicyAction = ({
   adjustmentType,
   adjustmentTypeChanged,
-  alarm, 
-  isMin, 
+  alarm,
+  isMin,
   operator,
   stepAdjustments,
-  stepsChanged
-}: IStepPolicyActionProps ) => { 
+  stepsChanged,
+}: IStepPolicyActionProps) => {
   const hasEqualTo = alarm?.comparisonOperator.includes('Equal');
   const availableActions = ['Add', 'Remove', 'Set to'];
   const adjustmentTypeOptions = operator === 'Set to' ? ['instances'] : ['instances', 'percent of group'];
 
-  const [ action, setAction ] = React.useState<Operator>(operator);
+  const [action, setAction] = React.useState<Operator>(operator);
   const onActionChange = (val: Operator) => {
-    operator = val;
     setAction(val);
     adjustmentTypeChanged(val, adjustmentType);
   };
 
-  const [ adjustmentTypeView, setAdjustmentTypeView ] = React.useState<AdjustmentTypeView>(adjustmentType);
+  const [adjustmentTypeView, setAdjustmentTypeView] = React.useState<AdjustmentTypeView>(adjustmentType);
   const onAdjustmentTypeChange = (type: AdjustmentTypeView) => {
     setAdjustmentTypeView(type);
     adjustmentTypeChanged(action, type);
   };
 
-  const [ steps, setSteps ] = React.useState<IStepAdjustment[]>(stepAdjustments);
+  const [steps, setSteps] = React.useState<IStepAdjustment[]>(stepAdjustments);
   const addStep = () => {
-    const newStep = { scalingAdjustment: 1} as IStepAdjustment;
+    const newStep = { scalingAdjustment: 1 } as IStepAdjustment;
     const newSteps = [...steps, newStep];
     stepAdjustments = newSteps;
     setSteps(newSteps);
@@ -57,7 +56,7 @@ export const StepPolicyAction = ({
     setSteps(newSteps);
     stepsChanged(newSteps);
   };
-  const updateStep = (updatedStep: IStepAdjustment, index: number) => {    
+  const updateStep = (updatedStep: IStepAdjustment, index: number) => {
     const newSteps = [...steps];
     newSteps[index] = updatedStep;
     setSteps(newSteps);
@@ -68,55 +67,79 @@ export const StepPolicyAction = ({
     <div className="StepPolicyAction row">
       {steps?.map((step: IStepAdjustment, index: number) => (
         <div key={`step-adjustment-${index}`} className="step-policy-row col-md-10 col-md-offset-1 horizontal middle">
-          {Boolean(index) ? <span className="action-input sp-margin-s-left">{action}</span> : 
-          <ReactSelectInput 
-            value={action}
-            stringOptions={availableActions}
-            onChange={(e) => onActionChange(e.target.value)}
-            clearable={false}
+          {Boolean(index) ? (
+            <span className="action-input sp-margin-s-left">{action}</span>
+          ) : (
+            <ReactSelectInput
+              value={action}
+              stringOptions={availableActions}
+              onChange={(e) => onActionChange(e.target.value)}
+              clearable={false}
+              inputClassName="action-input"
+            />
+          )}
+          <NumberInput
+            value={step.scalingAdjustment}
+            min={1}
+            onChange={(e) => updateStep({ ...step, scalingAdjustment: Number.parseInt(e.target.value) }, index)}
             inputClassName="action-input"
-          />}
-          <NumberInput 
-            value={step.scalingAdjustment} 
-            min={1} 
-            onChange={(e) => updateStep({...step, scalingAdjustment: Number.parseInt(e.target.value)}, index)}  
-            inputClassName="action-input"
-          /> 
-          {Boolean(index) ? <span className="sp-margin-xs-left">{adjustmentTypeView}</span> : 
-          <ReactSelectInput 
-            value={adjustmentType}
-            stringOptions={adjustmentTypeOptions}
-            onChange={(e) => onAdjustmentTypeChange(e.target.value)}
-            clearable={false}
-            inputClassName="adjustment-type-input"
-          />}
-          <span className="sp-margin-xs-xaxis"> when <b>{alarm?.metricName}</b> is </span>
-          {(index === steps.length - 1) && <span>{` ${isMin ? 'less' : 'greater'} than${(!Boolean(index) || hasEqualTo) ? ' or equal to' : ''} ${isMin ? (step.metricIntervalUpperBound || '') : (step.metricIntervalLowerBound || '')} `}</span>}
-          {(index < steps.length - 1) && 
+          />
+          {Boolean(index) ? (
+            <span className="sp-margin-xs-left">{adjustmentTypeView}</span>
+          ) : (
+            <ReactSelectInput
+              value={adjustmentType}
+              stringOptions={adjustmentTypeOptions}
+              onChange={(e) => onAdjustmentTypeChange(e.target.value)}
+              clearable={false}
+              inputClassName="adjustment-type-input"
+            />
+          )}
+          <span className="sp-margin-xs-xaxis">
+            {' '}
+            when <b>{alarm?.metricName}</b> is{' '}
+          </span>
+          {index === steps.length - 1 && (
+            <span>{` ${isMin ? 'less' : 'greater'} than${!Boolean(index) || hasEqualTo ? ' or equal to' : ''} ${
+              isMin ? step.metricIntervalUpperBound || '' : step.metricIntervalLowerBound || ''
+            } `}</span>
+          )}
+          {index < steps.length - 1 && (
             <>
               <span className="sp-margin-xs-xaxis">between</span>
-              {isMin ? 
-                <NumberInput 
-                  value={step.metricIntervalLowerBound} 
-                  max={step.metricIntervalUpperBound} 
-                  onChange={(e) => updateStep({...step, metricIntervalLowerBound: Number.parseInt(e.target.value)}, index)}
-                  inputClassName="action-input"
-                /> :
-                <span>{step.metricIntervalLowerBound}</span>}
-              <span className="sp-margin-xs-xaxis">and</span>
-              {isMin ? <span>{step.metricIntervalUpperBound}</span> : 
-                <NumberInput 
-                  value={step.metricIntervalUpperBound} 
-                  min={step.metricIntervalLowerBound} 
-                  onChange={(e) => updateStep({...step, metricIntervalUpperBound: Number.parseInt( e.target.value)}, index)}
+              {isMin ? (
+                <NumberInput
+                  value={step.metricIntervalLowerBound}
+                  max={step.metricIntervalUpperBound}
+                  onChange={(e) =>
+                    updateStep({ ...step, metricIntervalLowerBound: Number.parseInt(e.target.value) }, index)
+                  }
                   inputClassName="action-input"
                 />
-              }
-            </>  
-          }
-          {Boolean(index) && 
-            <a className="glyphicon glyphicon-trash clickable sp-margin-xs-xaxis remove-step-action-icon" onClick={() => removeStep(index)}/>
-          }
+              ) : (
+                <span>{step.metricIntervalLowerBound}</span>
+              )}
+              <span className="sp-margin-xs-xaxis">and</span>
+              {isMin ? (
+                <span>{step.metricIntervalUpperBound}</span>
+              ) : (
+                <NumberInput
+                  value={step.metricIntervalUpperBound}
+                  min={step.metricIntervalLowerBound}
+                  onChange={(e) =>
+                    updateStep({ ...step, metricIntervalUpperBound: Number.parseInt(e.target.value) }, index)
+                  }
+                  inputClassName="action-input"
+                />
+              )}
+            </>
+          )}
+          {Boolean(index) && (
+            <a
+              className="glyphicon glyphicon-trash clickable sp-margin-xs-xaxis remove-step-action-icon"
+              onClick={() => removeStep(index)}
+            />
+          )}
         </div>
       ))}
       <div className="row sp-margin-s">
@@ -140,4 +163,4 @@ export const StepPolicyAction = ({
       </div>
     </div>
   );
-}
+};

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+
+import { ReactSelectInput, NumberInput } from '@spinnaker/core';
+import { IStepAdjustment, IScalingPolicyAlarm } from '../../../../../domain';
+
+import './StepPolicyAction.less';
+
+type Operator = 'Add' | 'Remove' | 'Set to';
+type AdjustmentTypeView = 'instances' | 'percent of group';
+
+export interface IStepPolicyActionProps {
+  adjustmentType: AdjustmentTypeView;
+  adjustmentTypeChanged: (type: AdjustmentTypeView) => void;
+  alarm: IScalingPolicyAlarm;
+  isMin: boolean;
+  operator: Operator;
+  stepAdjustments: IStepAdjustment[];
+  stepsChanged: (steps: IStepAdjustment[]) => void;
+}
+
+export const StepPolicyAction = ({ 
+  adjustmentType,
+  adjustmentTypeChanged,
+  alarm, 
+  isMin, 
+  operator,
+  stepAdjustments,
+  stepsChanged
+}: IStepPolicyActionProps ) => { 
+  const hasEqualTo = alarm?.comparisonOperator.includes('Equal');
+  const availableActions = ['Add', 'Remove', 'Set to'];
+  const adjustmentTypeOptions = operator === 'Set to' ? ['instances'] : ['instances', 'percent of group'];
+
+  const [ action, setAction ] = React.useState<Operator>(operator);
+  const onActionChange = (val: Operator) => {
+    operator = val;
+    setAction(val);
+  };
+
+  const [ adjustmentTypeView, setAdjustmentTypeView ] = React.useState<AdjustmentTypeView>(adjustmentType);
+  const onAdjustmentTypeChange = (type: AdjustmentTypeView) => {
+    setAdjustmentTypeView(type);
+    adjustmentTypeChanged(type);
+  };
+
+  const [ steps, setSteps ] = React.useState<IStepAdjustment[]>(stepAdjustments);
+  const addStep = () => {
+    const newStep = { scalingAdjustment: 1} as IStepAdjustment;
+    const newSteps = [...steps, newStep];
+    stepAdjustments = newSteps;
+    setSteps(newSteps);
+    stepsChanged(newSteps);
+  };
+  const removeStep = (index: number) => {
+    const newSteps = steps.filter((_s, i) => i !== index);
+    setSteps(newSteps);
+    stepsChanged(newSteps);
+  };
+  const updateStep = (updatedStep: IStepAdjustment, index: number) => {    
+    const newSteps = [...steps];
+    newSteps[index] = updatedStep;
+    setSteps(newSteps);
+    stepsChanged(newSteps);
+  };
+
+  return (
+    <div className="StepPolicyAction row">
+      {steps?.map((step: IStepAdjustment, index: number) => (
+        <div key={`step-adjustment-${index}`} className="step-policy-row col-md-10 col-md-offset-1 horizontal middle">
+          {Boolean(index) ? <span className="action-input sp-margin-s-left">{action}</span> : 
+          <ReactSelectInput 
+            value={action}
+            stringOptions={availableActions}
+            onChange={(e) => onActionChange(e.target.value)}
+            clearable={false}
+            inputClassName="action-input"
+          />}
+          <NumberInput 
+            value={step.scalingAdjustment} 
+            min={1} 
+            onChange={(e) => updateStep({...step, scalingAdjustment: Number.parseInt(e.target.value)}, index)}  
+            inputClassName="action-input"
+          /> 
+          {Boolean(index) ? <span className="sp-margin-xs-left">{adjustmentTypeView}</span> : 
+          <ReactSelectInput 
+            value={adjustmentType}
+            stringOptions={adjustmentTypeOptions}
+            onChange={(e) => onAdjustmentTypeChange(e.target.value)}
+            clearable={false}
+            inputClassName="adjustment-type-input"
+          />}
+          <span className="sp-margin-xs-xaxis"> when <b>{alarm?.metricName}</b> is </span>
+          {(index === steps.length - 1) && <span>{` ${isMin ? 'less' : 'greater'} than${(!Boolean(index) || hasEqualTo) ? ' or equal to' : ''} ${isMin ? (step.metricIntervalUpperBound || '') : (step.metricIntervalLowerBound || '')} `}</span>}
+          {(index < steps.length - 1) && 
+            <>
+              <span className="sp-margin-xs-xaxis">between</span>
+              {isMin ? 
+                <NumberInput 
+                  value={step.metricIntervalLowerBound} 
+                  max={step.metricIntervalUpperBound} 
+                  onChange={(e) => updateStep({...step, metricIntervalLowerBound: Number.parseInt(e.target.value)}, index)}
+                  inputClassName="action-input"
+                /> :
+                <span>{step.metricIntervalLowerBound}</span>}
+              <span className="sp-margin-xs-xaxis">and</span>
+              {isMin ? <span>{step.metricIntervalUpperBound}</span> : 
+                <NumberInput 
+                  value={step.metricIntervalUpperBound} 
+                  min={step.metricIntervalLowerBound} 
+                  onChange={(e) => updateStep({...step, metricIntervalUpperBound: Number.parseInt( e.target.value)}, index)}
+                  inputClassName="action-input"
+                />
+              }
+            </>  
+          }
+          {Boolean(index) && 
+            <a className="glyphicon glyphicon-trash clickable sp-margin-xs-xaxis remove-step-action-icon" onClick={() => removeStep(index)}/>
+          }
+        </div>
+      ))}
+      <div className="row sp-margin-s">
+        <div className="col-md-10 col-md-offset-1">
+          <button className="btn btn-block btn-sm add-new" onClick={addStep}>
+            <span className="glyphicon glyphicon-plus-sign"></span>
+            Add step
+          </button>
+        </div>
+      </div>
+      <div className="row sp-margin-s-xaxis">
+        <div className="col-md-10 col-md-offset-1">
+          <a
+            href="http://docs.aws.amazon.com/autoscaling/latest/userguide/as-scale-based-on-demand.html#as-scaling-steps"
+            target="_blank"
+          >
+            <i className="far fa-file-alt sp-margin-xs-right" />
+            Documentation
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
@@ -29,7 +29,7 @@ export const StepPolicyAction = ({
 }: IStepPolicyActionProps) => {
   const hasEqualTo = alarm?.comparisonOperator.includes('Equal');
   const availableActions = ['Add', 'Remove', 'Set to'];
-  
+
   const [action, setAction] = React.useState<Operator>(operator);
   const adjustmentTypeOptions = action === 'Set to' ? ['instances'] : ['instances', 'percent of group'];
   const onActionChange = (val: Operator) => {

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
@@ -29,9 +29,9 @@ export const StepPolicyAction = ({
 }: IStepPolicyActionProps) => {
   const hasEqualTo = alarm?.comparisonOperator.includes('Equal');
   const availableActions = ['Add', 'Remove', 'Set to'];
-  const adjustmentTypeOptions = operator === 'Set to' ? ['instances'] : ['instances', 'percent of group'];
-
+  
   const [action, setAction] = React.useState<Operator>(operator);
+  const adjustmentTypeOptions = action === 'Set to' ? ['instances'] : ['instances', 'percent of group'];
   const onActionChange = (val: Operator) => {
     setAction(val);
     adjustmentTypeChanged(val, adjustmentType);
@@ -68,14 +68,14 @@ export const StepPolicyAction = ({
       {steps?.map((step: IStepAdjustment, index: number) => (
         <div key={`step-adjustment-${index}`} className="step-policy-row col-md-10 col-md-offset-1 horizontal middle">
           {Boolean(index) ? (
-            <span className="action-input sp-margin-s-left">{action}</span>
+            <span className="action-input sp-margin-xs-left">{action}</span>
           ) : (
             <ReactSelectInput
               value={action}
               stringOptions={availableActions}
               onChange={(e) => onActionChange(e.target.value)}
               clearable={false}
-              inputClassName="action-input"
+              inputClassName="action-input sp-margin-xs-right"
             />
           )}
           <NumberInput
@@ -88,7 +88,7 @@ export const StepPolicyAction = ({
             <span className="sp-margin-xs-left">{adjustmentTypeView}</span>
           ) : (
             <ReactSelectInput
-              value={adjustmentType}
+              value={adjustmentTypeView}
               stringOptions={adjustmentTypeOptions}
               onChange={(e) => onAdjustmentTypeChange(e.target.value)}
               clearable={false}

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
@@ -10,7 +10,7 @@ type AdjustmentTypeView = 'instances' | 'percent of group';
 
 export interface IStepPolicyActionProps {
   adjustmentType: AdjustmentTypeView;
-  adjustmentTypeChanged: (type: AdjustmentTypeView) => void;
+  adjustmentTypeChanged: (action: Operator, type: AdjustmentTypeView) => void;
   alarm: IScalingPolicyAlarm;
   isMin: boolean;
   operator: Operator;
@@ -35,12 +35,13 @@ export const StepPolicyAction = ({
   const onActionChange = (val: Operator) => {
     operator = val;
     setAction(val);
+    adjustmentTypeChanged(val, adjustmentType);
   };
 
   const [ adjustmentTypeView, setAdjustmentTypeView ] = React.useState<AdjustmentTypeView>(adjustmentType);
   const onAdjustmentTypeChange = (type: AdjustmentTypeView) => {
     setAdjustmentTypeView(type);
-    adjustmentTypeChanged(type);
+    adjustmentTypeChanged(action, type);
   };
 
   const [ steps, setSteps ] = React.useState<IStepAdjustment[]>(stepAdjustments);

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/awsStepPolicyAction.component.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/awsStepPolicyAction.component.ts
@@ -1,0 +1,46 @@
+import { module } from 'angular';
+
+import './stepPolicyAction.component.less';
+
+const stepPolicyActionComponent = {
+  bindings: {
+    command: '<',
+    viewState: '=',
+    boundsChanged: '&',
+  },
+  templateUrl: require('./stepPolicyAction.component.html'),
+  controller() {
+    this.operatorChanged = () => {
+      this.command.adjustmentType = this.viewState.operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
+      this.adjustmentTypeOptions =
+        this.viewState.operator === 'Set to' ? ['instances'] : ['instances', 'percent of group'];
+    };
+
+    this.availableActions = ['Add', 'Remove', 'Set to'];
+
+    this.adjustmentTypeChanged = () => {
+      if (this.viewState.adjustmentType === 'instances') {
+        this.command.adjustmentType = this.viewState.operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
+      } else {
+        this.command.adjustmentType = 'PercentChangeInCapacity';
+      }
+    };
+
+    this.addStep = () => {
+      this.command.step.stepAdjustments.push({ scalingAdjustment: 1 });
+    };
+
+    this.removeStep = (index: number) => {
+      this.command.step.stepAdjustments.splice(index, 1);
+      this.boundsChanged();
+    };
+
+    this.$onInit = () => {
+      this.operatorChanged();
+      this.adjustmentTypeChanged();
+    };
+  },
+};
+
+export const STEP_POLICY_ACTION = 'spinnaker.amazon.scalingPolicy.stepPolicy.action';
+module(STEP_POLICY_ACTION, []).component('awsStepPolicyAction', stepPolicyActionComponent);

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.ts
@@ -4,12 +4,17 @@ import { withErrorBoundary } from '@spinnaker/core';
 
 import { StepPolicyAction } from './StepPolicyAction';
 
-
 export const STEP_POLICY_ACTION_COMPONENT = 'spinnaker.amazon.scalingPolicy.stepPolicyAction.component';
-
-
 
 module(STEP_POLICY_ACTION_COMPONENT, []).component(
   'stepPolicyAction',
-  react2angular(withErrorBoundary(StepPolicyAction, 'stepPolicyAction'), ['adjustmentType', 'adjustmentTypeChanged', 'alarm', 'isMin', 'operator', 'stepAdjustments', 'stepsChanged']),
+  react2angular(withErrorBoundary(StepPolicyAction, 'stepPolicyAction'), [
+    'adjustmentType',
+    'adjustmentTypeChanged',
+    'alarm',
+    'isMin',
+    'operator',
+    'stepAdjustments',
+    'stepsChanged',
+  ]),
 );

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.ts
@@ -1,46 +1,15 @@
 import { module } from 'angular';
+import { react2angular } from 'react2angular';
+import { withErrorBoundary } from '@spinnaker/core';
 
-import './stepPolicyAction.component.less';
+import { StepPolicyAction } from './StepPolicyAction';
 
-const stepPolicyActionComponent = {
-  bindings: {
-    command: '<',
-    viewState: '=',
-    boundsChanged: '&',
-  },
-  templateUrl: require('./stepPolicyAction.component.html'),
-  controller() {
-    this.operatorChanged = () => {
-      this.command.adjustmentType = this.viewState.operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
-      this.adjustmentTypeOptions =
-        this.viewState.operator === 'Set to' ? ['instances'] : ['instances', 'percent of group'];
-    };
 
-    this.availableActions = ['Add', 'Remove', 'Set to'];
+export const STEP_POLICY_ACTION_COMPONENT = 'spinnaker.amazon.scalingPolicy.stepPolicyAction.component';
 
-    this.adjustmentTypeChanged = () => {
-      if (this.viewState.adjustmentType === 'instances') {
-        this.command.adjustmentType = this.viewState.operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
-      } else {
-        this.command.adjustmentType = 'PercentChangeInCapacity';
-      }
-    };
 
-    this.addStep = () => {
-      this.command.step.stepAdjustments.push({ scalingAdjustment: 1 });
-    };
 
-    this.removeStep = (index: number) => {
-      this.command.step.stepAdjustments.splice(index, 1);
-      this.boundsChanged();
-    };
-
-    this.$onInit = () => {
-      this.operatorChanged();
-      this.adjustmentTypeChanged();
-    };
-  },
-};
-
-export const STEP_POLICY_ACTION = 'spinnaker.amazon.scalingPolicy.stepPolicy.action';
-module(STEP_POLICY_ACTION, []).component('awsStepPolicyAction', stepPolicyActionComponent);
+module(STEP_POLICY_ACTION_COMPONENT, []).component(
+  'stepPolicyAction',
+  react2angular(withErrorBoundary(StepPolicyAction, 'stepPolicyAction'), ['adjustmentType', 'adjustmentTypeChanged', 'alarm', 'isMin', 'operator', 'stepAdjustments', 'stepsChanged']),
+);

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -133,9 +133,10 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTR
       this.boundsChanged();
     };
 
-    this.adjustmentTypeChanged = (type) => {
+    this.adjustmentTypeChanged = (action, type) => {
+      this.viewState.operator = action;
       this.viewState.adjustmentType = type;
-      const newType = type !== 'instances' ? 'PercentChangeInCapacity' : operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
+      const newType = type !== 'instances' ? 'PercentChangeInCapacity' : action === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
       this.command.adjustmentType = newType;
     };
 

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -9,7 +9,7 @@ import { ScalingPolicyWriter } from '../ScalingPolicyWriter';
 import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_ALARMCONFIGURER_COMPONENT } from './alarm/alarmConfigurer.component';
 import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_SIMPLE_SIMPLEPOLICYACTION_COMPONENT } from './simple/simplePolicyAction.component';
 import { STEP_POLICY_ACTION } from './step/awsStepPolicyAction.component';
-import { STEP_POLICY_ACTION_COMPONENT } from './step/stepPolicyAction.component'
+import { STEP_POLICY_ACTION_COMPONENT } from './step/stepPolicyAction.component';
 
 import './upsertScalingPolicy.modal.less';
 import { linen } from 'color-name';
@@ -136,7 +136,8 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTR
     this.adjustmentTypeChanged = (action, type) => {
       this.viewState.operator = action;
       this.viewState.adjustmentType = type;
-      const newType = type !== 'instances' ? 'PercentChangeInCapacity' : action === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
+      const newType =
+        type !== 'instances' ? 'PercentChangeInCapacity' : action === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
       this.command.adjustmentType = newType;
     };
 

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -8,9 +8,11 @@ import { TaskMonitor } from '@spinnaker/core';
 import { ScalingPolicyWriter } from '../ScalingPolicyWriter';
 import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_ALARMCONFIGURER_COMPONENT } from './alarm/alarmConfigurer.component';
 import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_SIMPLE_SIMPLEPOLICYACTION_COMPONENT } from './simple/simplePolicyAction.component';
-import { STEP_POLICY_ACTION } from './step/stepPolicyAction.component';
+import { STEP_POLICY_ACTION } from './step/awsStepPolicyAction.component';
+import { STEP_POLICY_ACTION_COMPONENT } from './step/stepPolicyAction.component'
 
 import './upsertScalingPolicy.modal.less';
+import { linen } from 'color-name';
 
 export const AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTROLLER =
   'spinnaker.amazon.serverGroup.details.scalingPolicy.upsertScalingPolicy.controller';
@@ -18,6 +20,7 @@ export const name = AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALIN
 module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTROLLER, [
   AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_SIMPLE_SIMPLEPOLICYACTION_COMPONENT,
   STEP_POLICY_ACTION,
+  STEP_POLICY_ACTION_COMPONENT,
   AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_ALARMCONFIGURER_COMPONENT,
 ]).controller('awsUpsertScalingPolicyCtrl', [
   '$uibModalInstance',
@@ -125,11 +128,14 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTR
       this.command.simple.scalingAdjustment = adjustment;
     };
 
-    this.adjustmentTypeChanged = (action, type) => {
-      this.viewState.operator = action;
+    this.stepsChanged = (newSteps) => {
+      this.command.step.stepAdjustments = newSteps;
+      this.boundsChanged();
+    };
+
+    this.adjustmentTypeChanged = (type) => {
       this.viewState.adjustmentType = type;
-      const newType =
-        type !== 'instances' ? 'PercentChangeInCapacity' : action === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
+      const newType = type !== 'instances' ? 'PercentChangeInCapacity' : operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
       this.command.adjustmentType = newType;
     };
 

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
@@ -38,11 +38,16 @@
           ></aws-simple-policy-action>
         </div>
         <div ng-if="ctrl.command.step">
-          <aws-step-policy-action
-            command="ctrl.command"
-            view-state="ctrl.viewState"
-            bounds-changed="ctrl.boundsChanged()"
-          ></aws-step-policy-action>
+          <step-policy-action
+            adjustment-type="ctrl.viewState.adjustmentType"
+            adjustment-type-changed="ctrl.adjustmentTypeChanged"
+            alarm="ctrl.command.alarm"
+            is-min="ctrl.viewState.comparatorBound === 'min'"
+            operator="ctrl.viewState.operator"
+            step-adjustments="ctrl.command.step.stepAdjustments"
+            steps-changed="ctrl.stepsChanged"
+          >
+          </step-policy-action>
         </div>
       </div>
       <h4 class="section-heading">Additional Settings</h4>


### PR DESCRIPTION
A few temporary changes with this PR that are not my favorite but necessary to rollout smoothly. 

1.  **Dual components until `@spinnker/amazon` is bumped and the new component can be imported elsewhere.** 
`awsStepPolicyAction.component.ts` - the old controller that is just renamed. It will be removed after updating other modules
`stepPolicyAction.component.ts - the new `react2angular wrapper` for `ScalingPolicyAction.tsx`

2. **Dual updates in `ScalingPolicyAction.tsx`**
The propagation of changes via props between the angular parent and new React component takes several seconds. To avoid this delay in rendering, I had to add `useState` for each input. This will be removed once the parent component refactored/optimized. 