### PR TITLE
refactor(amazon): Step Policy popover and details

### DIFF
--- a/packages/amazon/src/aws.module.ts
+++ b/packages/amazon/src/aws.module.ts
@@ -47,6 +47,7 @@ import { AWS_SECURITY_GROUP_MODULE } from './securityGroup/securityGroup.module'
 import { AmazonCloneServerGroupModal } from './serverGroup/configure/wizard/AmazonCloneServerGroupModal';
 import { AmazonServerGroupActions } from './serverGroup/details/AmazonServerGroupActions';
 import { amazonServerGroupDetailsGetter } from './serverGroup/details/amazonServerGroupDetailsGetter';
+import { AmazonUpsertScalingPolicyModal, AmazonUpsertTargetTrackingModal } from './serverGroup/details/scalingPolicy';
 import {
   AdvancedSettingsDetailsSection,
   AmazonCapacityDetailsSection,
@@ -142,6 +143,8 @@ module(AMAZON_MODULE, [
       commandBuilder: 'awsServerGroupCommandBuilder',
       configurationService: 'awsServerGroupConfigurationService',
       scalingActivitiesEnabled: true,
+      UpsertStepPolicyModal: AmazonUpsertScalingPolicyModal,
+      UpsertTargetTrackingModal: AmazonUpsertTargetTrackingModal,
     },
     instance: {
       instanceTypeService: 'awsInstanceTypeService',

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/StepPolicySummary.less
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/StepPolicySummary.less
@@ -1,0 +1,6 @@
+.StepPolicySummary {
+  .HoverablePopover {
+    min-height: 600px;
+    text-decoration: none;
+  }
+}

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/StepPolicySummary.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/StepPolicySummary.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+
+import {
+  Application,
+  CloudProviderRegistry,
+  ConfirmationModalService,
+  HoverablePopover,
+  IServerGroup,
+  ReactModal,
+  robotToHuman,
+} from '@spinnaker/core';
+
+import { ScalingPolicyWriter } from './ScalingPolicyWriter';
+import { IAmazonServerGroup, IScalingPolicyView } from '../../../domain';
+import { AlarmSummary } from './popover/AlarmSummary';
+import { StepPolicyPopoverContent } from './popover/StepPolicyPopoverContent';
+
+export interface IStepPolicySummaryProps {
+  application: Application;
+  policy: IScalingPolicyView;
+  serverGroup: IServerGroup;
+}
+
+export const StepPolicySummary = ({ application, policy, serverGroup }: IStepPolicySummaryProps) => {
+  const provider = serverGroup.type || serverGroup.cloudProvider || 'aws';
+  const providerConfig = CloudProviderRegistry.getValue(provider, 'serverGroup');
+
+  const UpsertModalComponent = providerConfig.UpsertStepPolicyModal;
+
+  const editPolicy = () => {
+    const upsertProps = {
+      app: application,
+      policy,
+      serverGroup,
+    };
+
+    const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
+    ReactModal.show<typeof UpsertModalComponent>(UpsertModalComponent, upsertProps, modalProps);
+  };
+  const deletePolicy = () => {
+    const taskMonitor = {
+      application,
+      title: `Deleting scaling policy ${policy.policyName}`,
+    };
+
+    const submitMethod = () => ScalingPolicyWriter.deleteScalingPolicy(application, serverGroup, policy);
+
+    ConfirmationModalService.confirm({
+      header: `Really delete ${policy.policyName}?`,
+      buttonText: 'Delete scaling policy',
+      account: policy.alarms.length ? serverGroup.account : null,
+      taskMonitorConfig: taskMonitor,
+      submitMethod: submitMethod,
+    });
+  };
+
+  if (!policy.alarms?.length) {
+    return <div>No alarms configured for this policy - it's safe to delete.</div>;
+  }
+
+  return (
+    <div>
+      <span className="label label-default">{robotToHuman(policy.policyType).toUpperCase()}</span>
+      <div>
+        {policy.alarms.map((a) => (
+          <div key={`step-summary-${policy.policyName}`}>
+            <HoverablePopover
+              Component={() => (
+                <StepPolicyPopoverContent policy={policy} serverGroup={serverGroup as IAmazonServerGroup} />
+              )}
+            >
+              <AlarmSummary alarm={a} />
+            </HoverablePopover>
+            <div className="actions">
+              <button className="btn btn-xs btn-link" onClick={editPolicy}>
+                <span className="glyphicon glyphicon-cog"></span>
+                <span className="sr-only">Edit policy</span>
+              </button>
+              <button className="btn btn-xs btn-link" onClick={deletePolicy}>
+                <span className="glyphicon glyphicon-trash"></span>
+                <span className="sr-only">Delete policy</span>
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/StepPolicySummary.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/StepPolicySummary.tsx
@@ -1,17 +1,16 @@
 import * as React from 'react';
 
 import {
-  Application,
   CloudProviderRegistry,
   ConfirmationModalService,
   HoverablePopover,
-  IServerGroup,
   ReactModal,
   robotToHuman,
   TaskExecutor,
 } from '@spinnaker/core';
+import type { Application, IServerGroup } from '@spinnaker/core';
 
-import { IAmazonServerGroup, IScalingPolicyView } from '../../../domain';
+import type { IAmazonServerGroup, IScalingPolicyView } from '../../../domain';
 import { AlarmSummary } from './popover/AlarmSummary';
 import { StepPolicyPopoverContent } from './popover/StepPolicyPopoverContent';
 

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/StepPolicySummary.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/StepPolicySummary.tsx
@@ -15,6 +15,8 @@ import { IAmazonServerGroup, IScalingPolicyView } from '../../../domain';
 import { AlarmSummary } from './popover/AlarmSummary';
 import { StepPolicyPopoverContent } from './popover/StepPolicyPopoverContent';
 
+import './StepPolicySummary.less';
+
 export interface IStepPolicySummaryProps {
   application: Application;
   policy: IScalingPolicyView;
@@ -59,7 +61,7 @@ export const StepPolicySummary = ({ application, policy, serverGroup }: IStepPol
   }
 
   return (
-    <div>
+    <div className="StepPolicySummary">
       <span className="label label-default">{robotToHuman(policy.policyType).toUpperCase()}</span>
       <div>
         {policy.alarms.map((a) => (
@@ -68,6 +70,8 @@ export const StepPolicySummary = ({ application, policy, serverGroup }: IStepPol
               Component={() => (
                 <StepPolicyPopoverContent policy={policy} serverGroup={serverGroup as IAmazonServerGroup} />
               )}
+              placement="left"
+              title={policy.policyName}
             >
               <AlarmSummary alarm={a} />
             </HoverablePopover>

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/alarmBasedSummary.template.html
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/alarmBasedSummary.template.html
@@ -1,5 +1,5 @@
-<alarm-based-summary
+<step-policy-summary
   policy="$ctrl.policy"
   server-group="$ctrl.serverGroup"
   application="$ctrl.application"
-></alarm-based-summary>
+></step-policy-summary>

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/index.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/index.ts
@@ -3,6 +3,7 @@ export { MetricAlarmChart } from './chart/MetricAlarmChart';
 export * from './ScalingPolicyTypeRegistry';
 export * from './CreateScalingPolicyButton';
 export * from './ScalingPolicyWriter';
+export * from './StepPolicySummary';
 export * from './targetTracking/TargetTrackingAdditionalSettings';
 export * from './targetTracking/TargetMetricFields';
 export * from './targetTracking/TargetTrackingChart';

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/index.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/index.ts
@@ -6,4 +6,5 @@ export * from './ScalingPolicyWriter';
 export * from './targetTracking/TargetTrackingAdditionalSettings';
 export * from './targetTracking/TargetMetricFields';
 export * from './targetTracking/TargetTrackingChart';
+export { UpsertTargetTrackingModal as AmazonUpsertTargetTrackingModal } from './targetTracking/UpsertTargetTrackingModal';
 export * from './upsert';

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/popover/AlarmSummary.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/popover/AlarmSummary.tsx
@@ -5,13 +5,22 @@ export interface IAlarmSummaryProps {
   alarm: IScalingPolicyAlarmView;
 }
 
+export const comparatorMap = {
+  GreaterThanOrEqualToThreshold: '>=',
+  GreaterThanThreshold: '>',
+  LessThanOrEqualToThreshold: '<=',
+  LessThanThreshold: '<',
+};
+
 export const AlarmSummary = ({ alarm }: IAlarmSummaryProps) => (
   <div>
-    <b>Whenever</b>
-    {` ${alarm.statistic} of `}
-    <span className="alarm-name">{alarm.metricName}</span>
-    {` is ${alarm.comparator} ${alarm.threshold} `}
-    <b>for at least</b>
-    {` ${alarm.evaluationPeriods} consecutive periods of ${alarm.period} seconds`}
+    <div>
+      <b>Whenever</b>
+      {` ${alarm.statistic} of ${alarm.metricName}`}
+    </div>
+    <div>
+      <b>for at least</b>
+      {` ${alarm.evaluationPeriods} consecutive periods of ${alarm.period} seconds`}
+    </div>
   </div>
 );

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/popover/StepPolicyPopoverContent.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/popover/StepPolicyPopoverContent.tsx
@@ -9,7 +9,7 @@ import {
   IScalingPolicyView,
   IStepAdjustmentView,
 } from '../../../../domain';
-import { COMPARATORS } from '../upsert';
+import { comparatorMap } from '../popover/AlarmSummary';
 
 export interface IStepPolicyPopoverContentProps {
   policy: IScalingPolicyView;
@@ -48,10 +48,10 @@ export const StepPolicyPopoverContent = ({ policy, serverGroup }: IStepPolicyPop
 
   return (
     <div>
-      <LabeledValueList>
+      <LabeledValueList className="dl-horizontal dl-narrow">
         <LabeledValue
           label="Whenever"
-          value={`${alarm.statistic} of ${alarm.metricName} is ${COMPARATORS[alarm.comparisonOperator]} ${
+          value={`${alarm.statistic} of ${alarm.metricName} is ${comparatorMap[alarm.comparisonOperator]} ${
             alarm.threshold
           }`}
         />
@@ -62,8 +62,8 @@ export const StepPolicyPopoverContent = ({ policy, serverGroup }: IStepPolicyPop
         {Boolean(stepAdjustments?.length) && (
           <LabeledValue
             label="then"
-            value={stepAdjustments.map((sa) => (
-              <div>
+            value={stepAdjustments.map((sa, index) => (
+              <div key={`step-adjustment-boundary-${index}`}>
                 {stepAdjustments.length > 1 && <span>{getBoundaryStr(sa)}</span>}
                 <span>{getAdjustmentTypeString(sa)}</span>
               </div>
@@ -78,10 +78,10 @@ export const StepPolicyPopoverContent = ({ policy, serverGroup }: IStepPolicyPop
           />
         )}
         {Boolean(showWait) && (
-          <LabeledValue label="wait" value={`${cooldown} seconds before allowign another scaling activity.`} />
+          <LabeledValue label="wait" value={`${cooldown} seconds before allowing another scaling activity.`} />
         )}
-        {Boolean(showWait && estimatedInstanceWarmup) && (
-          <LabeledValue label="" value={`${estimatedInstanceWarmup} seconds to warm up after each step.`} />
+        {Boolean(estimatedInstanceWarmup) && (
+          <LabeledValue label="wait" value={`${estimatedInstanceWarmup} seconds to warm up after each step.`} />
         )}
       </LabeledValueList>
       <MetricAlarmChart alarm={alarm} serverGroup={serverGroup} />

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/popover/StepPolicyPopoverContent.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/popover/StepPolicyPopoverContent.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { LabeledValue, LabeledValueList } from '@spinnaker/core';
 
 import { MetricAlarmChart } from '../chart/MetricAlarmChart';
-import {
+import type {
   IAmazonServerGroup,
   IScalingPolicyAlarmView,
   IScalingPolicyView,

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/popover/StepPolicyPopoverContent.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/popover/StepPolicyPopoverContent.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+
+import { LabeledValue, LabeledValueList } from '@spinnaker/core';
+
+import { MetricAlarmChart } from '../chart/MetricAlarmChart';
+import {
+  IAmazonServerGroup,
+  IScalingPolicyAlarmView,
+  IScalingPolicyView,
+  IStepAdjustmentView,
+} from '../../../../domain';
+import { COMPARATORS } from '../upsert';
+
+export interface IStepPolicyPopoverContentProps {
+  policy: IScalingPolicyView;
+  serverGroup: IAmazonServerGroup;
+}
+
+export const StepPolicyPopoverContent = ({ policy, serverGroup }: IStepPolicyPopoverContentProps) => {
+  const { adjustmentType, alarms, cooldown, estimatedInstanceWarmup, minAdjustmentMagnitude, stepAdjustments } = policy;
+  const showWait = cooldown ? true : stepAdjustments?.[0]?.operator === 'decrease';
+  const alarm = alarms[0] || ({} as IScalingPolicyAlarmView);
+  const isGreater = alarm?.comparisonOperator.includes('Greater');
+
+  const getAdjustmentTypeString = (step: IScalingPolicyView | IStepAdjustmentView): string => {
+    if (adjustmentType === 'ExactCapacity') {
+      return `set capacity to ${step.scalingAdjustment} instance${step.scalingAdjustment > 1 ? 's' : ''}`;
+    }
+
+    return `${step.operator} capacity by ${step.absAdjustment}${
+      adjustmentType === 'PercentChangeInCapacity' ? '%' : ' instance'
+    }${adjustmentType === 'ChangeInCapacity' && step.absAdjustment > 1 ? 's' : ''}`;
+  };
+
+  const getBoundaryStr = (step: IStepAdjustmentView) => {
+    const middleBounds =
+      step.metricIntervalLowerBound !== undefined && step.metricIntervalUpperBound !== undefined
+        ? `is between ${alarm.threshold + step.metricIntervalLowerBound} and ${
+            alarm.threshold + step.metricIntervalUpperBound
+          } `
+        : '';
+
+    const sourceBound = isGreater ? step.metricIntervalLowerBound : step.metricIntervalUpperBound;
+    const finalBound = `is ${isGreater ? 'greater' : 'less'} than ${alarm.threshold + sourceBound}`;
+
+    return `if ${alarm.metricName} ${middleBounds}${finalBound}`;
+  };
+
+  return (
+    <div>
+      <LabeledValueList>
+        <LabeledValue
+          label="Whenever"
+          value={`${alarm.statistic} of ${alarm.metricName} is ${COMPARATORS[alarm.comparisonOperator]} ${
+            alarm.threshold
+          }`}
+        />
+        <LabeledValue
+          label="for at least"
+          value={`${alarm.evaluationPeriods} consecutive periods of ${alarm.period} seconds`}
+        />
+        {Boolean(stepAdjustments?.length) && (
+          <LabeledValue
+            label="then"
+            value={stepAdjustments.map((sa) => (
+              <div>
+                {stepAdjustments.length > 1 && <span>{getBoundaryStr(sa)}</span>}
+                <span>{getAdjustmentTypeString(sa)}</span>
+              </div>
+            ))}
+          />
+        )}
+        {!Boolean(stepAdjustments?.length) && <LabeledValue label="then" value={getAdjustmentTypeString(policy)} />}
+        {Boolean(minAdjustmentMagnitude) && (
+          <LabeledValue
+            label="in"
+            value={`increments of at least ${minAdjustmentMagnitude} instance${minAdjustmentMagnitude > 1 ? 's' : ''}`}
+          />
+        )}
+        {Boolean(showWait) && (
+          <LabeledValue label="wait" value={`${cooldown} seconds before allowign another scaling activity.`} />
+        )}
+        {Boolean(showWait && estimatedInstanceWarmup) && (
+          <LabeledValue label="" value={`${estimatedInstanceWarmup} seconds to warm up after each step.`} />
+        )}
+      </LabeledValueList>
+      <MetricAlarmChart alarm={alarm} serverGroup={serverGroup} />
+    </div>
+  );
+};

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/scalingPolicy.module.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/scalingPolicy.module.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ALARMBASEDSUMMARY_COMPONENT } from './alarmBasedSummary.component';
 import { DETAILS_SUMMARY } from './detailsSummary.component';
+import { STEP_POLICY_SUMMARY_COMPONENT } from './stepPolicySummary.component';
 import { TARGET_TRACKING_MODULE } from './targetTracking/targetTracking.module';
 
 export const SCALING_POLICY_MODULE = 'spinnaker.amazon.scalingPolicy.module';
@@ -9,4 +10,5 @@ module(SCALING_POLICY_MODULE, [
   DETAILS_SUMMARY,
   TARGET_TRACKING_MODULE,
   AMAZON_SERVERGROUP_DETAILS_SCALINGPOLICY_ALARMBASEDSUMMARY_COMPONENT,
+  STEP_POLICY_SUMMARY_COMPONENT,
 ]);

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/stepPolicySummary.component.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/stepPolicySummary.component.ts
@@ -1,0 +1,10 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+import { withErrorBoundary } from '@spinnaker/core';
+import { StepPolicySummary } from './StepPolicySummary';
+
+export const STEP_POLICY_SUMMARY_COMPONENT = 'spinnaker.amazon.scalingPolicy.stepPolicySummary.component';
+module(STEP_POLICY_SUMMARY_COMPONENT, []).component(
+  'stepPolicySummary',
+  react2angular(withErrorBoundary(StepPolicySummary, 'stepPolicySummary'), ['application', 'policy', 'serverGroup']),
+);

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/AlarmConfigurer.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/AlarmConfigurer.tsx
@@ -20,7 +20,7 @@ export interface IAlarmConfigurerProps {
 
 const STATISTICS = ['Average', 'Maximum', 'Minimum', 'SampleCount', 'Sum'];
 
-const COMPARATORS = [
+export const COMPARATORS = [
   { label: '>=', value: 'GreaterThanOrEqualToThreshold' },
   { label: '>', value: 'GreaterThanThreshold' },
   { label: '<=', value: 'LessThanOrEqualToThreshold' },

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/index.ts
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/index.ts
@@ -4,3 +4,4 @@ export * from './alarm/MetricSelector';
 export * from './PolicyTypeSelectionModal';
 export * from './ScalingPolicyAdditionalSettings';
 export * from './step/StepPolicyAction';
+export { UpsertScalingPolicyModal as AmazonUpsertScalingPolicyModal } from './UpsertScalingPolicyModal';


### PR DESCRIPTION

- `StepPolicyContent` and `StepPolicySummary` components
- Utilize components in `@spinnaker/amazon`
- Register upsert modals with cloud provider so `StepPolicySummary` can be used across providers
- temporary `react2angular` converter until parent is converted to react