### PR TITLE
refactor(amazon): Scaling policy additional settings

### DIFF
--- a/packages/amazon/src/serverGroup/details/scalingPolicy/ScalingPolicyWriter.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/ScalingPolicyWriter.ts
@@ -29,6 +29,7 @@ export interface ISimplePolicyDescription {
 }
 
 export interface IStepPolicyDescription {
+  cooldown?: number;
   stepAdjustments: IStepAdjustment[];
   estimatedInstanceWarmup: number;
   cooldown?: number;

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/ScalingPolicyWriter.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/ScalingPolicyWriter.ts
@@ -32,7 +32,6 @@ export interface IStepPolicyDescription {
   cooldown?: number;
   stepAdjustments: IStepAdjustment[];
   estimatedInstanceWarmup: number;
-  cooldown?: number;
   metricAggregationType: MetricAggregationType;
 }
 

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/ScalingPolicyAdditionalSettings.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/ScalingPolicyAdditionalSettings.tsx
@@ -1,0 +1,123 @@
+import { module } from 'angular';
+import { set } from 'lodash';
+import * as React from 'react';
+import { react2angular } from 'react2angular';
+
+import { HelpField, NumberInput, withErrorBoundary } from '@spinnaker/core';
+
+import { IUpsertScalingPolicyCommand } from '../ScalingPolicyWriter';
+
+export interface IScalingPolicyAdditionalSettingsProps {
+  command: IUpsertScalingPolicyCommand;
+  isInstanceType: boolean;
+  isNew: boolean;
+  operator: string;
+  updateCommand: (command: IUpsertScalingPolicyCommand) => void;
+}
+
+export const ScalingPolicyAdditionalSettings = ({
+  command,
+  isInstanceType,
+  isNew,
+  operator,
+  updateCommand,
+}: IScalingPolicyAdditionalSettingsProps) => {
+  const [commandView, setCommandView] = React.useState<IUpsertScalingPolicyCommand>(command);
+  const setCommandField = (path: string, value: number) => {
+    const newCommand = { ...command };
+    set(newCommand, path, value);
+    setCommandView(newCommand);
+    updateCommand(newCommand);
+  };
+
+  return (
+    <div>
+      <h4 className="section-heading">Additional Settings</h4>
+      <div className="section-body section-additional-settings">
+        {!isNew && (
+          <div className="row">
+            <div className="col-md-2 sm-label-right">Policy Name</div>
+            <div className="col-md-10 content-fields">
+              <span className="form-control-static select-placeholder">{commandView.name}</span>
+            </div>
+          </div>
+        )}
+        {!isInstanceType && (
+          <div className="row">
+            <div className="col-md-2 sm-label-right">Adjustment Step</div>
+            <div className="col-md-10 content-fields">
+              <span className="form-control-static select-placeholder">
+                {`${operator} instannces in increments of at least `}
+              </span>
+              <NumberInput
+                value={commandView.minAdjustmentMagnitude}
+                onChange={(e) => setCommandField('minAdjustmentMagnitude', Number.parseInt(e.target.value))}
+                inputClassName="sp-margin-xs-right input-sm number-input-sm"
+              />
+              <span className="input-label"> instance(s) </span>
+            </div>
+          </div>
+        )}
+        {Boolean(commandView.simple) && (
+          <div className="row">
+            <div className="col-md-2 sm-label-right">Cooldown</div>
+            <div className="col-md-10 content-fields">
+              <span className="form-control-static select-placeholder"> Wait at least </span>
+              <NumberInput
+                value={commandView.simple?.cooldown}
+                onChange={(e) => setCommandField('simple.cooldown', Number.parseInt(e.target.value))}
+                inputClassName="sp-margin-xs-xaxis input-sm number-input-sm"
+              />
+              <span className="input-label"> seconds before another scaling event </span>
+            </div>
+          </div>
+        )}
+        {Boolean(commandView.step?.estimatedInstanceWarmup) && operator !== 'Remove' && (
+          <div className="row">
+            <div className="col-md-2 sm-label-right">Warmup</div>
+            <div className="col-md-10 content-fields">
+              <span className="form-control-static select-placeholder">Instances need</span>
+              <NumberInput
+                value={commandView.step.estimatedInstanceWarmup}
+                onChange={(e) => setCommandField('step.estimatedInstanceWarmup', Number.parseInt(e.target.value))}
+                inputClassName="sp-margin-xs-xaxis input-sm number-input-sm"
+              />
+              <span className="input-label"> seconds to warm up after each step </span>
+            </div>
+          </div>
+        )}
+        {Boolean(commandView.step?.cooldown) && operator !== 'Remove' && (
+          <div className="row">
+            <div className="col-md-2 sm-label-right">
+              <span className="sp-margin-xs-right">Cooldown</span>
+              <HelpField id={`${commandView.cloudProvider || commandView.provider}.autoscaling.cooldown`} />
+            </div>
+            <div className="col-md-10 content-fields">
+              <NumberInput
+                value={commandView.step?.cooldown}
+                onChange={(e) => setCommandField('step.cooldown', Number.parseInt(e.target.value))}
+                inputClassName="sp-margin-xs-xaxis input-sm number-input-sm"
+              />
+              <span className="input-label"> seconds </span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ADDITIONAL_SETTINGS_COMPONENT =
+  'spinnaker.amazon.serverGroup.details.scalingPolicy.additionalSettings.component';
+export const name = AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ADDITIONAL_SETTINGS_COMPONENT;
+
+module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ADDITIONAL_SETTINGS_COMPONENT, []).component(
+  'scalingPolicyAdditionalSettings',
+  react2angular(withErrorBoundary(ScalingPolicyAdditionalSettings, 'scalingPolicyAdditionalSettings'), [
+    'command',
+    'isInstanceType',
+    'isNew',
+    'operator',
+    'updateCommand',
+  ]),
+);

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -6,6 +6,7 @@ import { cloneDeep } from 'lodash';
 
 import { TaskMonitor } from '@spinnaker/core';
 
+import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ADDITIONAL_SETTINGS_COMPONENT } from './ScalingPolicyAdditionalSettings';
 import { ScalingPolicyWriter } from '../ScalingPolicyWriter';
 import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_ALARMCONFIGURER_COMPONENT } from './alarm/alarmConfigurer.component';
 import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ALARM_CONFIGURER_COMPONENT } from './alarm/awsAlarmConfigurer.component';
@@ -22,6 +23,7 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTR
   STEP_POLICY_ACTION_COMPONENT,
   AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_ALARM_ALARMCONFIGURER_COMPONENT,
   AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ALARM_CONFIGURER_COMPONENT,
+  AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ADDITIONAL_SETTINGS_COMPONENT,
 ]).controller('awsUpsertScalingPolicyCtrl', [
   '$uibModalInstance',
   'serverGroup',
@@ -123,6 +125,10 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTR
         scalingAdjustment: Math.abs(policy.scalingAdjustment) || 1,
       };
     }
