### PR TITLE
fix(titus): Deal with absence of non-required fields

### DIFF
--- a/packages/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/JobDisruptionBudget.tsx
+++ b/packages/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/JobDisruptionBudget.tsx
@@ -155,11 +155,11 @@ export class JobDisruptionBudget extends React.Component<IJobDisruptionBudgetPro
     const PolicyFields = policyType.fieldComponent;
 
     const rateType = this.getSelectionFromFields(rateOptions);
-    const RateFields = rateType.fieldComponent;
+    const RateFields = rateType?.fieldComponent;
 
     const windowType = this.getTimeWindowSelection();
 
-    const selectedProviders = budget.containerHealthProviders.map((p) => p.name);
+    const selectedProviders = (budget.containerHealthProviders ?? []).map((p) => p.name);
 
     const isSelfManaged = !!budget.selfManaged;
     const showConfig = !runJobView || (runJobView && !usingDefault);


### PR DESCRIPTION
When the disruption budget policy is self managed, there is really no requirement for the budget to contain any of the rate or container health fields, so while the UI will add them in, users may have also previously configured the budget with something as minimal as:
```
    "disruptionBudget": {
      "selfManaged": {
        "relocationTimeMs": 3600000
      }
    },
```
Thus, deck should be able to deal with their absence.