### PR TITLE
fix(style): keep submit button status indicator inline with label

### DIFF
--- a/packages/core/src/modal/buttons/submitButton.component.ts
+++ b/packages/core/src/modal/buttons/submitButton.component.ts
@@ -10,9 +10,11 @@ export const submitButtonComponent: IComponentOptions = {
   },
   template: `
     <button class="btn btn-primary" ng-disabled="$ctrl.isDisabled" ng-click="$ctrl.onClick()">
-      <i ng-if="!$ctrl.submitting" class="far fa-check-circle"></i>
-      <loading-spinner ng-if="$ctrl.submitting" mode="'circular'"></loading-spinner>
-      {{$ctrl.label || ($ctrl.isNew ? 'Create' : 'Update')}}
+      <div class="flex-container-h horizontal middle">
+        <i ng-if="!$ctrl.submitting" class="far fa-check-circle"></i>
+        <loading-spinner ng-if="$ctrl.submitting" mode="'circular'"></loading-spinner>
+        <span class="sp-margin-xs-left">{{$ctrl.label || ($ctrl.isNew ? 'Create' : 'Update')}}</span>
+      </div>
     </button>`,
 };
 


### PR DESCRIPTION
This only affects old-timey Angular submit buttons. The React ones look fine.

Before:
<img width="76" alt="Screen Shot 2021-09-10 at 1 02 26 PM" src="https://user-images.githubusercontent.com/73450/132912348-b738a23d-0782-4d1b-8c3c-85cbeceae5f3.png">

After:
<img width="94" alt="Screen Shot 2021-09-10 at 1 01 57 PM" src="https://user-images.githubusercontent.com/73450/132912367-95127396-9d56-4c70-9c3c-bdc553890a53.png">
