### PR TITLE
fix(core): Ensure text is string in CopyToClipboard

### DIFF
--- a/packages/core/src/utils/clipboard/CopyToClipboard.tsx
+++ b/packages/core/src/utils/clipboard/CopyToClipboard.tsx
@@ -93,7 +93,7 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
 
     const persistOverlay = Boolean(tooltipCopy);
     const copy = tooltipCopy || toolTip;
-    const id = `clipboardValue-${text.replace(' ', '-')}`;
+    const id = `clipboardValue-${text.toString().replace(' ', '-')}`;
     const tooltipComponent = <Tooltip id={id}>{copy}</Tooltip>;
 
     // Hack - shouldUpdatePosition is a valid prop, just not declared in typings


### PR DESCRIPTION
In an edge case, `text` prop was a boolean (from the webhook stage). This would bypass defaulting the prop to an empty string, and cause `text.replace()` to fail. 