### PR TITLE
chore(app): make packages/app/tsconfig.json extend ../tsconfig.app.base.json

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,38 +1,9 @@
 {
+  "extends": "../tsconfig.app.base.json",
   "compilerOptions": {
-    // project options
-    "allowJs": true,
     "baseUrl": "./src",
-    "declaration": true,
-    "jsx": "react",
-    "module": "esnext",
     "outDir": "dist",
-    "rootDir": "./src",
-    "sourceMap": true,
-    "target": "es2017",
-
-    // strict checks
-    "noImplicitAny": true,
-    "noImplicitThis": false, // should really get to a place where we can turn this on
-    "strictNullChecks": false, // should really get to a place where we can turn this on
-
-    // module resolution
-    "allowSyntheticDefaultImports": true,
-    "moduleResolution": "node",
-
-    // linter
-    "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-
-    // experimental
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-
-    // advanced
-    "noEmitHelpers": false,
-    "pretty": true,
-    "skipLibCheck": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["**/*.spec.*"]


### PR DESCRIPTION
I moved this from app/scripts/modules/app  to packages/app a bit ago.  I just noticed that this config used (basically) all the same settings as `tsconfig.app.base.json`

