### PR TITLE
feat(provider/azure): Allow empty load balancer for Azure scale sets

### DIFF
--- a/packages/azure/src/loadBalancer/details/loadBalancerDetail.html
+++ b/packages/azure/src/loadBalancer/details/loadBalancerDetail.html
@@ -55,10 +55,10 @@
           <account-tag account="loadBalancer.account" pad="right" provider="loadBalancer.type"></account-tag>
           {{loadBalancer.region}}
         </dd>
-        <dt ng-if="loadBalancer.loadBalancerType !== 'Azure Load Balancer'">VNet</dt>
-        <dd ng-if="loadBalancer.loadBalancerType !== 'Azure Load Balancer'">{{loadBalancer.elb.vnet}}</dd>
-        <dt ng-if="loadBalancer.loadBalancerType !== 'Azure Load Balancer'">Subnet</dt>
-        <dd ng-if="loadBalancer.loadBalancerType !== 'Azure Load Balancer'">{{loadBalancer.elb.subnet}}</dd>
+        <dt ng-if="loadBalancer.loadBalancerType === 'Azure Application Gateway'">VNet</dt>
+        <dd ng-if="loadBalancer.loadBalancerType === 'Azure Application Gateway'">{{loadBalancer.elb.vnet}}</dd>
+        <dt ng-if="loadBalancer.loadBalancerType === 'Azure Application Gateway'">Subnet</dt>
+        <dd ng-if="loadBalancer.loadBalancerType === 'Azure Application Gateway'">{{loadBalancer.elb.subnet}}</dd>
       </dl>
       <dl class="horizontal-when-filters-collapsed">
         <dt ng-if="loadBalancer.serverGroups">Server Groups</dt>

--- a/packages/azure/src/serverGroup/configure/wizard/loadBalancers/serverGroupLoadBalancersSelector.directive.html
+++ b/packages/azure/src/serverGroup/configure/wizard/loadBalancers/serverGroupLoadBalancersSelector.directive.html
@@ -6,11 +6,20 @@
   <div class="form-group">
     <div class="col-md-3 sm-label-right"><b>Load Balancers</b></div>
     <div class="col-md-7">
+      <label for="useLoadBalancerCheckbox">
+        <input
+          type="checkbox"
+          ng-model="useLoadBalancer"
+          id="useLoadBalancerCheckbox"
+          ng-change="loadBalancerCtrl.loadBalancerChanged(null)"
+        />
+        Use load balancer
+      </label>
       <ui-select
-        required
         ng-model="command.loadBalancerName"
         class="form-control input-sm"
         ng-change="loadBalancerCtrl.loadBalancerChanged($select.selected)"
+        ng-show="useLoadBalancer"
       >
         <ui-select-match placeholder="select a loadBalancer">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="loadBalancer in command.loadBalancers | filter: $select.search">
@@ -20,7 +29,7 @@
     </div>
   </div>
 
-  <div class="form-group">
+  <div class="form-group" ng-show="command.loadBalancerName">
     <div class="col-md-12">
       <div class="well-compact" ng-class="well">
         <h5 class="text-center">

--- a/packages/azure/src/serverGroup/configure/wizard/networkSettings/ServerGroupNetworkSettingsSelector.directive.html
+++ b/packages/azure/src/serverGroup/configure/wizard/networkSettings/ServerGroupNetworkSettingsSelector.directive.html
@@ -5,7 +5,7 @@
   ng-if="command.viewState.networkSettingsConfigured"
   ng-controller="azureServerGroupNetworkSettingsCtrl as networkSettingCtrl"
 >
-  <div class="form-group" ng-if="command.loadBalancerType === 'Azure Load Balancer'">
+  <div class="form-group" ng-if="command.loadBalancerType === 'Azure Load Balancer' || !command.loadBalancerType">
     <div class="col-md-3 sm-label-right">Virtual Network</div>
     <div class="col-md-7">
       <ui-select


### PR DESCRIPTION
Azure health settings can be placed directly on scale sets. If client-
side load balancing (e.g. through Eureka) is used, a load balancer
is not necessary.

This change is dependent on https://github.com/spinnaker/clouddriver/pull/5494.

**Testing done**:

1. Modified an existing pipeline to remove load balancer
2. Modified pipeline from 1) to re-add load balancer
3. Created a new pipeline without a load balancer
4. Created a new pipeline with a load balancer