### PR TITLE
fix(amazon): Use account or awsAccount for cloud metrics reader

### DIFF
--- a/packages/amazon/src/domain/IAmazonServerGroup.ts
+++ b/packages/amazon/src/domain/IAmazonServerGroup.ts
@@ -22,6 +22,7 @@ export interface IAmazonServerGroup extends IServerGroup {
   scalingPolicies?: IScalingPolicy[];
   targetGroups?: string[];
   asg: IAmazonAsg;
+  awsAccount?: string;
   launchTemplate?: IAmazonLaunchTemplate;
   mixedInstancesPolicy?: IAmazonMixedInstancesPolicy;
 }

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/chart/MetricAlarmChart.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/chart/MetricAlarmChart.tsx
@@ -32,7 +32,7 @@ export function MetricAlarmChart(props: IMetricAlarmChartProps) {
 export function MetricAlarmChartImpl(props: IMetricAlarmChartProps) {
   const alarm = props.alarm ?? ({} as IScalingPolicyAlarm);
   const serverGroup = props.serverGroup ?? ({} as IAmazonServerGroup);
-  const { type, account, region } = serverGroup;
+  const { account, awsAccount, cloudProvider, region, type } = serverGroup;
   const { metricName, namespace, statistic, period } = alarm;
 
   const { status, result } = useData<ICloudMetricStatistics>(
@@ -40,7 +40,8 @@ export function MetricAlarmChartImpl(props: IMetricAlarmChartProps) {
       const parameters: Record<string, string | number> = { namespace, statistics: statistic, period };
       alarm.dimensions.forEach((dimension) => (parameters[dimension.name] = dimension.value));
 
-      const result = await CloudMetricsReader.getMetricStatistics(type, account, region, metricName, parameters);
+      const metricAccount = cloudProvider === 'aws' ? account : awsAccount;
+      const result = await CloudMetricsReader.getMetricStatistics('aws', metricAccount, region, metricName, parameters);
       result.datapoints = result.datapoints || [];
       props.onChartLoaded?.(result);
 

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/MetricSelector.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/MetricSelector.tsx
@@ -53,7 +53,8 @@ export const MetricSelector = ({ alarm, updateAlarm, serverGroup }: IMetricSelec
   const dimensionValuesStr = buildDimensionValues(alarm?.dimensions || []);
 
   const fetchCloudMetrics = () => {
-    return CloudMetricsReader.listMetrics('aws', serverGroup.account, serverGroup.region, dimensionsObject).then(
+    const account = serverGroup.cloudProvider === 'aws' ? serverGroup.account : serverGroup?.awsAccount;
+    return CloudMetricsReader.listMetrics('aws', account, serverGroup.region, dimensionsObject).then(
       (metrics: ICloudMetricDescriptor[]) => {
         const sortedMetrics: IMetricOption[] = metrics
           .map((m) => ({


### PR DESCRIPTION
Fallback to `awsAccount` if cloudprovider is not `aws`. 