+
+    this.commandChanged = (updatedCommand) => {
+      this.command = updatedCommand;
+    };
 
     this.scalingAdjustmentChanged = (adjustment) => {
       this.command.simple.scalingAdjustment = adjustment;

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -29,7 +29,8 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTR
   'serverGroup',
   'application',
   'policy',
-  function ($uibModalInstance, serverGroup, application, policy) {
+  '$scope',
+  function ($uibModalInstance, serverGroup, application, policy, $scope) {
     this.serverGroup = serverGroup;
 
     this.viewState = {
@@ -127,7 +128,9 @@ module(AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTR
     }
 
     this.commandChanged = (updatedCommand) => {
-      this.command = updatedCommand;
+      this.$scope.$applyAsync(() => {
+        this.command = updatedCommand;
+      });
     };
 
     this.scalingAdjustmentChanged = (adjustment) => {

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
@@ -52,65 +52,13 @@
           </step-policy-action>
         </div>
       </div>
-      <h4 class="section-heading">Additional Settings</h4>
-      <div class="section-body section-additional-settings">
-        <div class="row" ng-if="!ctrl.viewState.isNew">
-          <div class="col-md-2 sm-label-right">Policy Name</div>
-          <div class="col-md-10 content-fields">
-            <span
-              class="form-control-static select-placeholder"
-              ng-if="!ctrl.viewState.isNew"
-              ng-bind="ctrl.command.name"
-            ></span>
-          </div>
-        </div>
-
-        <div class="row" ng-if="ctrl.viewState.adjustmentType !== 'instances'">
-          <div class="col-md-2 sm-label-right">Adjustment Step</div>
-          <div class="col-md-10 content-fields">
-            <span class="form-control-static select-placeholder">
-              <span ng-bind="ctrl.viewState.operator"></span>
-              instances in increments of at least
-            </span>
-            <input
-              type="number"
-              style="width: 60px"
-              class="form-control input-sm"
-              required
-              ng-model="ctrl.command.minAdjustmentMagnitude"
-            />
-            <span class="input-label"> instance(s) </span>
-          </div>
-        </div>
-        <div class="row" ng-if="ctrl.command.simple">
-          <div class="col-md-2 sm-label-right">Cooldown</div>
-          <div class="col-md-10 content-fields">
-            <span class="form-control-static select-placeholder"> Wait at least </span>
-            <input
-              type="number"
-              style="width: 60px"
-              class="form-control input-sm"
-              required
-              ng-model="ctrl.command.simple.cooldown"
-            />
-            <span class="input-label"> seconds before another scaling event </span>
-          </div>
-        </div>
-        <div class="row" ng-if="ctrl.command.step && ctrl.viewState.operator !== 'Remove'">
-          <div class="col-md-2 sm-label-right">Warmup</div>
-          <div class="col-md-10 content-fields">
-            <span class="form-control-static select-placeholder">Instances need</span>
-            <input
-              type="number"
-              style="width: 60px"
-              class="form-control input-sm"
-              required
-              ng-model="ctrl.command.step.estimatedInstanceWarmup"
-            />
-            <span class="input-label"> seconds to warm up after each step </span>
-          </div>
-        </div>
-      </div>
+      <scaling-policy-additional-settings
+        command="ctrl.command"
+        is-instance-type="ctrl.viewState.adjustmentType === 'instances'"
+        is-new="ctrl.viewState.isNew"
+        operator="ctrl.viewState.operator"
+        update-command="ctrl.commandChanged"
+      ></scaling-policy-additional-settings>
     </form>
   </div>
 

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.less
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.less
@@ -13,6 +13,10 @@
     .row {
       margin-bottom: 10px;
     }
+
+    .number-input-sm {
+      width: 60px;
+    }
   }
 
   aws-alarm-configurer > .row {


### PR DESCRIPTION
Creates a component with the additional settings section of the step scaling policy modal. This component will be used for both AWS and Titus. 