### PR TITLE
refactor(amazon/scalingPolicy): Reactify MetricSelector

### DIFF
--- a/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/upsertTargetTracking.controller.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/upsertTargetTracking.controller.ts
@@ -6,7 +6,11 @@ import { Subject } from 'rxjs';
 import { Application, IServerGroup, TaskMonitor } from '@spinnaker/core';
 
 import { IUpsertScalingPolicyCommand, ScalingPolicyWriter } from '../ScalingPolicyWriter';
-import { ITargetTrackingConfiguration, ITargetTrackingPolicy } from '../../../../domain';
+import {
+  ICustomizedMetricSpecification,
+  ITargetTrackingConfiguration,
+  ITargetTrackingPolicy,
+} from '../../../../domain';
 
 export type MetricType = 'custom' | 'predefined';
 
@@ -71,6 +75,10 @@ export class UpsertTargetTrackingController implements IComponentController {
   public scaleInChanged(): void {
     this.state.scaleInChanged = true;
   }
+
+  public alarmChanged = (newAlarm: ICustomizedMetricSpecification) => {
+    this.command.targetTrackingConfiguration.customizedMetricSpecification = newAlarm;
+  };
 
   public cancel(): void {
     this.$uibModalInstance.dismiss();

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/upsertTargetTracking.modal.html
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/upsertTargetTracking.modal.html
@@ -28,11 +28,11 @@
             </div>
 
             <div ng-if="$ctrl.state.metricType === 'custom'">
-              <aws-metric-selector
-                alarm-updated="$ctrl.alarmUpdated"
+              <metric-selector
                 alarm="$ctrl.command.targetTrackingConfiguration.customizedMetricSpecification"
                 server-group="$ctrl.serverGroup"
-              ></aws-metric-selector>
+                update-alarm="$ctrl.alarmChanged"
+              ></metric-selector>
               <div>
                 <a href ng-click="$ctrl.toggleMetricType()">Use a predefined metric</a>
               </div>

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/DimensionsEditor.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/DimensionsEditor.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import { flatMap, uniq } from 'lodash';
+import * as React from 'react';
 import { Subject } from 'rxjs';
-import { IScalingPolicyAlarmView } from '../../../../../domain';
+
 import {
   CloudMetricsReader,
   IMetricAlarmDimension,
@@ -11,13 +11,15 @@ import {
   useData,
 } from '@spinnaker/core';
 
+import { IScalingPolicyAlarmView } from '../../../../../domain';
+
 import './dimensionsEditor.less';
 
 export interface IDimensionsEditorProps {
   alarm: IScalingPolicyAlarmView;
   namespaceUpdated?: Subject<void>;
   serverGroup: IServerGroup;
-  updateAvailableMetrics: () => void;
+  updateAvailableMetrics: (dimensions: IMetricAlarmDimension[]) => void;
 }
 
 export const DimensionsEditor = ({ alarm, serverGroup, updateAvailableMetrics }: IDimensionsEditorProps) => {
@@ -36,22 +38,20 @@ export const DimensionsEditor = ({ alarm, serverGroup, updateAvailableMetrics }:
 
   const addDimension = () => {
     const newDimensions = [...dimensions, {} as IMetricAlarmDimension];
-    alarm.dimensions = newDimensions;
     setDimensions(newDimensions);
+    updateAvailableMetrics(newDimensions);
   };
   const removeDimension = (index: number) => {
     const newDimensions = alarm.dimensions.filter((_d, i) => i !== index);
-    alarm.dimensions = newDimensions;
     setDimensions(newDimensions);
-    updateAvailableMetrics();
+    updateAvailableMetrics(newDimensions);
   };
   const updateDimension = (key: 'name' | 'value', value: string, index: number) => {
     const newDimensions = [...dimensions];
     const updatedDimension = newDimensions[index];
     updatedDimension[key] = value;
-    alarm.dimensions = newDimensions;
     setDimensions(newDimensions);
-    updateAvailableMetrics();
+    updateAvailableMetrics(newDimensions);
   };
 
   return (

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/MetricSelector.less
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/MetricSelector.less
@@ -1,0 +1,15 @@
+.MetricSelector {
+  font-size: 12px;
+
+  .simple-input {
+    width: 216px;
+  }
+
+  .advanced-input-namespace {
+    width: 138px;
+  }
+
+  .advanced-input-metric {
+    width: 300px;
+  }
+}

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/MetricSelector.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/MetricSelector.tsx
@@ -1,0 +1,187 @@
+import { Dictionary } from 'lodash';
+import * as React from 'react';
+
+import {
+  CloudMetricsReader,
+  HelpField,
+  ICloudMetricDescriptor,
+  IMetricAlarmDimension,
+  ReactSelectInput,
+  Spinner,
+  useData,
+} from '@spinnaker/core';
+
+import { DimensionsEditor } from './DimensionsEditor';
+import { AWSProviderSettings } from '../../../../../aws.settings';
+import { IAmazonServerGroup, IScalingPolicyAlarmView } from '../../../../../domain';
+import { NAMESPACES } from './namespaces';
+
+import './MetricSelector.less';
+
+export interface IMetricOption extends ICloudMetricDescriptor {
+  label: string;
+  dimensionValues: string;
+  value: ICloudMetricDescriptor;
+}
+
+export interface IMetricSelectorProps {
+  alarm: IScalingPolicyAlarmView;
+  serverGroup: IAmazonServerGroup;
+  updateAlarm: (alarm: IScalingPolicyAlarmView) => void;
+}
+
+export const MetricSelector = ({ alarm, updateAlarm, serverGroup }: IMetricSelectorProps) => {
+  const namespaces = (AWSProviderSettings?.metrics?.customNamespaces || []).concat(NAMESPACES);
+  const [advancedMode, setAdvancedMode] = React.useState<boolean>(false);
+  // TODO: Remove useState once rendering speed improve (after refactoring to React)
+  const [selectedMetric, setSelectedMetric] = React.useState({});
+  const [metricName, setMetricName] = React.useState<string>(alarm.metricName);
+  const [namespace, setNamespace] = React.useState<string>(alarm.namespace);
+
+  const dimensionsObject = (alarm.dimensions || []).reduce(
+    (acc: Dictionary<string>, dimension: IMetricAlarmDimension) => {
+      acc[dimension.name] = dimension.value;
+      return acc;
+    },
+    {} as Dictionary<string>,
+  );
+
+  const buildDimensionValues = (dimensions: IMetricAlarmDimension[]) =>
+    dimensions
+      .sort((a: IMetricAlarmDimension, b: IMetricAlarmDimension) => a.name?.localeCompare(b.name))
+      .map((d: IMetricAlarmDimension) => d.value)
+      .join(', ');
+  const dimensionValuesStr = buildDimensionValues(alarm.dimensions);
+
+  const fetchCloudMetrics = () => {
+    return CloudMetricsReader.listMetrics('aws', serverGroup.account, serverGroup.region, dimensionsObject).then(
+      (metrics: ICloudMetricDescriptor[]) => {
+        const sortedMetrics: IMetricOption[] = metrics
+          .map((m) => ({
+            label: `(${m.namespace}) ${m.name}`,
+            dimensions: [],
+            dimensionValues: buildDimensionValues(m.dimensions),
+            value: m,
+            ...m,
+          }))
+          .sort((a, b) => a.label?.localeCompare(b.label));
+
+        const chosenMetric =
+          sortedMetrics.find(
+            (m) =>
+              m.name === alarm.metricName &&
+              m.namespace === alarm.namespace &&
+              m.dimensionValues === dimensionValuesStr,
+          ) ||
+          metrics.find((m) => m.name.match('CPUUtilization')) ||
+          metrics[0];
+        setSelectedMetric(chosenMetric);
+        return sortedMetrics;
+      },
+    );
+  };
+
+  const { result: metrics, status } = useData(fetchCloudMetrics, [], [serverGroup, alarm.namespace]);
+  // TODO: Once rendering speeds improve, infer `selectedMetric` from the result of useData metrics. useState is needed now to update dropdown until data propagates.
+
+  const toggleMode = () => {
+    const newMode = !advancedMode;
+    if (newMode) {
+      dimensionsObject.namespace = alarm.namespace;
+    } else {
+      const newAlarm = {
+        ...alarm,
+        dimension: [{ name: 'AutoScalingGroupName', value: serverGroup.name }],
+      };
+      updateAlarm(newAlarm);
+    }
+    setAdvancedMode(newMode);
+  };
+
+  const onMetricChange = (metric: IMetricOption) => {
+    const newAlarm = {
+      ...alarm,
+      metricName: metric.name,
+      namespace: metric.namespace,
+      dimensions: metric.dimensions,
+    };
+
+    const newMetric = metrics.find((m) => m.namespace === metric.namespace && m.name === metric.name);
+    setSelectedMetric(newMetric);
+    updateAlarm(newAlarm);
+  };
+
+  const onAdvancedChange = (newNamespace: string, newName: string) => {
+    const newAlarm = {
+      ...alarm,
+      metricName: newName,
+      namespace: newNamespace,
+    };
+    setMetricName(newName);
+    setNamespace(newNamespace);
+    updateAlarm(newAlarm);
+  };
+
+  const updateDimensions = (dimensions: IMetricAlarmDimension[]) => {
+    const newAlarm = {
+      ...alarm,
+      dimensions: dimensions,
+    };
+    updateAlarm(newAlarm);
+  };
+
+  if (status === 'PENDING') {
+    return <Spinner size="small" mode="circular" />;
+  }
+
+  if (!advancedMode) {
+    return (
+      <div className="MetricSelector horizontal middle">
+        <ReactSelectInput
+          value={selectedMetric}
+          onChange={(e) => onMetricChange(e.target.value)}
+          options={metrics}
+          clearable={false}
+          inputClassName="sp-margin-s-right simple-input"
+        />
+        <a className="clickable" onClick={toggleMode}>
+          <span className="sp-margin-xs-right">Search all metrics</span>
+          <HelpField id="aws.scalingPolicy.search.all" />
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="MetricSelector">
+      <div className="horizontal middle">
+        <ReactSelectInput
+          value={namespace}
+          onChange={(e) => onAdvancedChange(e.target.value, alarm.metricName)}
+          stringOptions={namespaces}
+          inputClassName="advanced-input-namespace sp-margin-m-right"
+        />
+        <ReactSelectInput
+          value={metricName}
+          onChange={(e) => onAdvancedChange(alarm.namespace, e.target.value)}
+          stringOptions={metrics.map((m) => m.name)}
+          placeholder="name"
+          searchable={true}
+          inputClassName="advanced-input-metric"
+        />
+      </div>
+      <div className="vertical">
+        {!Boolean(metrics.length) && (
+          <span className="input-label">
+            <b>Note:</b> no metrics found for selected namespace + dimensions
+          </span>
+        )}
+        <a className="clickable" onClick={toggleMode}>
+          <span className="sp-margin-s-yaxis sp-margin-xs-right">Only show metrics for this auto scaling group</span>
+          <HelpField id="aws.scalingPolicy.search.restricted" />
+        </a>
+      </div>
+      <DimensionsEditor alarm={alarm} serverGroup={serverGroup} updateAvailableMetrics={updateDimensions} />
+    </div>
+  );
+};

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
@@ -32,11 +32,11 @@
       ng-options="stat for stat in $ctrl.statistics"
     ></select>
     <span class="input-label" style="vertical-align: top; margin-top: 7px"> of </span>
-    <aws-metric-selector
-      alarm-updated="$ctrl.alarmUpdated"
+    <metric-selector
+      update-alarm="$ctrl.alarmChanged"
       alarm="$ctrl.command.alarm"
       server-group="$ctrl.serverGroup"
-    ></aws-metric-selector>
+    ></metric-selector>
   </div>
 </div>
 

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
@@ -3,6 +3,7 @@
 import { module } from 'angular';
 import { Subject } from 'rxjs';
 
+import { AWS_METRIC_SELECTOR_COMPONENT } from './awsMetricSelector.component';
 import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_DIMENSIONSEDITOR_COMPONENT } from './dimensionsEditor.component';
 import { METRIC_SELECTOR_COMPONENT } from './metricSelector.component';
 
@@ -12,6 +13,7 @@ export const name = AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_ALARMC
 module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_ALARMCONFIGURER_COMPONENT, [
   AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_DIMENSIONSEDITOR_COMPONENT,
   METRIC_SELECTOR_COMPONENT,
+  AWS_METRIC_SELECTOR_COMPONENT,
 ]).component('awsAlarmConfigurer', {
   bindings: {
     command: '=',
@@ -61,6 +63,10 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_ALARMCONFIGURER_COM
         }
         this.boundsChanged();
         this.alarmUpdated.next();
+      };
+
+      this.alarmChanged = (newAlarm) => {
+        this.command.alarm = newAlarm;
       };
 
       this.updateChart = () => this.alarmUpdated.next();

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/awsMetricSelector.component.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/awsMetricSelector.component.ts
@@ -1,0 +1,11 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { withErrorBoundary } from '@spinnaker/core';
+import { MetricSelector } from './MetricSelector';
+
+export const AWS_METRIC_SELECTOR_COMPONENT = 'spinnaker.amazon.scalingPolicy.alarm.metric.selector.component';
+module(AWS_METRIC_SELECTOR_COMPONENT, []).component(
+  'metricSelector',
+  react2angular(withErrorBoundary(MetricSelector, 'metricSelector'), ['alarm', 'serverGroup', 'updateAlarm']),
+);


### PR DESCRIPTION
Update the metric selector to react. 

- Dual-updating via state and a method passed from the angular controller. The plan is to remove this as the rendering speeds improve with this refactor. 
- The interface changed slightly, so I created a second component until all packages are bumped.

**Up Next:**
- Once`@spinnaker/amazon` is bumped, I can integrate this with `@spinnaker/titus` and delete the duplicate files. 