### PR TITLE
fix(amazon): Scaling policy data fetch failure from undefined cloud provider

### DIFF
--- a/packages/amazon/src/serverGroup/details/scalingPolicy/chart/MetricAlarmChart.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/chart/MetricAlarmChart.tsx
@@ -32,7 +32,7 @@ export function MetricAlarmChart(props: IMetricAlarmChartProps) {
 export function MetricAlarmChartImpl(props: IMetricAlarmChartProps) {
   const alarm = props.alarm ?? ({} as IScalingPolicyAlarm);
   const serverGroup = props.serverGroup ?? ({} as IAmazonServerGroup);
-  const { account, awsAccount, cloudProvider, region, type } = serverGroup;
+  const { account, awsAccount, region, type } = serverGroup;
   const { metricName, namespace, statistic, period } = alarm;
 
   const { status, result } = useData<ICloudMetricStatistics>(
@@ -40,7 +40,7 @@ export function MetricAlarmChartImpl(props: IMetricAlarmChartProps) {
       const parameters: Record<string, string | number> = { namespace, statistics: statistic, period };
       alarm.dimensions.forEach((dimension) => (parameters[dimension.name] = dimension.value));
 
-      const metricAccount = cloudProvider === 'aws' ? account : awsAccount;
+      const metricAccount = type === 'aws' ? account : awsAccount;
       const result = await CloudMetricsReader.getMetricStatistics('aws', metricAccount, region, metricName, parameters);
       result.datapoints = result.datapoints || [];
       props.onChartLoaded?.(result);


### PR DESCRIPTION
It turns out that only some server groups have `cloudProvider` set, but they all have `type` set. This fixes an error where the incorrect parameter was being passed to the `CloudMetricsReader`. 