### PR TITLE
Titus: Support default subnets

### DIFF
--- a/packages/amazon/src/subnet/SubnetSelectField.tsx
+++ b/packages/amazon/src/subnet/SubnetSelectField.tsx
@@ -1,5 +1,4 @@
-import { some } from 'lodash';
-import React from 'react';
+import * as React from 'react';
 
 import { Application, HelpField, ISubnet, Markdown } from '@spinnaker/core';
 
@@ -15,7 +14,10 @@ export interface ISubnetSelectFieldProps {
   labelColumns: number;
   onChange: () => void;
   readOnly?: boolean;
-  provider?: 'aws' | 'titus';
+  // The default value to select when subnets change
+  defaultSubnetTypes?: string[];
+  // The recommended values; all other values will display a configurable warning
+  recommendedSubnetTypes?: string[];
   region: string;
   subnets: ISubnet[];
   showSubnetWarning?: boolean;
@@ -29,12 +31,22 @@ export class SubnetSelectField extends React.Component<ISubnetSelectFieldProps> 
   };
 
   public render() {
-    const { labelColumns, helpKey, component, provider, region, field, showSubnetWarning, ...otherProps } = this.props;
+    const {
+      component,
+      defaultSubnetTypes,
+      field,
+      helpKey,
+      labelColumns,
+      recommendedSubnetTypes,
+      region,
+      showSubnetWarning,
+      ...otherProps
+    } = this.props;
+
     const value = component[field];
-    const isRecommended = some(
-      AWSProviderSettings.serverGroups?.recommendedSubnets || [],
-      (subnet) => value && value.includes(subnet),
-    );
+    const recommendedSubnets =
+      this.props.recommendedSubnetTypes ?? AWSProviderSettings.serverGroups?.recommendedSubnets ?? [];
+    const isRecommended = recommendedSubnets.some((subnet) => value && value.includes(subnet));
     const subnetWarning = AWSProviderSettings.serverGroups?.subnetWarning;
     return (
       <div className="form-group">
@@ -46,8 +58,8 @@ export class SubnetSelectField extends React.Component<ISubnetSelectFieldProps> 
             <SubnetSelectInput
               {...otherProps}
               inputClassName="form-control input-sm"
-              provider={provider ?? 'aws'}
               credentials={component.credentials}
+              defaultSubnetTypes={defaultSubnetTypes}
               region={region}
               value={value}
               onChange={this.handleChange}

--- a/packages/amazon/src/subnet/SubnetSelectInput.spec.tsx
+++ b/packages/amazon/src/subnet/SubnetSelectInput.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, render } from 'enzyme';
 import { mock } from 'angular';
 import { SubnetSelectInput } from './SubnetSelectInput';
 import { Application, ApplicationModelBuilder } from '@spinnaker/core';
@@ -35,8 +35,8 @@ describe('SubnetSelectInput', () => {
   });
 
   it('should generate options', () => {
-    const wrapper = shallow<SubnetSelectInput>(<SubnetSelectInput {...INPUT_PROPS} />);
-    expect(wrapper.state().options.length).toBeGreaterThan(0);
+    const wrapper = render(<SubnetSelectInput {...INPUT_PROPS} />);
+    expect(wrapper.find('option').length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/amazon/src/subnet/SubnetSelectInput.tsx
+++ b/packages/amazon/src/subnet/SubnetSelectInput.tsx
@@ -64,7 +64,7 @@ function getOptions(subnets: ISubnet[], isClassicHidden: boolean): Array<Option<
   return classicOption.concat(activeOptions).concat(deprecatedOptions) as Array<Option<string>>;
 }
 
-function getDefaultSubnet(subnets: ISubnet[], defaultSubnetTypes: string[]): ISubnet {
+function getDefaultSubnet(subnets: ISubnet[], defaultSubnetTypes: string[] = []): ISubnet {
   for (const subnetType of defaultSubnetTypes) {
     const defaultSubnet = subnets.find((subnet) => subnetType === subnet.purpose);
     if (defaultSubnet) {

--- a/packages/amazon/src/subnet/SubnetSelectInput.tsx
+++ b/packages/amazon/src/subnet/SubnetSelectInput.tsx
@@ -4,13 +4,13 @@ import { Option } from 'react-select';
 
 import {
   Application,
-  arePropsEqual,
   createFakeReactSyntheticEvent,
   ISelectInputProps,
   ISubnet,
   Omit,
   SelectInput,
-  SETTINGS,
+  useDeepObjectDiff,
+  useMountStatusRef,
 } from '@spinnaker/core';
 import { AWSProviderSettings } from '../aws.settings';
 
@@ -20,7 +20,9 @@ export interface ISubnetSelectInputProps extends Omit<ISelectInputProps, 'option
   application: Application;
   readOnly?: boolean;
   hideClassic?: boolean;
-  provider: 'aws' | 'titus';
+  // Ordered list of subnet types to default to
+  // higher priority defaults should be ordered first
+  defaultSubnetTypes: string[];
   subnets: ISubnet[];
   region: string;
   credentials: string;
@@ -30,79 +32,88 @@ export interface ISubnetSelectInputState {
   options: Array<Option<string>>;
 }
 
-export class SubnetSelectInput extends React.Component<ISubnetSelectInputProps, ISubnetSelectInputState> {
-  public state: ISubnetSelectInputState = { options: [] };
+function isClassicLockout(region: string, credentials: string, application: Application): boolean {
+  const { classicLaunchLockout, classicLaunchAllowlist: allowlist } = AWSProviderSettings;
 
-  private isClassicLockout(region: string, credentials: string, application: Application): boolean {
-    const { classicLaunchLockout, classicLaunchAllowlist: allowlist } = AWSProviderSettings;
+  const appCreationDate = Number(get(application, 'attributes.createTs', 0));
+  const appCreatedAfterLockout = appCreationDate > (classicLaunchLockout || 0);
+  const isAllowlisted = !!allowlist && allowlist.some((e) => e.region === region && e.credentials === credentials);
+  return appCreatedAfterLockout || !isAllowlisted;
+}
 
-    const appCreationDate = Number(get(application, 'attributes.createTs', 0));
-    const appCreatedAfterLockout = appCreationDate > (classicLaunchLockout || 0);
-    const isAllowlisted = !!allowlist && allowlist.some((e) => e.region === region && e.credentials === credentials);
-    return appCreatedAfterLockout || !isAllowlisted;
+function getOptions(subnets: ISubnet[], isClassicHidden: boolean): Array<Option<string>> {
+  const sortByLabel = (a: ISubnet, b: ISubnet) => a.label.localeCompare(b.label);
+  const asOption = (subnet: ISubnet): Option<string> => ({ value: subnet.purpose, label: subnet.label });
+
+  const classicOption = isClassicHidden ? [] : [{ label: 'None (EC2 Classic)', value: '' } as Option];
+
+  const activeOptions = subnets
+    .filter((x) => !x.deprecated)
+    .sort(sortByLabel)
+    .map(asOption);
+
+  const deprecatedOptions = subnets
+    .filter((x) => x.deprecated)
+    .sort(sortByLabel)
+    .map(asOption);
+
+  if (deprecatedOptions.length) {
+    deprecatedOptions.unshift({ label: '-----------', value: '', disabled: true });
   }
 
-  private getOptions(subnets: ISubnet[], isClassicHidden: boolean): Array<Option<string>> {
-    const sortByLabel = (a: ISubnet, b: ISubnet) => a.label.localeCompare(b.label);
-    const asOption = (subnet: ISubnet): Option<string> => ({ value: subnet.purpose, label: subnet.label });
+  return classicOption.concat(activeOptions).concat(deprecatedOptions) as Array<Option<string>>;
+}
 
-    const classicOption = isClassicHidden ? [] : [{ label: 'None (EC2 Classic)', value: '' } as Option];
-
-    const activeOptions = subnets
-      .filter((x) => !x.deprecated)
-      .sort(sortByLabel)
-      .map(asOption);
-
-    const deprecatedOptions = subnets
-      .filter((x) => x.deprecated)
-      .sort(sortByLabel)
-      .map(asOption);
-
-    if (deprecatedOptions.length) {
-      deprecatedOptions.unshift({ label: '-----------', value: '', disabled: true });
-    }
-
-    return classicOption.concat(activeOptions).concat(deprecatedOptions) as Array<Option<string>>;
-  }
-
-  private updateOptions() {
-    const { value, hideClassic, subnets, region, credentials, application } = this.props;
-    const isClassicHidden = hideClassic || this.isClassicLockout(region, credentials, application);
-    const options = this.getOptions(subnets, isClassicHidden);
-
-    this.setState({ options });
-
-    if (!value) {
-      this.applyDefaultSubnet();
+function getDefaultSubnet(subnets: ISubnet[], defaultSubnetTypes: string[]): ISubnet {
+  for (const subnetType of defaultSubnetTypes) {
+    const defaultSubnet = subnets.find((subnet) => subnetType === subnet.purpose);
+    if (defaultSubnet) {
+      return defaultSubnet;
     }
   }
+  return undefined;
+}
 
-  public componentDidMount() {
-    this.updateOptions();
-  }
+export function SubnetSelectInput(props: ISubnetSelectInputProps) {
+  const {
+    application,
+    credentials,
+    defaultSubnetTypes,
+    hideClassic,
+    name,
+    onChange,
+    readOnly,
+    region,
+    subnets,
+    value,
+    ...otherProps
+  } = props;
 
-  public componentDidUpdate(prevProps: ISubnetSelectInputProps): void {
-    if (!arePropsEqual(this.props, prevProps, ['hideClassic', 'subnets', 'region', 'credentials', 'application'])) {
-      this.updateOptions();
-    }
-  }
+  // Allow subnets array reference to change by parent component
+  const subnetsDiff = useDeepObjectDiff(subnets);
 
-  public applyDefaultSubnet() {
-    const { value, onChange, provider, subnets, name } = this.props;
-    const defaultSubnetType = get(SETTINGS, `providers.${provider}.defaults.subnetType`);
-    const defaultSubnet = subnets.find((subnet) => defaultSubnetType === subnet.purpose) || subnets[0];
-    if (!value && defaultSubnet) {
+  const options = React.useMemo(() => {
+    const isClassicHidden = hideClassic || isClassicLockout(region, credentials, application);
+    return getOptions(subnets, isClassicHidden);
+  }, [hideClassic, region, credentials, application, subnetsDiff]);
+
+  const defaultSubnet = getDefaultSubnet(subnets, defaultSubnetTypes) || subnets[0];
+  const mountStatus = useMountStatusRef().current;
+
+  React.useEffect(() => {
+    const isSelectionValid = options.some((o) => o.value === value);
+    // - apply the default value whenever `options` changes and the current
+    // selection is invalid, including on the first pass
+    // - apply the default value on all subsequent renders if `options` changes
+    const applyDefault = !isSelectionValid || mountStatus !== 'FIRST_RENDER';
+    if (defaultSubnet && applyDefault) {
       onChange(createFakeReactSyntheticEvent({ name, value: defaultSubnet.purpose }));
     }
+  }, [options]);
+
+  if (readOnly) {
+    return <p className="form-control-static">{props.value || 'None (EC2 Classic)'}</p>;
   }
 
-  public render() {
-    const { readOnly, ...otherProps } = this.props;
-
-    if (readOnly) {
-      return <p className="form-control-static">{this.props.value || 'None (EC2 Classic)'}</p>;
-    }
-
-    return <SelectInput options={this.state.options} {...otherProps} />;
-  }
+  return <SelectInput options={options} value={value} onChange={onChange} {...otherProps} />;
 }

--- a/packages/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/packages/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -1,7 +1,7 @@
 import { Field, FormikErrors, FormikProps } from 'formik';
 import React from 'react';
 
-import { SubnetSelectField } from '@spinnaker/amazon';
+import { AWSProviderSettings, SubnetSelectField } from '@spinnaker/amazon';
 import {
   AccountSelectInput,
   AccountTag,
@@ -20,6 +20,7 @@ import {
 import { DockerImageAndTagSelector, DockerImageUtils } from '@spinnaker/docker';
 
 import { ITitusServerGroupCommand } from '../../../configure/serverGroupConfiguration.service';
+import { TitusProviderSettings } from '../../../../titus.settings';
 
 const isNotExpressionLanguage = (field: string) => field && !field.includes('${');
 
@@ -191,6 +192,11 @@ export class ServerGroupBasicSettings
 
     const customImage = values.imageId && values.imageId !== '${trigger.properties.imageName}';
 
+    const defaultSubnetTypes = []
+      .concat(TitusProviderSettings.defaults?.subnetType)
+      .concat(AWSProviderSettings.defaults?.subnetType)
+      .filter((x) => !!x);
+
     return (
       <div className="container-fluid form-horizontal">
         <DeployingIntoManagedClusterWarning app={app} formik={formik} />
@@ -233,9 +239,10 @@ export class ServerGroupBasicSettings
           helpKey="titus.serverGroup.subnet"
           labelColumns={3}
           onChange={this.onSubnetChange}
-          provider="titus"
           region={values.region}
           subnets={values.backingData.filtered.subnetPurposes}
+          defaultSubnetTypes={defaultSubnetTypes}
+          recommendedSubnetTypes={TitusProviderSettings.serverGroups?.recommendedSubnets}
           showSubnetWarning={true}
         />
         <div className="form-group">

--- a/packages/titus/src/titus.settings.ts
+++ b/packages/titus/src/titus.settings.ts
@@ -7,6 +7,9 @@ export interface ITitusProviderSettings extends IProviderSettings {
     subnetType?: string;
     iamProfile?: string;
   };
+  serverGroups?: {
+    recommendedSubnets?: string[];
+  };
   scalingActivities?: string[];
 }
 


### PR DESCRIPTION
- Migrates AWS `SubnetSelectInput` to functional component
- `SubnetSelectInput` now uses the default subnet any time the account/region is changed
- Adds support to Titus for default subnet types (merges with AWS default subnet type)
- Adds support to Titus for recommended subnet types