### PR TITLE
fix(pipelines): Reduce pipelineConfig fetches

### DIFF
--- a/packages/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/packages/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -30,7 +30,7 @@ export interface ISingleExecutionRouterStateChange extends IStateChange {
 }
 
 export function getAndTransformExecution(id: string, app: Application) {
-  return ReactInjector.executionService.getExecution(id).then((execution) => {
+  return ReactInjector.executionService.getExecution(id, app.pipelineConfigs?.data).then((execution) => {
     ExecutionsTransformer.transformExecution(app, execution);
     return execution;
   });


### PR DESCRIPTION
We were indiscriminately fetching `pipelineConfig`s on `getExecution` even though we might already have it locally under the `pipelineConfigs` data source.

This especially hurts when running `mergeRunningExecutionsIntoExecutions` doesn't find an `isActive` execution in the `runningExecutions` data source so it decides to fetch it individually (multiplied by the number of running executions that weren't found):
https://github.com/spinnaker/deck/blob/d28eac29c463069358e8c07413a56b290af9f7ce/packages/core/src/pipeline/service/execution.service.ts#L403-L409

This became especially apparent today when I saw an app with 71 running executions making 71 requests to refresh those executions where another 71 fetches for pipelineConfigs (many duplicate as there are only 5 unique).

Why were so many active executions not found in the `runningExecutions` data source? That is a great question which I will be looking into next, but either way, it doesn't hurt skip the fetch if we already have it locally.