### PR TITLE
fix(core): do not show "0" when no scaling activities detected

### DIFF
--- a/packages/core/src/serverGroup/details/scalingActivities/ScalingActivitiesModal.tsx
+++ b/packages/core/src/serverGroup/details/scalingActivities/ScalingActivitiesModal.tsx
@@ -89,7 +89,7 @@ export const ScalingActivitiesModal = ({ dismissModal, serverGroup }: IScalingAc
             <p>{`No scaling activities found for ${serverGroup.name}.`}</p>
           </div>
         )}
-        {!loading && !error && scalingActivities.length && (
+        {!loading && !error && scalingActivities.length > 0 && (
           <div className="ScalingAcivitiesModalBody middle sp-margin-xl-yaxis">
             {scalingActivities.map((a, i) => (
               <div key={a.cause}>


### PR DESCRIPTION
Removes the "0" when there are no scaling activities:
<img width="983" alt="Screen Shot 2021-09-07 at 10 38 59 AM" src="https://user-images.githubusercontent.com/73450/132387752-f0463d25-96d8-4424-a401-69c6c9d873f2.png">

(I still make this mistake at least once a month)