### PR TITLE
fix(provider/azure): Re-expose Azure provider in deck

### DIFF
--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -7,6 +7,7 @@ import { CORE_MODULE } from '@spinnaker/core';
 import { DOCKER_MODULE } from '@spinnaker/docker';
 import { AMAZON_MODULE } from '@spinnaker/amazon';
 import { APPENGINE_MODULE } from '@spinnaker/appengine';
+import { AZURE_MODULE } from '@spinnaker/azure';
 import { GOOGLE_MODULE } from '@spinnaker/google';
 import { CANARY_MODULE } from './canary/canary.module';
 import { KUBERNETES_MODULE } from '@spinnaker/kubernetes';
@@ -19,6 +20,7 @@ import '@spinnaker/cloudfoundry';
 module('netflix.spinnaker', [
   CORE_MODULE,
   AMAZON_MODULE,
+  AZURE_MODULE,
   GOOGLE_MODULE,
   ECS_MODULE,
   DOCKER_MODULE,


### PR DESCRIPTION
It looks like Azure did not survive [this move](https://github.com/spinnaker/deck/commit/69ff222cecb35572b8e6df8aaaa4c6e2872dbb4b) on 6/24. This change registers the azure module in `app.ts`.

### Without this change

Trying to do anything on an Azure provider will result in this error:

```
Error: No "serverGroup.commandBuilder" service found for provider "azure"
    at ProviderServiceDelegate.getDelegate (index.js:1025)
    at ServerGroupCommandBuilderService.getDelegate (index.js:1832)
    at ServerGroupCommandBuilderService.buildServerGroupCommandFromPipeline (index.js:1832)
    at Object.editCluster (index.js:4258)
    at fn (eval at compile (angular.js:1), <anonymous>:4:360)
    at callback (angular.js:27956)
    at Scope.$eval (angular.js:18796)
    at Scope.$apply (angular.js:18895)
    at HTMLAnchorElement.eval (angular.js:27961)
    at HTMLAnchorElement.dispatch (jquery-3.5.1.min.js:2) undefined
```

### With this change

You can once again view and edit Azure resources through the Deck UI.



