### PR TITLE
feat(provider/azure): Allow specifying App Gateway sku

### DIFF
--- a/packages/azure/src/loadBalancer/configure/advancedSettings.html
+++ b/packages/azure/src/loadBalancer/configure/advancedSettings.html
@@ -62,6 +62,19 @@
           <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.probes[0].timeout" />
         </div>
       </div>
+      <div class="form-group" ng-if="isNew && !isALB">
+        <div class="col-md-4 sm-label-right">
+          <b>SKU</b>
+          <help-field key="azure.loadBalancer.sku"></help-field>
+        </div>
+        <div class="col-md-4">
+          <select
+            class="form-control input-sm"
+            ng-model="loadBalancer.sku"
+            ng-options="sku for sku in validSkus"
+          ></select>
+        </div>
+      </div>
       <div class="form-group" ng-if="isALB">
         <div class="col-md-4 sm-label-right">
           <b>Session persistence</b>

--- a/packages/azure/src/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/packages/azure/src/loadBalancer/configure/createLoadBalancer.controller.js
@@ -53,6 +53,8 @@ module(AZURE_LOADBALANCER_CONFIGURE_CREATELOADBALANCER_CONTROLLER, [
       submitting: false,
     };
 
+    $scope.validSkus = ['Standard_v2', 'Standard_Small'];
+
     function onApplicationRefresh() {
       // If the user has already closed the modal, do not navigate to the new details view
       if ($scope.$$destroyed) {

--- a/packages/azure/src/loadBalancer/loadBalancer.transformer.js
+++ b/packages/azure/src/loadBalancer/loadBalancer.transformer.js
@@ -96,6 +96,7 @@ module(AZURE_LOADBALANCER_LOADBALANCER_TRANSFORMER, []).factory('azureLoadBalanc
             idleTimeout: 4,
           },
         ],
+        sku: 'Standard_v2',
       };
     }
 


### PR DESCRIPTION
Azure released App Gateway v2 which allows certs from key vault. In order to take advantage of this, allow the user to select v2 or v1 (Standard_Small) skus from the UI.

This change is dependent on https://github.com/spinnaker/clouddriver/pull/5510.

**Screenshots**:

![image](https://user-images.githubusercontent.com/910168/131927524-8b6e937d-0c3d-4a0a-b942-b25cd54ea72b.png)

**Testing Done**:

1. Tested (together with changes in deck) the following:
    1. Modify existing v1-sku App Gateways
    2. Create new v1-sku App Gateways
    3. Create new v2-sku App Gateways
    4. Delete v1-sku App Gateways
    5. Delete v2-sku App Gateways
    6. Deploy to v1-sku App Gateway
    6. Deploy to v2-sku App Gateway