### PR TITLE
Enable eslint rules for typescript test files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 # Built lib files
-/**/*.spec.*
+/**/*.spec.js
 node_modules
 packages/*/dist/**
 packages/*/lib/**

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepare": "husky install"
   },
   "devDependencies": {
-    "@spinnaker/eslint-plugin": "^1.0.13",
+    "@spinnaker/eslint-plugin": "^3.0.0",
     "@types/jasmine": "3.6.9",
     "angular-mocks": "1.6.10",
     "babel-loader": "8.1.0",

--- a/packages/amazon/src/function/details/FunctionActions.spec.tsx
+++ b/packages/amazon/src/function/details/FunctionActions.spec.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Application } from '@spinnaker/core';
+import type { Application } from '@spinnaker/core';
 
-import { IAmazonFunction, FunctionActions } from '../../index';
+import type { IAmazonFunction } from '../../index';
+import { FunctionActions } from '../../index';
 import { AWSProviderSettings } from '../../aws.settings';
 
 describe('FunctionActions', () => {

--- a/packages/amazon/src/function/details/FunctionActions.spec.tsx
+++ b/packages/amazon/src/function/details/FunctionActions.spec.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 
 import type { Application } from '@spinnaker/core';
 
+import { AWSProviderSettings } from '../../aws.settings';
 import type { IAmazonFunction } from '../../index';
 import { FunctionActions } from '../../index';
-import { AWSProviderSettings } from '../../aws.settings';
 
 describe('FunctionActions', () => {
   it('should render correct state when all attributes exist', () => {

--- a/packages/amazon/src/function/details/FunctionActions.spec.tsx
+++ b/packages/amazon/src/function/details/FunctionActions.spec.tsx
@@ -8,9 +8,9 @@ import { AWSProviderSettings } from '../../aws.settings';
 
 describe('FunctionActions', () => {
   it('should render correct state when all attributes exist', () => {
-    let app = { name: 'app' } as Application;
+    const app = { name: 'app' } as Application;
 
-    let functionDef = { functionName: 'app-function' } as IAmazonFunction;
+    const functionDef = { functionName: 'app-function' } as IAmazonFunction;
     AWSProviderSettings.adHocInfraWritesEnabled = true;
 
     const wrapper = shallow(
@@ -25,15 +25,15 @@ describe('FunctionActions', () => {
       />,
     );
 
-    let dropDown = wrapper.find('DropdownToggle');
+    const dropDown = wrapper.find('DropdownToggle');
 
     expect(dropDown.childAt(0).text()).toEqual('Function Actions');
   });
 
   it('should not render DropdownToggle if aws.adHocInfraWritesEnabled is false', () => {
-    let app = { name: 'app' } as Application;
+    const app = { name: 'app' } as Application;
 
-    let functionDef = { functionName: 'app-function' } as IAmazonFunction;
+    const functionDef = { functionName: 'app-function' } as IAmazonFunction;
     AWSProviderSettings.adHocInfraWritesEnabled = false;
 
     const wrapper = shallow(
@@ -48,7 +48,7 @@ describe('FunctionActions', () => {
       />,
     );
 
-    let dropDown = wrapper.find('div');
+    const dropDown = wrapper.find('div');
     expect(dropDown.children().length).toEqual(0);
   });
 });

--- a/packages/amazon/src/instance/details/InstanceInformation.spec.tsx
+++ b/packages/amazon/src/instance/details/InstanceInformation.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
+
 import { mockInstance } from '@spinnaker/mocks';
 
 import { InstanceInformation } from './InstanceInformation';

--- a/packages/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
+++ b/packages/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
@@ -1,6 +1,6 @@
+import type { StateService } from '@uirouter/core';
 import type { IControllerService, IRootScopeService } from 'angular';
 import { mock } from 'angular';
-import type { StateService } from '@uirouter/core';
 
 import type { ISubnet } from '@spinnaker/core';
 import { ApplicationModelBuilder } from '@spinnaker/core';

--- a/packages/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
+++ b/packages/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
@@ -1,7 +1,9 @@
-import { IControllerService, IRootScopeService, mock } from 'angular';
-import { StateService } from '@uirouter/core';
+import type { IControllerService, IRootScopeService } from 'angular';
+import { mock } from 'angular';
+import type { StateService } from '@uirouter/core';
 
-import { ApplicationModelBuilder, ISubnet } from '@spinnaker/core';
+import type { ISubnet } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
 
 import { AWS_LOAD_BALANCER_DETAILS_CTRL, AwsLoadBalancerDetailsController } from './loadBalancerDetails.controller';
 

--- a/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
+++ b/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { mockHttpClient } from 'core/api/mock/jasmine';
+// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
+import { mockHttpClient } from '../../../../core/src/api/mock/jasmine';
 import { mock } from 'angular';
 import type { ShallowWrapper, ReactWrapper } from 'enzyme';
 import { shallow, mount } from 'enzyme';
 
 import type { IAmazonImage } from '../../image';
-import { Application } from 'core/application';
-import { REACT_MODULE } from 'core/reactShims';
+import { Application } from '@spinnaker/core';
+import { REACT_MODULE } from '@spinnaker/core';
 
 import type { IAmazonImageSelectorProps, IAmazonImageSelectorState } from './AmazonImageSelectInput';
 import { AmazonImageSelectInput } from './AmazonImageSelectInput';

--- a/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
+++ b/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mock } from 'angular';
-import { ShallowWrapper, ReactWrapper, shallow, mount } from 'enzyme';
+import type { ShallowWrapper, ReactWrapper } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
-import { IAmazonImage } from '../../image';
+import type { IAmazonImage } from '../../image';
 import { Application } from 'core/application';
 import { REACT_MODULE } from 'core/reactShims';
 
-import { AmazonImageSelectInput, IAmazonImageSelectorProps, IAmazonImageSelectorState } from './AmazonImageSelectInput';
+import type { IAmazonImageSelectorProps, IAmazonImageSelectorState } from './AmazonImageSelectInput';
+import { AmazonImageSelectInput } from './AmazonImageSelectInput';
 const application = new Application('testapp', null, []);
 const region = 'us-region-1';
 const credentials = 'prodaccount';

--- a/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
+++ b/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
-import { mockHttpClient } from '../../../../core/src/api/mock/jasmine';
 import { mock } from 'angular';
-import type { ShallowWrapper, ReactWrapper } from 'enzyme';
-import { shallow, mount } from 'enzyme';
+import type { ReactWrapper, ShallowWrapper } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import React from 'react';
 
-import type { IAmazonImage } from '../../image';
 import { Application } from '@spinnaker/core';
 import { REACT_MODULE } from '@spinnaker/core';
 
 import type { IAmazonImageSelectorProps, IAmazonImageSelectorState } from './AmazonImageSelectInput';
 import { AmazonImageSelectInput } from './AmazonImageSelectInput';
+// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
+import { mockHttpClient } from '../../../../core/src/api/mock/jasmine';
+import type { IAmazonImage } from '../../image';
 const application = new Application('testapp', null, []);
 const region = 'us-region-1';
 const credentials = 'prodaccount';

--- a/packages/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/packages/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -1,4 +1,4 @@
-import type { IQService, IScope, IRootScopeService } from 'angular';
+import type { IQService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
 import type { CacheInitializerService, LoadBalancerReader, SecurityGroupReader } from '@spinnaker/core';

--- a/packages/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/packages/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -1,19 +1,12 @@
-import { mock, IQService, IScope, IRootScopeService } from 'angular';
+import type { IQService, IScope, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
-import {
-  AccountService,
-  ApplicationModelBuilder,
-  CacheInitializerService,
-  LoadBalancerReader,
-  SecurityGroupReader,
-  SubnetReader,
-} from '@spinnaker/core';
+import type { CacheInitializerService, LoadBalancerReader, SecurityGroupReader } from '@spinnaker/core';
+import { AccountService, ApplicationModelBuilder, SubnetReader } from '@spinnaker/core';
 
 import { KeyPairsReader } from '../../keyPairs';
-import {
-  AWS_SERVER_GROUP_CONFIGURATION_SERVICE,
-  AwsServerGroupConfigurationService,
-} from './serverGroupConfiguration.service';
+import type { AwsServerGroupConfigurationService } from './serverGroupConfiguration.service';
+import { AWS_SERVER_GROUP_CONFIGURATION_SERVICE } from './serverGroupConfiguration.service';
 
 describe('Service: awsServerGroupConfiguration', function () {
   let service: AwsServerGroupConfigurationService,

--- a/packages/amazon/src/serverGroup/details/scalingProcesses/AutoScalingProcessService.spec.ts
+++ b/packages/amazon/src/serverGroup/details/scalingProcesses/AutoScalingProcessService.spec.ts
@@ -1,6 +1,5 @@
-import type { IAmazonAsg, IAmazonServerGroup } from '../../../domain';
-
 import { AutoScalingProcessService } from './AutoScalingProcessService';
+import type { IAmazonAsg, IAmazonServerGroup } from '../../../domain';
 
 describe('AutoScalingProcessService', () => {
   describe('normalizeScalingProcesses', () => {

--- a/packages/amazon/src/serverGroup/details/scalingProcesses/AutoScalingProcessService.spec.ts
+++ b/packages/amazon/src/serverGroup/details/scalingProcesses/AutoScalingProcessService.spec.ts
@@ -1,4 +1,4 @@
-import { IAmazonAsg, IAmazonServerGroup } from '../../../domain';
+import type { IAmazonAsg, IAmazonServerGroup } from '../../../domain';
 
 import { AutoScalingProcessService } from './AutoScalingProcessService';
 

--- a/packages/amazon/src/serverGroup/details/sections/InstancesDistributionDetailsSection.spec.tsx
+++ b/packages/amazon/src/serverGroup/details/sections/InstancesDistributionDetailsSection.spec.tsx
@@ -50,7 +50,7 @@ describe('InstancesDistribution', () => {
     ]);
     let index = 0;
     expectedLabels.forEach((value, key) => {
-      let labeledValue = actualLabeledValues.at(index++);
+      const labeledValue = actualLabeledValues.at(index++);
       expect(labeledValue.prop('label')).toEqual(key);
       expect(labeledValue.prop('value')).toEqual(value);
     });
@@ -77,7 +77,7 @@ describe('InstancesDistribution', () => {
     ]);
     let index = 0;
     expectedLabels.forEach((value, key) => {
-      let labeledValue = actualLabeledValues.at(index++);
+      const labeledValue = actualLabeledValues.at(index++);
       expect(labeledValue.prop('label')).toEqual(key);
       expect(labeledValue.prop('value')).toEqual(value);
     });

--- a/packages/amazon/src/serverGroup/details/sections/InstancesDistributionDetailsSection.spec.tsx
+++ b/packages/amazon/src/serverGroup/details/sections/InstancesDistributionDetailsSection.spec.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
 import { shallow } from 'enzyme';
-import { mockLaunchTemplate, mockServerGroup } from '@spinnaker/mocks';
-import type { IAmazonMixedInstancesPolicy, IAmazonServerGroupView, IScalingPolicy } from '../../../domain';
-import { InstancesDistributionDetailsSection } from '../../../index';
+import React from 'react';
+
 import type { Application } from '@spinnaker/core';
 import { ApplicationModelBuilder } from '@spinnaker/core';
+import { mockLaunchTemplate, mockServerGroup } from '@spinnaker/mocks';
+
+import type { IAmazonMixedInstancesPolicy, IAmazonServerGroupView, IScalingPolicy } from '../../../domain';
+import { InstancesDistributionDetailsSection } from '../../../index';
 
 describe('InstancesDistribution', () => {
   let app: Application;

--- a/packages/amazon/src/serverGroup/details/sections/InstancesDistributionDetailsSection.spec.tsx
+++ b/packages/amazon/src/serverGroup/details/sections/InstancesDistributionDetailsSection.spec.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { mockLaunchTemplate, mockServerGroup } from '@spinnaker/mocks';
-import { IAmazonMixedInstancesPolicy, IAmazonServerGroupView, IScalingPolicy } from '../../../domain';
+import type { IAmazonMixedInstancesPolicy, IAmazonServerGroupView, IScalingPolicy } from '../../../domain';
 import { InstancesDistributionDetailsSection } from '../../../index';
-import { Application, ApplicationModelBuilder } from '@spinnaker/core';
+import type { Application } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
 
 describe('InstancesDistribution', () => {
   let app: Application;

--- a/packages/amazon/src/serverGroup/details/sections/LaunchTemplateDetailsSection.spec.tsx
+++ b/packages/amazon/src/serverGroup/details/sections/LaunchTemplateDetailsSection.spec.tsx
@@ -144,7 +144,7 @@ describe('Launch template details', () => {
     ]);
     let index = 0;
     expectedLabels.forEach((value, key) => {
-      let labeledValue = actualLabeledValues.at(index++);
+      const labeledValue = actualLabeledValues.at(index++);
       expect(labeledValue.prop('label')).toEqual(key);
       value != '' && expect(labeledValue.prop('value')).toEqual(value);
     });
@@ -239,7 +239,7 @@ describe('Launch template details', () => {
   });
 
   it('should not render multiple instance types subsection when overrides are not specified', () => {
-    let testServerGroup = baseServerGroupWithMipOverrides;
+    const testServerGroup = baseServerGroupWithMipOverrides;
     testServerGroup.mixedInstancesPolicy.launchTemplateOverridesForInstanceType = null;
 
     const multipleInstanceTypes = shallow(

--- a/packages/amazon/src/serverGroup/details/sections/LaunchTemplateDetailsSection.spec.tsx
+++ b/packages/amazon/src/serverGroup/details/sections/LaunchTemplateDetailsSection.spec.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
+
+import type { Application } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
 import {
   createCustomMockLaunchTemplate,
   mockLaunchTemplate,
   mockLaunchTemplateData,
   mockServerGroup,
 } from '@spinnaker/mocks';
-import type { Application } from '@spinnaker/core';
-import { ApplicationModelBuilder } from '@spinnaker/core';
-import type { IAmazonServerGroupView, IAmazonMixedInstancesPolicy, IScalingPolicy } from '../../../domain';
+
 import { LaunchTemplateDetailsSection } from './LaunchTemplateDetailsSection';
 import { MultipleInstanceTypesSubSection } from './MultipleInstanceTypesSubSection';
+import type { IAmazonMixedInstancesPolicy, IAmazonServerGroupView, IScalingPolicy } from '../../../domain';
 
 describe('Launch template details', () => {
   let app: Application;

--- a/packages/amazon/src/serverGroup/details/sections/LaunchTemplateDetailsSection.spec.tsx
+++ b/packages/amazon/src/serverGroup/details/sections/LaunchTemplateDetailsSection.spec.tsx
@@ -6,8 +6,9 @@ import {
   mockLaunchTemplateData,
   mockServerGroup,
 } from '@spinnaker/mocks';
-import { Application, ApplicationModelBuilder } from '@spinnaker/core';
-import { IAmazonServerGroupView, IAmazonMixedInstancesPolicy, IScalingPolicy } from '../../../domain';
+import type { Application } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
+import type { IAmazonServerGroupView, IAmazonMixedInstancesPolicy, IScalingPolicy } from '../../../domain';
 import { LaunchTemplateDetailsSection } from './LaunchTemplateDetailsSection';
 import { MultipleInstanceTypesSubSection } from './MultipleInstanceTypesSubSection';
 

--- a/packages/amazon/src/serverGroup/serverGroup.transformer.spec.ts
+++ b/packages/amazon/src/serverGroup/serverGroup.transformer.spec.ts
@@ -1,7 +1,9 @@
-import { mock, IQService, IRootScopeService, IScope } from 'angular';
+import type { IQService, IRootScopeService, IScope } from 'angular';
+import { mock } from 'angular';
 
-import { AWS_SERVER_GROUP_TRANSFORMER, AwsServerGroupTransformer } from './serverGroup.transformer';
-import { IScalingPolicyAlarmView, IAmazonServerGroup, IStepAdjustment } from '../domain';
+import type { AwsServerGroupTransformer } from './serverGroup.transformer';
+import { AWS_SERVER_GROUP_TRANSFORMER } from './serverGroup.transformer';
+import type { IScalingPolicyAlarmView, IAmazonServerGroup, IStepAdjustment } from '../domain';
 import { VpcReader } from '../vpc/VpcReader';
 
 describe('awsServerGroupTransformer', () => {

--- a/packages/amazon/src/serverGroup/serverGroup.transformer.spec.ts
+++ b/packages/amazon/src/serverGroup/serverGroup.transformer.spec.ts
@@ -1,9 +1,9 @@
 import type { IQService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
+import type { IAmazonServerGroup, IScalingPolicyAlarmView, IStepAdjustment } from '../domain';
 import type { AwsServerGroupTransformer } from './serverGroup.transformer';
 import { AWS_SERVER_GROUP_TRANSFORMER } from './serverGroup.transformer';
-import type { IScalingPolicyAlarmView, IAmazonServerGroup, IStepAdjustment } from '../domain';
 import { VpcReader } from '../vpc/VpcReader';
 
 describe('awsServerGroupTransformer', () => {

--- a/packages/amazon/src/subnet/SubnetSelectInput.spec.tsx
+++ b/packages/amazon/src/subnet/SubnetSelectInput.spec.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { shallow, render } from 'enzyme';
 import { mock } from 'angular';
 import { SubnetSelectInput } from './SubnetSelectInput';
-import { Application, ApplicationModelBuilder } from '@spinnaker/core';
+import type { Application } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
 import { mockServerGroupDataSourceConfig, mockSubnet } from '@spinnaker/mocks';
 
 describe('SubnetSelectInput', () => {

--- a/packages/amazon/src/subnet/SubnetSelectInput.spec.tsx
+++ b/packages/amazon/src/subnet/SubnetSelectInput.spec.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
-import { shallow, render } from 'enzyme';
 import { mock } from 'angular';
-import { SubnetSelectInput } from './SubnetSelectInput';
+import { render, shallow } from 'enzyme';
+import React from 'react';
+
 import type { Application } from '@spinnaker/core';
 import { ApplicationModelBuilder } from '@spinnaker/core';
 import { mockServerGroupDataSourceConfig, mockSubnet } from '@spinnaker/mocks';
+
+import { SubnetSelectInput } from './SubnetSelectInput';
 
 describe('SubnetSelectInput', () => {
   let application: Application;

--- a/packages/amazon/src/vpc/VpcTag.spec.tsx
+++ b/packages/amazon/src/vpc/VpcTag.spec.tsx
@@ -1,7 +1,8 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import { VpcReader } from '../vpc/VpcReader';
+
 import { VpcTag } from './VpcTag';
+import { VpcReader } from '../vpc/VpcReader';
 
 const tick = () => new Promise((resolve) => setTimeout(resolve));
 

--- a/packages/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
+++ b/packages/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { mockHttpClient } from 'core/api/mock/jasmine';
+// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
+import { mockHttpClient } from '../../../../../core/src/api/mock/jasmine';
 import { mount } from 'enzyme';
 
 import type { IArtifactAccount, IArtifactAccountPair } from '@spinnaker/core';

--- a/packages/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
+++ b/packages/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { mockHttpClient } from 'core/api/mock/jasmine';
 import { mount } from 'enzyme';
 
-import { IArtifactAccount, IArtifactAccountPair, StageArtifactSelector } from '@spinnaker/core';
+import type { IArtifactAccount, IArtifactAccountPair } from '@spinnaker/core';
+import { StageArtifactSelector } from '@spinnaker/core';
 import { mockDeployStage, mockPipeline } from '@spinnaker/mocks';
 import { ConfigFileArtifactList } from './ConfigFileArtifactList';
 

--- a/packages/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
+++ b/packages/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
-import { mockHttpClient } from '../../../../../core/src/api/mock/jasmine';
 import { mount } from 'enzyme';
+import React from 'react';
 
 import type { IArtifactAccount, IArtifactAccountPair } from '@spinnaker/core';
 import { StageArtifactSelector } from '@spinnaker/core';
 import { mockDeployStage, mockPipeline } from '@spinnaker/mocks';
+
 import { ConfigFileArtifactList } from './ConfigFileArtifactList';
+// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
+import { mockHttpClient } from '../../../../../core/src/api/mock/jasmine';
 
 describe('<ConfigFileArtifactList/>', () => {
   it('renders empty children when null/empty artifacts are passed in', () => {

--- a/packages/appengine/src/serverGroup/transformet.spec.ts
+++ b/packages/appengine/src/serverGroup/transformet.spec.ts
@@ -31,7 +31,7 @@ describe('command transforms', () => {
       application: 'dockerImageApp',
     };
 
-    let transformed = transformer.convertServerGroupCommandToDeployConfiguration(command);
+    const transformed = transformer.convertServerGroupCommandToDeployConfiguration(command);
     expect(transformed.cloudProvider).toBe('appengine');
     expect(transformed.provider).toBe('appengine');
     expect(transformed.application).toBe('dockerImageApp');

--- a/packages/azure/src/utility.spec.ts
+++ b/packages/azure/src/utility.spec.ts
@@ -1,4 +1,5 @@
-import Utility, { ITagResult, TagError } from './utility';
+import type { ITagResult } from './utility';
+import Utility, { TagError } from './utility';
 
 describe('Azure Utility', function () {
   it('returns tag error when null object passed', function () {

--- a/packages/cloudfoundry/src/pipeline/stages/bakeCloudFoundryManifest/bakeCloudFoundryManifestConfig.spec.tsx
+++ b/packages/cloudfoundry/src/pipeline/stages/bakeCloudFoundryManifest/bakeCloudFoundryManifestConfig.spec.tsx
@@ -1,4 +1,4 @@
-import { IArtifact, IExpectedArtifact } from '@spinnaker/core';
+import type { IArtifact, IExpectedArtifact } from '@spinnaker/core';
 
 import { validateInputArtifacts, validateProducedArtifacts } from './BakeCloudFoundryManifestConfig';
 

--- a/packages/cloudfoundry/src/pipeline/stages/createServiceBindings/CloudFoundryCreateServiceBindingsConfig.spec.tsx
+++ b/packages/cloudfoundry/src/pipeline/stages/createServiceBindings/CloudFoundryCreateServiceBindingsConfig.spec.tsx
@@ -1,4 +1,5 @@
-import { validateServiceBindingRequests, ServiceBindingRequests } from './CloudFoundryCreateServiceBindingsConfig';
+import type { ServiceBindingRequests } from './CloudFoundryCreateServiceBindingsConfig';
+import { validateServiceBindingRequests } from './CloudFoundryCreateServiceBindingsConfig';
 
 describe('Cloud Foundry Create Service Bindings Config', () => {
   describe('validate Service Binding Requests', () => {

--- a/packages/cloudfoundry/src/pipeline/stages/createServiceBindings/cloudFoundryCreateServiceBindingsStageForm.spec.tsx
+++ b/packages/cloudfoundry/src/pipeline/stages/createServiceBindings/cloudFoundryCreateServiceBindingsStageForm.spec.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
 import { mock } from 'angular';
-import { mount } from 'enzyme';
-
-import { mockServerGroupDataSourceConfig } from '@spinnaker/mocks';
 import type { IStage } from 'core';
 import { ApplicationModelBuilder, REACT_MODULE, SpinFormik, StageConfigField } from 'core';
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { mockServerGroupDataSourceConfig } from '@spinnaker/mocks';
+
 import { CloudFoundryCreateServiceBindingsStageConfigForm } from './CloudFoundryCreateServiceBindingsStageConfigForm';
 
 describe('<CloudFoundryCreateServiceBindingsStageConfigForm/>', function () {

--- a/packages/cloudfoundry/src/pipeline/stages/createServiceBindings/cloudFoundryCreateServiceBindingsStageForm.spec.tsx
+++ b/packages/cloudfoundry/src/pipeline/stages/createServiceBindings/cloudFoundryCreateServiceBindingsStageForm.spec.tsx
@@ -3,7 +3,8 @@ import { mock } from 'angular';
 import { mount } from 'enzyme';
 
 import { mockServerGroupDataSourceConfig } from '@spinnaker/mocks';
-import { ApplicationModelBuilder, IStage, REACT_MODULE, SpinFormik, StageConfigField } from 'core';
+import type { IStage } from 'core';
+import { ApplicationModelBuilder, REACT_MODULE, SpinFormik, StageConfigField } from 'core';
 import { CloudFoundryCreateServiceBindingsStageConfigForm } from './CloudFoundryCreateServiceBindingsStageConfigForm';
 
 describe('<CloudFoundryCreateServiceBindingsStageConfigForm/>', function () {

--- a/packages/cloudfoundry/src/pipeline/stages/deleteServiceBindings/cloudFoundryDeleteServiceBindingsStageForm.spec.tsx
+++ b/packages/cloudfoundry/src/pipeline/stages/deleteServiceBindings/cloudFoundryDeleteServiceBindingsStageForm.spec.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
 import { mock } from 'angular';
 import { mount } from 'enzyme';
+import React from 'react';
 
-import { mockServerGroupDataSourceConfig } from '@spinnaker/mocks';
 import type { IStage } from '@spinnaker/core';
 import { ApplicationModelBuilder, REACT_MODULE, SpinFormik, StageConfigField } from '@spinnaker/core';
+import { mockServerGroupDataSourceConfig } from '@spinnaker/mocks';
+
 import { CloudFoundryDeleteServiceBindingsStageConfigForm } from './CloudFoundryDeleteServiceBindingsStageConfigForm';
 
 describe('<CloudFoundryDeleteServiceBindingsStageConfigForm/>', function () {

--- a/packages/cloudfoundry/src/pipeline/stages/deleteServiceBindings/cloudFoundryDeleteServiceBindingsStageForm.spec.tsx
+++ b/packages/cloudfoundry/src/pipeline/stages/deleteServiceBindings/cloudFoundryDeleteServiceBindingsStageForm.spec.tsx
@@ -3,7 +3,8 @@ import { mock } from 'angular';
 import { mount } from 'enzyme';
 
 import { mockServerGroupDataSourceConfig } from '@spinnaker/mocks';
-import { ApplicationModelBuilder, IStage, REACT_MODULE, SpinFormik, StageConfigField } from '@spinnaker/core';
+import type { IStage } from '@spinnaker/core';
+import { ApplicationModelBuilder, REACT_MODULE, SpinFormik, StageConfigField } from '@spinnaker/core';
 import { CloudFoundryDeleteServiceBindingsStageConfigForm } from './CloudFoundryDeleteServiceBindingsStageConfigForm';
 
 describe('<CloudFoundryDeleteServiceBindingsStageConfigForm/>', function () {

--- a/packages/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.spec.tsx
+++ b/packages/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.spec.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import type { IScope } from 'angular';
 import { mock, noop } from 'angular';
 import { mount, shallow } from 'enzyme';
+import React from 'react';
 
 import type { Application, ApplicationDataSource, IMoniker, IServerGroup } from '@spinnaker/core';
 import { ApplicationModelBuilder, REACT_MODULE } from '@spinnaker/core';

--- a/packages/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.spec.tsx
+++ b/packages/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.spec.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import { mock, noop, IScope } from 'angular';
+import type { IScope } from 'angular';
+import { mock, noop } from 'angular';
 import { mount, shallow } from 'enzyme';
 
-import {
-  Application,
-  ApplicationModelBuilder,
-  ApplicationDataSource,
-  IMoniker,
-  IServerGroup,
-  REACT_MODULE,
-} from '@spinnaker/core';
+import type { Application, ApplicationDataSource, IMoniker, IServerGroup } from '@spinnaker/core';
+import { ApplicationModelBuilder, REACT_MODULE } from '@spinnaker/core';
 
-import { AccountRegionClusterSelector, IAccountRegionClusterSelectorProps } from './AccountRegionClusterSelector';
+import type { IAccountRegionClusterSelectorProps } from './AccountRegionClusterSelector';
+import { AccountRegionClusterSelector } from './AccountRegionClusterSelector';
 
 describe('<AccountRegionClusterSelector />', () => {
   let $scope: IScope;

--- a/packages/core/src/account/AccountSelectInput.spec.tsx
+++ b/packages/core/src/account/AccountSelectInput.spec.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { ShallowWrapper, shallow } from 'enzyme';
-import { IScope, mock } from 'angular';
-import { AccountService, IAccountDetails } from './AccountService';
-import { AccountSelectInput, IAccountSelectInputProps, IAccountSelectInputState } from './AccountSelectInput';
+import type { ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
+import type { IScope } from 'angular';
+import { mock } from 'angular';
+import type { IAccountDetails } from './AccountService';
+import { AccountService } from './AccountService';
+import type { IAccountSelectInputProps, IAccountSelectInputState } from './AccountSelectInput';
+import { AccountSelectInput } from './AccountSelectInput';
 import Spy = jasmine.Spy;
 
 const makeAccount = (name: string, cloudProvider: string, primaryAccount: boolean): IAccountDetails => {

--- a/packages/core/src/account/AccountSelectInput.spec.tsx
+++ b/packages/core/src/account/AccountSelectInput.spec.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-import type { ShallowWrapper } from 'enzyme';
-import { shallow } from 'enzyme';
 import type { IScope } from 'angular';
 import { mock } from 'angular';
-import type { IAccountDetails } from './AccountService';
-import { AccountService } from './AccountService';
+import type { ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
+import React from 'react';
+
 import type { IAccountSelectInputProps, IAccountSelectInputState } from './AccountSelectInput';
 import { AccountSelectInput } from './AccountSelectInput';
+import type { IAccountDetails } from './AccountService';
+import { AccountService } from './AccountService';
 import Spy = jasmine.Spy;
 
 const makeAccount = (name: string, cloudProvider: string, primaryAccount: boolean): IAccountDetails => {

--- a/packages/core/src/account/AccountService.spec.ts
+++ b/packages/core/src/account/AccountService.spec.ts
@@ -1,12 +1,13 @@
 import { mock } from 'angular';
 import { mockHttpClient } from '../api/mock/jasmine';
-import { MockHttpClient } from '../api/mock/mockHttpClient';
+import type { MockHttpClient } from '../api/mock/mockHttpClient';
 
 import { SETTINGS } from '../config/settings';
 import { $rootScope } from 'ngimport';
 import { CloudProviderRegistry } from '../cloudProvider';
 
-import { AccountService, IAccount } from './AccountService';
+import type { IAccount } from './AccountService';
+import { AccountService } from './AccountService';
 
 function flush<T>(http: MockHttpClient, promise: PromiseLike<T>): Promise<T> {
   return http

--- a/packages/core/src/account/AccountService.spec.ts
+++ b/packages/core/src/account/AccountService.spec.ts
@@ -1,13 +1,12 @@
 import { mock } from 'angular';
-import { mockHttpClient } from '../api/mock/jasmine';
-import type { MockHttpClient } from '../api/mock/mockHttpClient';
-
-import { SETTINGS } from '../config/settings';
 import { $rootScope } from 'ngimport';
-import { CloudProviderRegistry } from '../cloudProvider';
 
 import type { IAccount } from './AccountService';
 import { AccountService } from './AccountService';
+import { mockHttpClient } from '../api/mock/jasmine';
+import type { MockHttpClient } from '../api/mock/mockHttpClient';
+import { CloudProviderRegistry } from '../cloudProvider';
+import { SETTINGS } from '../config/settings';
 
 function flush<T>(http: MockHttpClient, promise: PromiseLike<T>): Promise<T> {
   return http

--- a/packages/core/src/api/ApiService.spec.ts
+++ b/packages/core/src/api/ApiService.spec.ts
@@ -1,4 +1,4 @@
-import { IHttpClientImplementation } from './ApiService';
+import type { IHttpClientImplementation } from './ApiService';
 import { SETTINGS } from '../config/settings';
 import { makeRequestBuilderConfig, RequestBuilder } from './ApiService';
 

--- a/packages/core/src/api/ApiService.spec.ts
+++ b/packages/core/src/api/ApiService.spec.ts
@@ -1,6 +1,6 @@
 import type { IHttpClientImplementation } from './ApiService';
-import { SETTINGS } from '../config/settings';
 import { makeRequestBuilderConfig, RequestBuilder } from './ApiService';
+import { SETTINGS } from '../config/settings';
 
 describe('RequestBuilder backend', () => {
   const createBackend = (): IHttpClientImplementation => jasmine.createSpyObj(['get', 'post', 'put', 'delete']);

--- a/packages/core/src/api/ApiServiceDeprecated.spec.ts
+++ b/packages/core/src/api/ApiServiceDeprecated.spec.ts
@@ -3,7 +3,7 @@
 import Spy = jasmine.Spy;
 import { mock, noop } from 'angular';
 import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
-import { ICache } from '../cache';
+import type { ICache } from '../cache';
 import { API, InvalidAPIResponse, invalidContentMessage } from './ApiService';
 import { SETTINGS } from '../config/settings';
 

--- a/packages/core/src/api/ApiServiceDeprecated.spec.ts
+++ b/packages/core/src/api/ApiServiceDeprecated.spec.ts
@@ -2,9 +2,10 @@
 
 import Spy = jasmine.Spy;
 import { mock, noop } from 'angular';
+
+import { API, InvalidAPIResponse, invalidContentMessage } from './ApiService';
 import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
 import type { ICache } from '../cache';
-import { API, InvalidAPIResponse, invalidContentMessage } from './ApiService';
 import { SETTINGS } from '../config/settings';
 
 describe('API Service', function () {

--- a/packages/core/src/api/ApiServiceDeprecated.spec.ts
+++ b/packages/core/src/api/ApiServiceDeprecated.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @spinnaker/api-deprecation, @spinnaker/api-no-slashes, @spinnaker/migrate-to-mock-http-client */
+
 import Spy = jasmine.Spy;
 import { mock, noop } from 'angular';
 import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';

--- a/packages/core/src/application/application.model.spec.ts
+++ b/packages/core/src/application/application.model.spec.ts
@@ -1,14 +1,14 @@
 import { mock } from 'angular';
 
-import { Application } from './application.model';
+import type { Application } from './application.model';
 import { ApplicationModelBuilder } from './applicationModel.builder';
 import { ApplicationDataSourceRegistry } from './service/ApplicationDataSourceRegistry';
 import { LOAD_BALANCER_DATA_SOURCE } from '../loadBalancer/loadBalancer.dataSource';
-import { SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
+import type { SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
 import { SERVER_GROUP_DATA_SOURCE } from '../serverGroup/serverGroup.dataSource';
 import { SECURITY_GROUP_DATA_SOURCE } from '../securityGroup/securityGroup.dataSource';
 
-import { IEntityTag, IEntityTags, IServerGroup, IInstanceCounts, ILoadBalancer } from '../domain';
+import type { IEntityTag, IEntityTags, IServerGroup, IInstanceCounts, ILoadBalancer } from '../domain';
 
 describe('Application Model', function () {
   let application: Application,

--- a/packages/core/src/application/application.model.spec.ts
+++ b/packages/core/src/application/application.model.spec.ts
@@ -187,19 +187,19 @@ describe('Application Model', function () {
   describe('setting default credentials and regions', function () {
     it('sets default credentials and region from server group when only one account/region found', function () {
       const serverGroups: IServerGroup[] = [
-          {
-            name: 'deck-test-v001',
-            cluster: 'deck-test',
-            account: 'test',
-            region: 'us-west-2',
-            type: 'aws',
-            cloudProvider: 'aws',
-            instances: [],
-            instanceCounts: {} as IInstanceCounts,
-          },
-        ],
-        loadBalancers: ILoadBalancer[] = [],
-        securityGroupsByApplicationName: any[] = [];
+        {
+          name: 'deck-test-v001',
+          cluster: 'deck-test',
+          account: 'test',
+          region: 'us-west-2',
+          type: 'aws',
+          cloudProvider: 'aws',
+          instances: [],
+          instanceCounts: {} as IInstanceCounts,
+        },
+      ];
+      const loadBalancers: ILoadBalancer[] = [];
+      const securityGroupsByApplicationName: any[] = [];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
       expect(application.defaultCredentials.aws).toBe('test');
@@ -207,11 +207,11 @@ describe('Application Model', function () {
     });
 
     it('sets default credentials and region from load balancer when only one account/region found', function () {
-      const serverGroups: IServerGroup[] = [],
-        loadBalancers: ILoadBalancer[] = [
-          { name: 'deck-frontend', cloudProvider: 'gce', vpcId: 'vpc0', region: 'us-central-1', account: 'prod' },
-        ],
-        securityGroupsByApplicationName: any[] = [];
+      const serverGroups: IServerGroup[] = [];
+      const loadBalancers: ILoadBalancer[] = [
+        { name: 'deck-frontend', cloudProvider: 'gce', vpcId: 'vpc0', region: 'us-central-1', account: 'prod' },
+      ];
+      const securityGroupsByApplicationName: any[] = [];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
       expect(application.defaultCredentials.gce).toBe('prod');
@@ -219,11 +219,11 @@ describe('Application Model', function () {
     });
 
     it('sets default credentials and region from firewall', function () {
-      const serverGroups: any[] = [],
-        loadBalancers: ILoadBalancer[] = [],
-        securityGroupsByApplicationName: any[] = [
-          { name: 'deck-test', provider: 'cf', accountName: 'test', region: 'us-south-7' },
-        ];
+      const serverGroups: any[] = [];
+      const loadBalancers: ILoadBalancer[] = [];
+      const securityGroupsByApplicationName: any[] = [
+        { name: 'deck-test', provider: 'cf', accountName: 'test', region: 'us-south-7' },
+      ];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
       expect(application.defaultCredentials.cf).toBe('test');
@@ -231,13 +231,13 @@ describe('Application Model', function () {
     });
 
     it('does not set defaults when multiple values found for the same provider', function () {
-      const serverGroups: IServerGroup[] = [],
-        loadBalancers: ILoadBalancer[] = [
-          { name: 'deck-frontend', cloudProvider: 'aws', vpcId: 'vpcId', region: 'us-west-1', account: 'prod' },
-        ],
-        securityGroupsByApplicationName: any[] = [
-          { name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-east-1' },
-        ];
+      const serverGroups: IServerGroup[] = [];
+      const loadBalancers: ILoadBalancer[] = [
+        { name: 'deck-frontend', cloudProvider: 'aws', vpcId: 'vpcId', region: 'us-west-1', account: 'prod' },
+      ];
+      const securityGroupsByApplicationName: any[] = [
+        { name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-east-1' },
+      ];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
       expect(application.defaultCredentials.aws).toBeUndefined();
@@ -245,13 +245,13 @@ describe('Application Model', function () {
     });
 
     it('sets default region or default credentials if possible', function () {
-      const serverGroups: IServerGroup[] = [],
-        loadBalancers: ILoadBalancer[] = [
-          { name: 'deck-frontend', cloudProvider: 'aws', vpcId: 'vpcId', region: 'us-east-1', account: 'prod' },
-        ],
-        securityGroupsByApplicationName: any[] = [
-          { name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-east-1' },
-        ];
+      const serverGroups: IServerGroup[] = [];
+      const loadBalancers: ILoadBalancer[] = [
+        { name: 'deck-frontend', cloudProvider: 'aws', vpcId: 'vpcId', region: 'us-east-1', account: 'prod' },
+      ];
+      const securityGroupsByApplicationName: any[] = [
+        { name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-east-1' },
+      ];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
       expect(application.defaultCredentials.aws).toBeUndefined();
@@ -259,13 +259,13 @@ describe('Application Model', function () {
     });
 
     it('sets default credentials, even if region cannot be set', function () {
-      const serverGroups: IServerGroup[] = [],
-        loadBalancers: ILoadBalancer[] = [
-          { name: 'deck-frontend', cloudProvider: 'aws', vpcId: 'vpc0', region: 'us-east-1', account: 'test' },
-        ],
-        securityGroupsByApplicationName: any[] = [
-          { name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-west-1' },
-        ];
+      const serverGroups: IServerGroup[] = [];
+      const loadBalancers: ILoadBalancer[] = [
+        { name: 'deck-frontend', cloudProvider: 'aws', vpcId: 'vpc0', region: 'us-east-1', account: 'test' },
+      ];
+      const securityGroupsByApplicationName: any[] = [
+        { name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-west-1' },
+      ];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
       expect(application.defaultCredentials.aws).toBe('test');
@@ -274,35 +274,35 @@ describe('Application Model', function () {
 
     it('should set defaults for multiple providers', function () {
       const serverGroups: any[] = [
-          {
-            name: 'deck-test-v001',
-            account: 'test',
-            region: 'us-west-2',
-            provider: 'aws',
-            instances: [],
-            instanceCounts: { up: 0, down: 0, starting: 0, unknown: 0, outOfService: 0 },
-          },
-          {
-            name: 'deck-gce-v001',
-            account: 'gce-test',
-            region: 'us-central-1',
-            provider: 'gce',
-            instances: [],
-            instanceCounts: { up: 0, down: 0, starting: 0, unknown: 0, outOfService: 0 },
-          },
-        ],
-        loadBalancers: ILoadBalancer[] = [
-          {
-            name: 'deck-frontend',
-            account: 'gce-test',
-            cloudProvider: 'gce',
-            region: 'us-central-1',
-            serverGroups: [],
-          },
-        ],
-        securityGroupsByApplicationName: any[] = [
-          { name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-west-2' },
-        ];
+        {
+          name: 'deck-test-v001',
+          account: 'test',
+          region: 'us-west-2',
+          provider: 'aws',
+          instances: [],
+          instanceCounts: { up: 0, down: 0, starting: 0, unknown: 0, outOfService: 0 },
+        },
+        {
+          name: 'deck-gce-v001',
+          account: 'gce-test',
+          region: 'us-central-1',
+          provider: 'gce',
+          instances: [],
+          instanceCounts: { up: 0, down: 0, starting: 0, unknown: 0, outOfService: 0 },
+        },
+      ];
+      const loadBalancers: ILoadBalancer[] = [
+        {
+          name: 'deck-frontend',
+          account: 'gce-test',
+          cloudProvider: 'gce',
+          region: 'us-central-1',
+          serverGroups: [],
+        },
+      ];
+      const securityGroupsByApplicationName: any[] = [
+        { name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-west-2' },
+      ];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
       expect(application.defaultCredentials.aws).toBe('test');

--- a/packages/core/src/application/application.model.spec.ts
+++ b/packages/core/src/application/application.model.spec.ts
@@ -2,13 +2,12 @@ import { mock } from 'angular';
 
 import type { Application } from './application.model';
 import { ApplicationModelBuilder } from './applicationModel.builder';
-import { ApplicationDataSourceRegistry } from './service/ApplicationDataSourceRegistry';
+import type { IEntityTag, IEntityTags, IInstanceCounts, ILoadBalancer, IServerGroup } from '../domain';
 import { LOAD_BALANCER_DATA_SOURCE } from '../loadBalancer/loadBalancer.dataSource';
+import { SECURITY_GROUP_DATA_SOURCE } from '../securityGroup/securityGroup.dataSource';
 import type { SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
 import { SERVER_GROUP_DATA_SOURCE } from '../serverGroup/serverGroup.dataSource';
-import { SECURITY_GROUP_DATA_SOURCE } from '../securityGroup/securityGroup.dataSource';
-
-import type { IEntityTag, IEntityTags, IServerGroup, IInstanceCounts, ILoadBalancer } from '../domain';
+import { ApplicationDataSourceRegistry } from './service/ApplicationDataSourceRegistry';
 
 describe('Application Model', function () {
   let application: Application,

--- a/packages/core/src/application/config/customBanner/CustomBannerConfig.spec.tsx
+++ b/packages/core/src/application/config/customBanner/CustomBannerConfig.spec.tsx
@@ -3,7 +3,8 @@ import { shallow } from 'enzyme';
 
 import { noop } from '../../../utils';
 
-import { CustomBannerConfig, ICustomBannerConfig } from './CustomBannerConfig';
+import type { ICustomBannerConfig } from './CustomBannerConfig';
+import { CustomBannerConfig } from './CustomBannerConfig';
 
 describe('<CustomBannerConfig />', () => {
   let bannerConfigs: ICustomBannerConfig[];

--- a/packages/core/src/application/config/customBanner/CustomBannerConfig.spec.tsx
+++ b/packages/core/src/application/config/customBanner/CustomBannerConfig.spec.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { shallow } from 'enzyme';
-
-import { noop } from '../../../utils';
+import React from 'react';
 
 import type { ICustomBannerConfig } from './CustomBannerConfig';
 import { CustomBannerConfig } from './CustomBannerConfig';
+import { noop } from '../../../utils';
 
 describe('<CustomBannerConfig />', () => {
   let bannerConfigs: ICustomBannerConfig[];

--- a/packages/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
+++ b/packages/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
@@ -1,11 +1,11 @@
 import { mock } from 'angular';
 
 import type { Application } from '../../application.model';
-import { ApplicationModelBuilder } from '../../applicationModel.builder';
 import type { DataSourceEditorController } from './applicationDataSourceEditor.component';
 import { APPLICATION_DATA_SOURCE_EDITOR } from './applicationDataSourceEditor.component';
-import { ApplicationWriter } from '../../service/ApplicationWriter';
+import { ApplicationModelBuilder } from '../../applicationModel.builder';
 import { TaskReader } from '../../../index';
+import { ApplicationWriter } from '../../service/ApplicationWriter';
 
 describe('Component: Application Data Source Editor', () => {
   let application: Application,

--- a/packages/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
+++ b/packages/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
@@ -1,8 +1,9 @@
 import { mock } from 'angular';
 
-import { Application } from '../../application.model';
+import type { Application } from '../../application.model';
 import { ApplicationModelBuilder } from '../../applicationModel.builder';
-import { APPLICATION_DATA_SOURCE_EDITOR, DataSourceEditorController } from './applicationDataSourceEditor.component';
+import type { DataSourceEditorController } from './applicationDataSourceEditor.component';
+import { APPLICATION_DATA_SOURCE_EDITOR } from './applicationDataSourceEditor.component';
 import { ApplicationWriter } from '../../service/ApplicationWriter';
 import { TaskReader } from '../../../index';
 

--- a/packages/core/src/application/config/footer/configSectionFooter.component.spec.ts
+++ b/packages/core/src/application/config/footer/configSectionFooter.component.spec.ts
@@ -1,7 +1,8 @@
 import { mock } from 'angular';
 
 import { ApplicationWriter } from '../../service/ApplicationWriter';
-import { CONFIG_SECTION_FOOTER, ConfigSectionFooterController } from './configSectionFooter.component';
+import type { ConfigSectionFooterController } from './configSectionFooter.component';
+import { CONFIG_SECTION_FOOTER } from './configSectionFooter.component';
 
 describe('Component: ConfigSectionFooter', () => {
   let $componentController: ng.IComponentControllerService,

--- a/packages/core/src/application/config/footer/configSectionFooter.component.spec.ts
+++ b/packages/core/src/application/config/footer/configSectionFooter.component.spec.ts
@@ -1,8 +1,8 @@
 import { mock } from 'angular';
 
-import { ApplicationWriter } from '../../service/ApplicationWriter';
 import type { ConfigSectionFooterController } from './configSectionFooter.component';
 import { CONFIG_SECTION_FOOTER } from './configSectionFooter.component';
+import { ApplicationWriter } from '../../service/ApplicationWriter';
 
 describe('Component: ConfigSectionFooter', () => {
   let $componentController: ng.IComponentControllerService,

--- a/packages/core/src/application/listExtractor/AppListExtractor.spec.ts
+++ b/packages/core/src/application/listExtractor/AppListExtractor.spec.ts
@@ -1,8 +1,8 @@
-import { IInstance, IServerGroup } from '../../domain';
-import { Application } from '../application.model';
+import type { IInstance, IServerGroup } from '../../domain';
+import type { Application } from '../application.model';
 import { ApplicationModelBuilder } from '../applicationModel.builder';
 import { AppListExtractor } from './AppListExtractor';
-import { IMoniker } from '../../naming/IMoniker';
+import type { IMoniker } from '../../naming/IMoniker';
 
 describe('AppListExtractor', function () {
   const buildApplication = (serverGroups: any[] = []): Application => {

--- a/packages/core/src/application/listExtractor/AppListExtractor.spec.ts
+++ b/packages/core/src/application/listExtractor/AppListExtractor.spec.ts
@@ -1,7 +1,7 @@
-import type { IInstance, IServerGroup } from '../../domain';
+import { AppListExtractor } from './AppListExtractor';
 import type { Application } from '../application.model';
 import { ApplicationModelBuilder } from '../applicationModel.builder';
-import { AppListExtractor } from './AppListExtractor';
+import type { IInstance, IServerGroup } from '../../domain';
 import type { IMoniker } from '../../naming/IMoniker';
 
 describe('AppListExtractor', function () {

--- a/packages/core/src/application/modal/PermissionsConfigurer.spec.tsx
+++ b/packages/core/src/application/modal/PermissionsConfigurer.spec.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 import { mock } from 'angular';
 import { mount } from 'enzyme';
+import React from 'react';
 
-import { AuthenticationService } from '../../authentication';
-import { REACT_MODULE } from '../../reactShims';
 import type { IPermissions, IPermissionsConfigurerProps } from './PermissionsConfigurer';
 import { PermissionsConfigurer } from './PermissionsConfigurer';
+import { AuthenticationService } from '../../authentication';
+import { REACT_MODULE } from '../../reactShims';
 
 describe('PermissionsConfigurer', () => {
   const createComponent = (props: IPermissionsConfigurerProps) => {

--- a/packages/core/src/application/modal/PermissionsConfigurer.spec.tsx
+++ b/packages/core/src/application/modal/PermissionsConfigurer.spec.tsx
@@ -4,7 +4,8 @@ import { mount } from 'enzyme';
 
 import { AuthenticationService } from '../../authentication';
 import { REACT_MODULE } from '../../reactShims';
-import { IPermissions, IPermissionsConfigurerProps, PermissionsConfigurer } from './PermissionsConfigurer';
+import type { IPermissions, IPermissionsConfigurerProps } from './PermissionsConfigurer';
+import { PermissionsConfigurer } from './PermissionsConfigurer';
 
 describe('PermissionsConfigurer', () => {
   const createComponent = (props: IPermissionsConfigurerProps) => {

--- a/packages/core/src/application/modal/validation/ApplicationNameValidator.spec.ts
+++ b/packages/core/src/application/modal/validation/ApplicationNameValidator.spec.ts
@@ -1,6 +1,7 @@
 import { mock } from 'angular';
 
-import { ApplicationNameValidator, IApplicationNameValidationResult } from './ApplicationNameValidator';
+import type { IApplicationNameValidationResult } from './ApplicationNameValidator';
+import { ApplicationNameValidator } from './ApplicationNameValidator';
 import { ExampleApplicationNameValidator, ExampleApplicationNameValidator2 } from './ExampleApplicationNameValidator';
 import { AccountService } from '../../../account/AccountService';
 

--- a/packages/core/src/application/modal/validation/validateApplicationName.directive.spec.ts
+++ b/packages/core/src/application/modal/validation/validateApplicationName.directive.spec.ts
@@ -2,8 +2,8 @@ import type { ICompileService, IQService, IRootScopeService } from 'angular';
 import { mock } from 'angular';
 
 import { ExampleApplicationNameValidator, ExampleApplicationNameValidator2 } from './ExampleApplicationNameValidator';
-import { VALIDATE_APPLICATION_NAME } from './validateApplicationName.directive';
 import { AccountService } from '../../../account/AccountService';
+import { VALIDATE_APPLICATION_NAME } from './validateApplicationName.directive';
 
 describe('Validator: validateApplicationName', function () {
   const validator1 = new ExampleApplicationNameValidator();

--- a/packages/core/src/application/modal/validation/validateApplicationName.directive.spec.ts
+++ b/packages/core/src/application/modal/validation/validateApplicationName.directive.spec.ts
@@ -1,4 +1,5 @@
-import { ICompileService, IQService, IRootScopeService, mock } from 'angular';
+import type { ICompileService, IQService, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
 import { ExampleApplicationNameValidator, ExampleApplicationNameValidator2 } from './ExampleApplicationNameValidator';
 import { VALIDATE_APPLICATION_NAME } from './validateApplicationName.directive';

--- a/packages/core/src/application/nav/ApplicationNavigation.spec.tsx
+++ b/packages/core/src/application/nav/ApplicationNavigation.spec.tsx
@@ -1,26 +1,26 @@
-import React from 'react';
-import { RecoilRoot } from 'recoil';
-import { mount } from 'enzyme';
-import { mock } from 'angular';
+import { StateMatcher } from '@uirouter/core';
 import type { UIRouterReact } from '@uirouter/react';
 import { UIRouterContext } from '@uirouter/react';
-import { StateMatcher } from '@uirouter/core';
+import { mock } from 'angular';
+import { mount } from 'enzyme';
+import React from 'react';
+import { RecoilRoot } from 'recoil';
 
-import { REACT_MODULE } from '../../reactShims';
-import { OVERRIDE_REGISTRY } from '../../overrideRegistry';
 import {
   mockAppConfigDataSourceConfig,
-  mockServerGroupDataSourceConfig,
   mockLoadBalancerDataSourceConfig,
-  mockTaskDataSourceConfig,
   mockPipelineDataSourceConfig,
+  mockServerGroupDataSourceConfig,
+  mockTaskDataSourceConfig,
 } from '@spinnaker/mocks';
-import { ApplicationModelBuilder } from '../../application';
-import type { IPipeline } from '../../domain';
-import type { ApplicationDataSource } from '../service/applicationDataSource';
 
 import { ApplicationNavigation } from './ApplicationNavigation';
+import { ApplicationModelBuilder } from '../../application';
 import { SETTINGS } from '../../config';
+import type { IPipeline } from '../../domain';
+import { OVERRIDE_REGISTRY } from '../../overrideRegistry';
+import { REACT_MODULE } from '../../reactShims';
+import type { ApplicationDataSource } from '../service/applicationDataSource';
 
 describe('ApplicationNavigation', () => {
   let $uiRouter: UIRouterReact;

--- a/packages/core/src/application/nav/ApplicationNavigation.spec.tsx
+++ b/packages/core/src/application/nav/ApplicationNavigation.spec.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { mount } from 'enzyme';
 import { mock } from 'angular';
-import { UIRouterReact, UIRouterContext } from '@uirouter/react';
+import type { UIRouterReact } from '@uirouter/react';
+import { UIRouterContext } from '@uirouter/react';
 import { StateMatcher } from '@uirouter/core';
 
 import { REACT_MODULE } from '../../reactShims';
@@ -15,8 +16,8 @@ import {
   mockPipelineDataSourceConfig,
 } from '@spinnaker/mocks';
 import { ApplicationModelBuilder } from '../../application';
-import { IPipeline } from '../../domain';
-import { ApplicationDataSource } from '../service/applicationDataSource';
+import type { IPipeline } from '../../domain';
+import type { ApplicationDataSource } from '../service/applicationDataSource';
 
 import { ApplicationNavigation } from './ApplicationNavigation';
 import { SETTINGS } from '../../config';

--- a/packages/core/src/application/nav/NavItem.spec.tsx
+++ b/packages/core/src/application/nav/NavItem.spec.tsx
@@ -4,9 +4,10 @@ import { mount } from 'enzyme';
 import { BehaviorSubject } from 'rxjs';
 
 import { mockEntityTags, mockServerGroupDataSourceConfig, mockPipelineDataSourceConfig } from '@spinnaker/mocks';
-import { Application, ApplicationModelBuilder } from '../../application';
-import { ApplicationDataSource, IDataSourceConfig } from '../service/applicationDataSource';
-import { IEntityTags, IServerGroup, IPipeline } from '../../domain';
+import type { Application } from '../../application';
+import { ApplicationModelBuilder } from '../../application';
+import type { ApplicationDataSource, IDataSourceConfig } from '../service/applicationDataSource';
+import type { IEntityTags, IServerGroup, IPipeline } from '../../domain';
 import { NavItem } from './NavItem';
 
 describe('NavItem', () => {

--- a/packages/core/src/application/nav/NavItem.spec.tsx
+++ b/packages/core/src/application/nav/NavItem.spec.tsx
@@ -1,14 +1,15 @@
+import { mount } from 'enzyme';
 import React from 'react';
 import { RecoilRoot } from 'recoil';
-import { mount } from 'enzyme';
 import { BehaviorSubject } from 'rxjs';
 
-import { mockEntityTags, mockServerGroupDataSourceConfig, mockPipelineDataSourceConfig } from '@spinnaker/mocks';
+import { mockEntityTags, mockPipelineDataSourceConfig, mockServerGroupDataSourceConfig } from '@spinnaker/mocks';
+
+import { NavItem } from './NavItem';
 import type { Application } from '../../application';
 import { ApplicationModelBuilder } from '../../application';
+import type { IEntityTags, IPipeline, IServerGroup } from '../../domain';
 import type { ApplicationDataSource, IDataSourceConfig } from '../service/applicationDataSource';
-import type { IEntityTags, IServerGroup, IPipeline } from '../../domain';
-import { NavItem } from './NavItem';
 
 describe('NavItem', () => {
   const buildApp = <T,>(config: IDataSourceConfig<T>): Application =>

--- a/packages/core/src/application/nav/NavSection.spec.tsx
+++ b/packages/core/src/application/nav/NavSection.spec.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 
 import {
   mockLoadBalancerDataSourceConfig,
   mockPipelineDataSourceConfig,
   mockServerGroupDataSourceConfig,
 } from '@spinnaker/mocks';
-import { ApplicationModelBuilder } from '../../application';
+
 import { NavSection } from './NavSection';
+import { ApplicationModelBuilder } from '../../application';
 
 describe('NavItem', () => {
   it('should render multiple categories', () => {

--- a/packages/core/src/application/service/ApplicationReader.spec.ts
+++ b/packages/core/src/application/service/ApplicationReader.spec.ts
@@ -1,20 +1,21 @@
 import { mock } from 'angular';
-import { mockHttpClient } from '../../api/mock/jasmine';
 
-import Spy = jasmine.Spy;
+import { ApplicationDataSourceRegistry } from './ApplicationDataSourceRegistry';
 import type { IApplicationDataSourceAttribute } from './ApplicationReader';
 import { ApplicationReader } from './ApplicationReader';
-import { ApplicationDataSourceRegistry } from './ApplicationDataSourceRegistry';
+import { mockHttpClient } from '../../api/mock/jasmine';
 import type { Application } from '../application.model';
+import type { ClusterService } from '../../cluster/cluster.service';
+import { CLUSTER_SERVICE } from '../../cluster/cluster.service';
 import { LOAD_BALANCER_DATA_SOURCE } from '../../loadBalancer/loadBalancer.dataSource';
 import type { LoadBalancerReader } from '../../loadBalancer/loadBalancer.read.service';
 import { LOAD_BALANCER_READ_SERVICE } from '../../loadBalancer/loadBalancer.read.service';
+import { SECURITY_GROUP_DATA_SOURCE } from '../../securityGroup/securityGroup.dataSource';
 import type { SecurityGroupReader } from '../../securityGroup/securityGroupReader.service';
 import { SECURITY_GROUP_READER } from '../../securityGroup/securityGroupReader.service';
-import type { ClusterService } from '../../cluster/cluster.service';
-import { CLUSTER_SERVICE } from '../../cluster/cluster.service';
 import { SERVER_GROUP_DATA_SOURCE } from '../../serverGroup/serverGroup.dataSource';
-import { SECURITY_GROUP_DATA_SOURCE } from '../../securityGroup/securityGroup.dataSource';
+
+import Spy = jasmine.Spy;
 
 describe('ApplicationReader', function () {
   let securityGroupReader: SecurityGroupReader;

--- a/packages/core/src/application/service/ApplicationReader.spec.ts
+++ b/packages/core/src/application/service/ApplicationReader.spec.ts
@@ -2,13 +2,17 @@ import { mock } from 'angular';
 import { mockHttpClient } from '../../api/mock/jasmine';
 
 import Spy = jasmine.Spy;
-import { IApplicationDataSourceAttribute, ApplicationReader } from './ApplicationReader';
+import type { IApplicationDataSourceAttribute } from './ApplicationReader';
+import { ApplicationReader } from './ApplicationReader';
 import { ApplicationDataSourceRegistry } from './ApplicationDataSourceRegistry';
-import { Application } from '../application.model';
+import type { Application } from '../application.model';
 import { LOAD_BALANCER_DATA_SOURCE } from '../../loadBalancer/loadBalancer.dataSource';
-import { LOAD_BALANCER_READ_SERVICE, LoadBalancerReader } from '../../loadBalancer/loadBalancer.read.service';
-import { SECURITY_GROUP_READER, SecurityGroupReader } from '../../securityGroup/securityGroupReader.service';
-import { CLUSTER_SERVICE, ClusterService } from '../../cluster/cluster.service';
+import type { LoadBalancerReader } from '../../loadBalancer/loadBalancer.read.service';
+import { LOAD_BALANCER_READ_SERVICE } from '../../loadBalancer/loadBalancer.read.service';
+import type { SecurityGroupReader } from '../../securityGroup/securityGroupReader.service';
+import { SECURITY_GROUP_READER } from '../../securityGroup/securityGroupReader.service';
+import type { ClusterService } from '../../cluster/cluster.service';
+import { CLUSTER_SERVICE } from '../../cluster/cluster.service';
 import { SERVER_GROUP_DATA_SOURCE } from '../../serverGroup/serverGroup.dataSource';
 import { SECURITY_GROUP_DATA_SOURCE } from '../../securityGroup/securityGroup.dataSource';
 

--- a/packages/core/src/application/service/ApplicationWriter.spec.ts
+++ b/packages/core/src/application/service/ApplicationWriter.spec.ts
@@ -1,7 +1,9 @@
 import { mock } from 'angular';
 
-import { ApplicationWriter, IApplicationAttributes } from './ApplicationWriter';
-import { IJob, TaskExecutor } from '../../task/taskExecutor';
+import type { IApplicationAttributes } from './ApplicationWriter';
+import { ApplicationWriter } from './ApplicationWriter';
+import type { IJob } from '../../task/taskExecutor';
+import { TaskExecutor } from '../../task/taskExecutor';
 import Spy = jasmine.Spy;
 
 describe('ApplicationWriter', function () {

--- a/packages/core/src/application/service/InferredApplicationWarningService.spec.ts
+++ b/packages/core/src/application/service/InferredApplicationWarningService.spec.ts
@@ -3,7 +3,7 @@ import Spy = jasmine.Spy;
 import { NotifierService } from '../../widgets/notifier/notifier.service';
 
 import { InferredApplicationWarningService } from './InferredApplicationWarningService';
-import { Application } from '../application.model';
+import type { Application } from '../application.model';
 import { ApplicationModelBuilder } from '../applicationModel.builder';
 
 describe('Service: inferredApplicationWarning', () => {

--- a/packages/core/src/application/service/InferredApplicationWarningService.spec.ts
+++ b/packages/core/src/application/service/InferredApplicationWarningService.spec.ts
@@ -1,10 +1,9 @@
 import Spy = jasmine.Spy;
 
-import { NotifierService } from '../../widgets/notifier/notifier.service';
-
 import { InferredApplicationWarningService } from './InferredApplicationWarningService';
 import type { Application } from '../application.model';
 import { ApplicationModelBuilder } from '../applicationModel.builder';
+import { NotifierService } from '../../widgets/notifier/notifier.service';
 
 describe('Service: inferredApplicationWarning', () => {
   describe('checkIfInferredAndWarn', () => {

--- a/packages/core/src/artifact/expectedArtifact.service.spec.ts
+++ b/packages/core/src/artifact/expectedArtifact.service.spec.ts
@@ -1,6 +1,6 @@
 import { noop } from 'lodash';
 import { ExpectedArtifactService } from './expectedArtifact.service';
-import { IArtifact, IArtifactKindConfig } from '../domain';
+import type { IArtifact, IArtifactKindConfig } from '../domain';
 import { Registry } from '../registry';
 
 describe('ExpectedArtifactService', () => {

--- a/packages/core/src/artifact/expectedArtifact.service.spec.ts
+++ b/packages/core/src/artifact/expectedArtifact.service.spec.ts
@@ -1,6 +1,7 @@
 import { noop } from 'lodash';
-import { ExpectedArtifactService } from './expectedArtifact.service';
+
 import type { IArtifact, IArtifactKindConfig } from '../domain';
+import { ExpectedArtifactService } from './expectedArtifact.service';
 import { Registry } from '../registry';
 
 describe('ExpectedArtifactService', () => {

--- a/packages/core/src/artifact/react/ExpectedArtifactSelector.spec.tsx
+++ b/packages/core/src/artifact/react/ExpectedArtifactSelector.spec.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
 import { ExpectedArtifactService } from '..';
-import type { IExpectedArtifact } from '../../domain';
-
 import { ExpectedArtifactSelector } from './ExpectedArtifactSelector';
+import type { IExpectedArtifact } from '../../domain';
 
 const artifact = (type: string): IExpectedArtifact => {
   const ea = ExpectedArtifactService.createEmptyArtifact();

--- a/packages/core/src/artifact/react/ExpectedArtifactSelector.spec.tsx
+++ b/packages/core/src/artifact/react/ExpectedArtifactSelector.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { ExpectedArtifactService } from '..';
-import { IExpectedArtifact } from '../../domain';
+import type { IExpectedArtifact } from '../../domain';
 
 import { ExpectedArtifactSelector } from './ExpectedArtifactSelector';
 

--- a/packages/core/src/authentication/AuthenticationInitializer.spec.ts
+++ b/packages/core/src/authentication/AuthenticationInitializer.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @spinnaker/migrate-to-mock-http-client */
 import { mock } from 'angular';
 
-import { IDeckRootScope } from '../domain';
+import type { IDeckRootScope } from '../domain';
 import { AuthenticationInitializer } from './AuthenticationInitializer';
 import { AuthenticationService } from './AuthenticationService';
 import { AUTHENTICATION_MODULE } from './authentication.module';

--- a/packages/core/src/authentication/AuthenticationInitializer.spec.ts
+++ b/packages/core/src/authentication/AuthenticationInitializer.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @spinnaker/migrate-to-mock-http-client */
 import { mock } from 'angular';
 
-import type { IDeckRootScope } from '../domain';
 import { AuthenticationInitializer } from './AuthenticationInitializer';
 import { AuthenticationService } from './AuthenticationService';
 import { AUTHENTICATION_MODULE } from './authentication.module';
 import { SETTINGS } from '../config/settings';
+import type { IDeckRootScope } from '../domain';
 
 declare const window: any;
 describe('authenticationProvider: application startup', function () {

--- a/packages/core/src/authentication/AuthenticationInitializer.spec.ts
+++ b/packages/core/src/authentication/AuthenticationInitializer.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @spinnaker/migrate-to-mock-http-client */
 import { mock } from 'angular';
 
 import { IDeckRootScope } from '../domain';

--- a/packages/core/src/authentication/AuthenticationService.spec.ts
+++ b/packages/core/src/authentication/AuthenticationService.spec.ts
@@ -1,4 +1,5 @@
-import { AuthenticationService, IUser } from './AuthenticationService';
+import type { IUser } from './AuthenticationService';
+import { AuthenticationService } from './AuthenticationService';
 
 describe('AuthenticationService', function () {
   beforeEach(() => AuthenticationService.reset());

--- a/packages/core/src/authentication/authentication.interceptor.spec.ts
+++ b/packages/core/src/authentication/authentication.interceptor.spec.ts
@@ -1,6 +1,8 @@
-import { IQService, IRequestConfig, IRootScopeService, mock } from 'angular';
+import type { IQService, IRequestConfig, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
-import { AUTHENTICATION_INTERCEPTOR_SERVICE, AuthenticationInterceptor } from './authentication.interceptor.service';
+import type { AuthenticationInterceptor } from './authentication.interceptor.service';
+import { AUTHENTICATION_INTERCEPTOR_SERVICE } from './authentication.interceptor.service';
 import { AuthenticationService } from './AuthenticationService';
 import { SETTINGS } from '../config/settings';
 

--- a/packages/core/src/authentication/authentication.interceptor.spec.ts
+++ b/packages/core/src/authentication/authentication.interceptor.spec.ts
@@ -1,9 +1,9 @@
 import type { IQService, IRequestConfig, IRootScopeService } from 'angular';
 import { mock } from 'angular';
 
+import { AuthenticationService } from './AuthenticationService';
 import type { AuthenticationInterceptor } from './authentication.interceptor.service';
 import { AUTHENTICATION_INTERCEPTOR_SERVICE } from './authentication.interceptor.service';
-import { AuthenticationService } from './AuthenticationService';
 import { SETTINGS } from '../config/settings';
 
 describe('authenticationInterceptor', function () {

--- a/packages/core/src/cache/cacheInitializer.service.spec.ts
+++ b/packages/core/src/cache/cacheInitializer.service.spec.ts
@@ -1,11 +1,11 @@
-import { flatten } from 'lodash';
-
 import type { IQService, IRootScopeService } from 'angular';
 import { mock } from 'angular';
+import { flatten } from 'lodash';
+
+import { InfrastructureCaches } from './';
+import { AccountService } from '../account/AccountService';
 import type { CacheInitializerService } from './cacheInitializer.service';
 import { CACHE_INITIALIZER_SERVICE } from './cacheInitializer.service';
-import { AccountService } from '../account/AccountService';
-import { InfrastructureCaches } from './';
 import type { SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
 import { SECURITY_GROUP_READER } from '../securityGroup/securityGroupReader.service';
 

--- a/packages/core/src/cache/cacheInitializer.service.spec.ts
+++ b/packages/core/src/cache/cacheInitializer.service.spec.ts
@@ -1,10 +1,13 @@
 import { flatten } from 'lodash';
 
-import { mock, IQService, IRootScopeService } from 'angular';
-import { CACHE_INITIALIZER_SERVICE, CacheInitializerService } from './cacheInitializer.service';
+import type { IQService, IRootScopeService } from 'angular';
+import { mock } from 'angular';
+import type { CacheInitializerService } from './cacheInitializer.service';
+import { CACHE_INITIALIZER_SERVICE } from './cacheInitializer.service';
 import { AccountService } from '../account/AccountService';
 import { InfrastructureCaches } from './';
-import { SECURITY_GROUP_READER, SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
+import type { SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
+import { SECURITY_GROUP_READER } from '../securityGroup/securityGroupReader.service';
 
 interface IKeys {
   [key: string]: string[];

--- a/packages/core/src/cache/infrastructureCaches.spec.ts
+++ b/packages/core/src/cache/infrastructureCaches.spec.ts
@@ -1,10 +1,9 @@
 import type { CacheFactory, CacheOptions } from 'cachefactory';
 
-import { noop } from '../utils';
-
-import { InfrastructureCaches } from './infrastructureCaches';
-import type { ICacheConfig, ICache } from './deckCacheFactory';
+import type { ICache, ICacheConfig } from './deckCacheFactory';
 import { DeckCacheFactory } from './deckCacheFactory';
+import { InfrastructureCaches } from './infrastructureCaches';
+import { noop } from '../utils';
 
 interface ICacheInstantiation {
   cacheId: string;

--- a/packages/core/src/cache/infrastructureCaches.spec.ts
+++ b/packages/core/src/cache/infrastructureCaches.spec.ts
@@ -1,9 +1,10 @@
-import { CacheFactory, CacheOptions } from 'cachefactory';
+import type { CacheFactory, CacheOptions } from 'cachefactory';
 
 import { noop } from '../utils';
 
 import { InfrastructureCaches } from './infrastructureCaches';
-import { DeckCacheFactory, ICacheConfig, ICache } from './deckCacheFactory';
+import type { ICacheConfig, ICache } from './deckCacheFactory';
+import { DeckCacheFactory } from './deckCacheFactory';
 
 interface ICacheInstantiation {
   cacheId: string;

--- a/packages/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
+++ b/packages/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
@@ -1,6 +1,8 @@
-import { mock, IComponentControllerService, IScope, IQService, IRootScopeService } from 'angular';
+import type { IComponentControllerService, IScope, IQService, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
-import { CHAOS_MONKEY_EXCEPTIONS_COMPONENT, ChaosMonkeyExceptionsController } from './chaosMonkeyExceptions.component';
+import type { ChaosMonkeyExceptionsController } from './chaosMonkeyExceptions.component';
+import { CHAOS_MONKEY_EXCEPTIONS_COMPONENT } from './chaosMonkeyExceptions.component';
 import { AccountService } from '../account/AccountService';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { ChaosMonkeyConfig } from './chaosMonkeyConfig.component';

--- a/packages/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
+++ b/packages/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
@@ -1,11 +1,11 @@
-import type { IComponentControllerService, IScope, IQService, IRootScopeService } from 'angular';
+import type { IComponentControllerService, IQService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
-import type { ChaosMonkeyExceptionsController } from './chaosMonkeyExceptions.component';
-import { CHAOS_MONKEY_EXCEPTIONS_COMPONENT } from './chaosMonkeyExceptions.component';
 import { AccountService } from '../account/AccountService';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { ChaosMonkeyConfig } from './chaosMonkeyConfig.component';
+import type { ChaosMonkeyExceptionsController } from './chaosMonkeyExceptions.component';
+import { CHAOS_MONKEY_EXCEPTIONS_COMPONENT } from './chaosMonkeyExceptions.component';
 
 describe('Controller: ChaosMonkeyExceptions', () => {
   let $componentController: IComponentControllerService,

--- a/packages/core/src/cloudProvider/providerSelection/ProviderSelectionService.spec.ts
+++ b/packages/core/src/cloudProvider/providerSelection/ProviderSelectionService.spec.ts
@@ -1,8 +1,10 @@
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import { Application } from '../../application/application.model';
-import { mock, IQService, IScope, IRootScopeService } from 'angular';
+import type { Application } from '../../application/application.model';
+import type { IQService, IScope, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
-import { AccountService, IAccountDetails } from '../../account/AccountService';
+import type { IAccountDetails } from '../../account/AccountService';
+import { AccountService } from '../../account/AccountService';
 import { CloudProviderRegistry } from '..';
 import { ProviderSelectionModal } from './ProviderSelectionModal';
 import { ProviderSelectionService } from './ProviderSelectionService';

--- a/packages/core/src/cloudProvider/providerSelection/ProviderSelectionService.spec.ts
+++ b/packages/core/src/cloudProvider/providerSelection/ProviderSelectionService.spec.ts
@@ -182,7 +182,7 @@ describe('ProviderSelectionService: API', () => {
     const k8s = fakeAccount('kubernetes');
     k8s.type = 'kubernetes';
     accounts = [k8s];
-    let configuration = {
+    const configuration = {
       name: 'Kubernetes',
       adHocInfrastructureWritesEnabled: true,
     };
@@ -200,7 +200,7 @@ describe('ProviderSelectionService: API', () => {
     const k8s = fakeAccount('kubernetes');
     k8s.type = 'kubernetes';
     accounts = [k8s];
-    let configuration = {
+    const configuration = {
       name: 'Kubernetes',
       adHocInfrastructureWritesEnabled: false,
     };
@@ -218,7 +218,7 @@ describe('ProviderSelectionService: API', () => {
     const k8s = fakeAccount('gce');
     k8s.type = 'gce';
     accounts = [k8s];
-    let configuration = {
+    const configuration = {
       name: 'Kubernetes',
     };
     CloudProviderRegistry.registerProvider('gce', configuration);
@@ -235,7 +235,7 @@ describe('ProviderSelectionService: API', () => {
     const k8s = fakeAccount('kubernetes');
     k8s.type = 'kubernetes';
     accounts = [k8s, fakeAccount('gce')];
-    let configuration = {
+    const configuration = {
       name: 'Kubernetes',
       adHocInfrastructureWritesEnabled: false,
     };
@@ -254,7 +254,7 @@ describe('ProviderSelectionService: API', () => {
     const k8s = fakeAccount('kubernetes');
     k8s.type = 'kubernetes';
     accounts = [k8s, fakeAccount('gce')];
-    let configuration = {
+    const configuration = {
       name: 'Kubernetes',
       adHocInfrastructureWritesEnabled: true,
     };
@@ -279,7 +279,7 @@ describe('ProviderSelectionService: API', () => {
       k8s_account.type = 'kubernetes';
 
       accounts = [k8s_account];
-      let configuration = {
+      const configuration = {
         name: 'kubernetes',
         adHocInfrastructureWritesEnabled: true,
       };
@@ -300,7 +300,7 @@ describe('ProviderSelectionService: API', () => {
       k8s_account.type = 'kubernetes';
 
       accounts = [k8s_account];
-      let configuration = {
+      const configuration = {
         name: 'kubernetes',
         adHocInfrastructureWritesEnabled: false,
       };
@@ -322,7 +322,7 @@ describe('ProviderSelectionService: API', () => {
       const k8s_account = fakeAccount('kubernetes');
       k8s_account.type = 'kubernetes';
       accounts = [k8s_account, fakeAccount('gce')];
-      let kubernetes_configuration = {
+      const kubernetes_configuration = {
         name: 'Kubernetes',
         adHocInfrastructureWritesEnabled: false,
       };
@@ -350,7 +350,7 @@ describe('ProviderSelectionService: API', () => {
       k8s_account_2.type = 'kubernetes';
 
       accounts = [k8s_account_1, k8s_account_2];
-      let configuration = {
+      const configuration = {
         name: 'kubernetes',
         adHocInfrastructureWritesEnabled: false,
       };
@@ -371,7 +371,7 @@ describe('ProviderSelectionService: API', () => {
       aws_account.type = 'aws';
 
       accounts = [aws_account];
-      let configuration = {
+      const configuration = {
         name: 'aws',
         adHocInfrastructureWritesEnabled: false,
       };
@@ -392,7 +392,7 @@ describe('ProviderSelectionService: API', () => {
       aws_account.type = 'aws';
 
       accounts = [aws_account];
-      let configuration = {
+      const configuration = {
         name: 'aws',
         adHocInfrastructureWritesEnabled: false,
       };
@@ -415,11 +415,11 @@ describe('ProviderSelectionService: API', () => {
       aws_account.type = 'aws';
 
       accounts = [k8s_account, aws_account];
-      let k8s_configuration = {
+      const k8s_configuration = {
         name: 'kubernetes',
         adHocInfrastructureWritesEnabled: false,
       };
-      let aws_configuration = {
+      const aws_configuration = {
         name: 'aws',
         adHocInfrastructureWritesEnabled: false,
       };
@@ -445,11 +445,11 @@ describe('ProviderSelectionService: API', () => {
       aws_account.type = 'aws';
 
       accounts = [k8s_account, aws_account];
-      let k8s_configuration = {
+      const k8s_configuration = {
         name: 'kubernetes',
         adHocInfrastructureWritesEnabled: true,
       };
-      let aws_configuration = {
+      const aws_configuration = {
         name: 'aws',
         adHocInfrastructureWritesEnabled: true,
       };
@@ -480,11 +480,11 @@ describe('ProviderSelectionService: API', () => {
       aws_account.type = 'aws';
 
       accounts = [k8s_account, aws_account];
-      let k8s_configuration = {
+      const k8s_configuration = {
         name: 'kubernetes',
         adHocInfrastructureWritesEnabled: false,
       };
-      let aws_configuration = {
+      const aws_configuration = {
         name: 'aws',
         adHocInfrastructureWritesEnabled: true,
       };

--- a/packages/core/src/cloudProvider/providerSelection/ProviderSelectionService.spec.ts
+++ b/packages/core/src/cloudProvider/providerSelection/ProviderSelectionService.spec.ts
@@ -1,13 +1,13 @@
-import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import type { Application } from '../../application/application.model';
-import type { IQService, IScope, IRootScopeService } from 'angular';
+import type { IQService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
-import type { IAccountDetails } from '../../account/AccountService';
-import { AccountService } from '../../account/AccountService';
 import { CloudProviderRegistry } from '..';
 import { ProviderSelectionModal } from './ProviderSelectionModal';
 import { ProviderSelectionService } from './ProviderSelectionService';
+import type { IAccountDetails } from '../../account/AccountService';
+import { AccountService } from '../../account/AccountService';
+import type { Application } from '../../application/application.model';
+import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import { SETTINGS } from '../../config/settings';
 
 function fakeAccount(provider: string): IAccountDetails {

--- a/packages/core/src/cluster/ClusterRuleMatcher.spec.ts
+++ b/packages/core/src/cluster/ClusterRuleMatcher.spec.ts
@@ -1,4 +1,5 @@
-import { DefaultClusterMatcher, IClusterMatcher, IClusterMatchRule } from './ClusterRuleMatcher';
+import type { IClusterMatcher, IClusterMatchRule } from './ClusterRuleMatcher';
+import { DefaultClusterMatcher } from './ClusterRuleMatcher';
 
 describe('CustomRuleMatcher', () => {
   let matcher: IClusterMatcher;

--- a/packages/core/src/cluster/cluster.service.spec.ts
+++ b/packages/core/src/cluster/cluster.service.spec.ts
@@ -1,16 +1,15 @@
-import { mockHttpClient } from '../api/mock/jasmine';
 import { mock } from 'angular';
 import { find } from 'lodash';
 
-import { REACT_MODULE } from '../reactShims';
-import * as State from '../state';
-import { ApplicationModelBuilder } from '../application/applicationModel.builder';
-import type { IInstanceCounts, IServerGroup } from '../domain';
+import { mockHttpClient } from '../api/mock/jasmine';
 import type { Application } from '../application/application.model';
-
+import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import type { ClusterService } from './cluster.service';
 import { CLUSTER_SERVICE } from './cluster.service';
 import { SETTINGS } from '../config/settings';
+import type { IInstanceCounts, IServerGroup } from '../domain';
+import { REACT_MODULE } from '../reactShims';
+import * as State from '../state';
 
 const ClusterState = State.ClusterState;
 

--- a/packages/core/src/cluster/cluster.service.spec.ts
+++ b/packages/core/src/cluster/cluster.service.spec.ts
@@ -5,10 +5,11 @@ import { find } from 'lodash';
 import { REACT_MODULE } from '../reactShims';
 import * as State from '../state';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
-import { IInstanceCounts, IServerGroup } from '../domain';
-import { Application } from '../application/application.model';
+import type { IInstanceCounts, IServerGroup } from '../domain';
+import type { Application } from '../application/application.model';
 
-import { CLUSTER_SERVICE, ClusterService } from './cluster.service';
+import type { ClusterService } from './cluster.service';
+import { CLUSTER_SERVICE } from './cluster.service';
 import { SETTINGS } from '../config/settings';
 
 const ClusterState = State.ClusterState;

--- a/packages/core/src/cluster/filter/ClusterFilterService.spec.ts
+++ b/packages/core/src/cluster/filter/ClusterFilterService.spec.ts
@@ -1,7 +1,7 @@
 import { mock } from 'angular';
 import { REACT_MODULE } from '../../reactShims';
 import { CLUSTER_SERVICE } from '../cluster.service';
-import { Application } from '../../application/application.model';
+import type { Application } from '../../application/application.model';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import * as State from '../../state';
 import { cloneDeep, filter } from 'lodash';

--- a/packages/core/src/cluster/filter/ClusterFilterService.spec.ts
+++ b/packages/core/src/cluster/filter/ClusterFilterService.spec.ts
@@ -324,8 +324,8 @@ describe('Service: clusterFilterService', function () {
 
   describe('filter by starting status', function () {
     it('should filter by starting status if checked', function (done) {
-      const starting: any = { healthState: 'Unknown' },
-        serverGroup = application.getDataSource('serverGroups').data[0];
+      const starting: any = { healthState: 'Unknown' };
+      const serverGroup = application.getDataSource('serverGroups').data[0];
       serverGroup.instances.push(starting);
 
       ClusterState.filterModel.asFilterModel.sortFilter.status = { Starting: true };
@@ -348,8 +348,8 @@ describe('Service: clusterFilterService', function () {
 
   describe('filter by out of service status', function () {
     it('should filter out by out of service status if checked', function (done) {
-      const starting: any = { healthState: 'Unknown' },
-        serverGroup = application.getDataSource('serverGroups').data[0];
+      const starting: any = { healthState: 'Unknown' };
+      const serverGroup = application.getDataSource('serverGroups').data[0];
       serverGroup.instances.push(starting);
 
       ClusterState.filterModel.asFilterModel.sortFilter.status = { OutOfService: true };
@@ -363,8 +363,8 @@ describe('Service: clusterFilterService', function () {
 
   describe('filter by unknown status', function () {
     it('should filter out by unknown status if checked', function (done) {
-      const starting: any = { healthState: 'Up' },
-        serverGroup = application.getDataSource('serverGroups').data[0];
+      const starting: any = { healthState: 'Up' };
+      const serverGroup = application.getDataSource('serverGroups').data[0];
       serverGroup.instances.push(starting);
 
       ClusterState.filterModel.asFilterModel.sortFilter.status = { Unknown: true };
@@ -650,8 +650,8 @@ describe('Service: clusterFilterService', function () {
 
     it('should remove all instanceIds if server group is no longer visible, and add back when visible again', function (done) {
       ClusterState.filterModel.asFilterModel.sortFilter.listInstances = true;
-      const serverGroup = application.getDataSource('serverGroups').data[0],
-        multiselectGroup = ClusterState.multiselectModel.getOrCreateInstanceGroup(serverGroup);
+      const serverGroup = application.getDataSource('serverGroups').data[0];
+      const multiselectGroup = ClusterState.multiselectModel.getOrCreateInstanceGroup(serverGroup);
 
       serverGroup.instances.push({ id: 'i-1234' });
       ClusterState.multiselectModel.toggleSelectAll(serverGroup, ['i-1234']);
@@ -1133,8 +1133,8 @@ describe('Service: clusterFilterService', function () {
     });
 
     it('adds executions and running tasks, even when stringVal does not change', function (done) {
-      const runningTasks: any = [{ name: 'a' }],
-        executions: any = [{ name: 'b' }];
+      const runningTasks: any = [{ name: 'a' }];
+      const executions: any = [{ name: 'b' }];
       application = this.buildApplication({
         serverGroups: {
           data: [

--- a/packages/core/src/cluster/filter/ClusterFilterService.spec.ts
+++ b/packages/core/src/cluster/filter/ClusterFilterService.spec.ts
@@ -1,10 +1,11 @@
 import { mock } from 'angular';
-import { REACT_MODULE } from '../../reactShims';
-import { CLUSTER_SERVICE } from '../cluster.service';
+import { cloneDeep, filter } from 'lodash';
+
 import type { Application } from '../../application/application.model';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
+import { CLUSTER_SERVICE } from '../cluster.service';
+import { REACT_MODULE } from '../../reactShims';
 import * as State from '../../state';
-import { cloneDeep, filter } from 'lodash';
 
 const ClusterState = State.ClusterState;
 

--- a/packages/core/src/cluster/filter/LabelFilter.spec.tsx
+++ b/packages/core/src/cluster/filter/LabelFilter.spec.tsx
@@ -3,7 +3,8 @@ import { shallow } from 'enzyme';
 
 import { noop } from '../../utils';
 
-import LabelFilter, { ILabelFilterProps, LabelFilterSelect } from './LabelFilter';
+import type { ILabelFilterProps } from './LabelFilter';
+import LabelFilter, { LabelFilterSelect } from './LabelFilter';
 
 describe('<LabelFilter />', () => {
   let props: ILabelFilterProps;

--- a/packages/core/src/cluster/filter/LabelFilter.spec.tsx
+++ b/packages/core/src/cluster/filter/LabelFilter.spec.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { shallow } from 'enzyme';
-
-import { noop } from '../../utils';
+import React from 'react';
 
 import type { ILabelFilterProps } from './LabelFilter';
 import LabelFilter, { LabelFilterSelect } from './LabelFilter';
+import { noop } from '../../utils';
 
 describe('<LabelFilter />', () => {
   let props: ILabelFilterProps;

--- a/packages/core/src/cluster/filter/MultiselectModel.spec.ts
+++ b/packages/core/src/cluster/filter/MultiselectModel.spec.ts
@@ -1,8 +1,8 @@
+import { MultiselectModel } from './MultiselectModel';
 import { ReactInjector } from '../../reactShims';
 import * as State from '../../state';
-const { ClusterState } = State;
 
-import { MultiselectModel } from './MultiselectModel';
+const { ClusterState } = State;
 
 describe('Multiselect Model', () => {
   let multiselectModel: MultiselectModel;

--- a/packages/core/src/cluster/filter/labelFilterUtils.spec.ts
+++ b/packages/core/src/cluster/filter/labelFilterUtils.spec.ts
@@ -1,10 +1,6 @@
-import {
-  buildLabelsMap,
-  labelFiltersToTrueKeyObject,
-  trueKeyObjectToLabelFilters,
-  ILabelFilter,
-} from './labelFilterUtils';
-import { IServerGroup } from '../../domain/IServerGroup';
+import type { ILabelFilter } from './labelFilterUtils';
+import { buildLabelsMap, labelFiltersToTrueKeyObject, trueKeyObjectToLabelFilters } from './labelFilterUtils';
+import type { IServerGroup } from '../../domain/IServerGroup';
 
 describe('Label filter utils', () => {
   let labelFilters: ILabelFilter[];

--- a/packages/core/src/cluster/filter/labelFilterUtils.spec.ts
+++ b/packages/core/src/cluster/filter/labelFilterUtils.spec.ts
@@ -1,6 +1,6 @@
+import type { IServerGroup } from '../../domain/IServerGroup';
 import type { ILabelFilter } from './labelFilterUtils';
 import { buildLabelsMap, labelFiltersToTrueKeyObject, trueKeyObjectToLabelFilters } from './labelFilterUtils';
-import type { IServerGroup } from '../../domain/IServerGroup';
 
 describe('Label filter utils', () => {
   let labelFilters: ILabelFilter[];

--- a/packages/core/src/filterModel/dependentFilter/DependentFilterService.spec.ts
+++ b/packages/core/src/filterModel/dependentFilter/DependentFilterService.spec.ts
@@ -1,4 +1,4 @@
-import { ISortFilter } from '..';
+import type { ISortFilter } from '..';
 
 import { digestDependentFilters } from './DependentFilterService';
 

--- a/packages/core/src/function/filter/FunctionFilterService.spec.ts
+++ b/packages/core/src/function/filter/FunctionFilterService.spec.ts
@@ -1,9 +1,10 @@
-import type { Application } from '../../application/application.model';
-import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import { FunctionState } from '../../state';
 import type { Dictionary } from 'lodash';
 import { groupBy } from 'lodash';
+
+import type { Application } from '../../application/application.model';
+import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import type { IFunction } from '../../domain';
+import { FunctionState } from '../../state';
 // Most of this logic has been moved to filter.model.service.js, so these act more as integration tests
 describe('Service: functionFilterService', function () {
   const debounceTimeout = 30;

--- a/packages/core/src/function/filter/FunctionFilterService.spec.ts
+++ b/packages/core/src/function/filter/FunctionFilterService.spec.ts
@@ -1,8 +1,9 @@
-import { Application } from '../../application/application.model';
+import type { Application } from '../../application/application.model';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import { FunctionState } from '../../state';
-import { groupBy, Dictionary } from 'lodash';
-import { IFunction } from '@spinnaker/core';
+import type { Dictionary } from 'lodash';
+import { groupBy } from 'lodash';
+import type { IFunction } from '@spinnaker/core';
 // Most of this logic has been moved to filter.model.service.js, so these act more as integration tests
 describe('Service: functionFilterService', function () {
   const debounceTimeout = 30;

--- a/packages/core/src/function/filter/FunctionFilterService.spec.ts
+++ b/packages/core/src/function/filter/FunctionFilterService.spec.ts
@@ -3,7 +3,7 @@ import { ApplicationModelBuilder } from '../../application/applicationModel.buil
 import { FunctionState } from '../../state';
 import type { Dictionary } from 'lodash';
 import { groupBy } from 'lodash';
-import type { IFunction } from '@spinnaker/core';
+import type { IFunction } from '../../domain';
 // Most of this logic has been moved to filter.model.service.js, so these act more as integration tests
 describe('Service: functionFilterService', function () {
   const debounceTimeout = 30;

--- a/packages/core/src/function/function.read.service.spec.ts
+++ b/packages/core/src/function/function.read.service.spec.ts
@@ -1,8 +1,8 @@
 import { mockHttpClient } from '../api/mock/jasmine';
-import type { IFunctionSourceData } from '../index';
-import { FunctionReader } from '../index';
 import type { MockHttpClient } from '../api/mock/mockHttpClient';
 import type { IFunctionTransformer } from './function.transformer';
+import type { IFunctionSourceData } from '../index';
+import { FunctionReader } from '../index';
 
 function flush<T>(http: MockHttpClient, promise: PromiseLike<T>): Promise<T> {
   return http.flush().then(() => promise);

--- a/packages/core/src/function/function.read.service.spec.ts
+++ b/packages/core/src/function/function.read.service.spec.ts
@@ -1,7 +1,8 @@
 import { mockHttpClient } from '../api/mock/jasmine';
-import { FunctionReader, IFunctionSourceData } from '../index';
-import { MockHttpClient } from '../api/mock/mockHttpClient';
-import { IFunctionTransformer } from './function.transformer';
+import type { IFunctionSourceData } from '../index';
+import { FunctionReader } from '../index';
+import type { MockHttpClient } from '../api/mock/mockHttpClient';
+import type { IFunctionTransformer } from './function.transformer';
 
 function flush<T>(http: MockHttpClient, promise: PromiseLike<T>): Promise<T> {
   return http.flush().then(() => promise);

--- a/packages/core/src/header/customBanner/CustomBanner.spec.tsx
+++ b/packages/core/src/header/customBanner/CustomBanner.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { Application } from '../../application/application.model';
-import { ICustomBannerConfig } from '../../application/config/customBanner/CustomBannerConfig';
+import type { ICustomBannerConfig } from '../../application/config/customBanner/CustomBannerConfig';
 import { getTestBannerConfigs } from '../../application/config/customBanner/CustomBannerConfig.spec';
 
 import { CustomBanner } from './CustomBanner';

--- a/packages/core/src/header/customBanner/CustomBanner.spec.tsx
+++ b/packages/core/src/header/customBanner/CustomBanner.spec.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 
+import { CustomBanner } from './CustomBanner';
 import { Application } from '../../application/application.model';
 import type { ICustomBannerConfig } from '../../application/config/customBanner/CustomBannerConfig';
 import { getTestBannerConfigs } from '../../application/config/customBanner/CustomBannerConfig.spec';
-
-import { CustomBanner } from './CustomBanner';
 
 describe('<CustomBanner />', () => {
   let application: Application;

--- a/packages/core/src/healthCounts/HealthCounts.spec.tsx
+++ b/packages/core/src/healthCounts/HealthCounts.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { mount, shallow } from 'enzyme';
+import React from 'react';
 
 import { HealthCounts } from './HealthCounts';
 import type { IInstanceCounts } from '../domain';

--- a/packages/core/src/healthCounts/HealthCounts.spec.tsx
+++ b/packages/core/src/healthCounts/HealthCounts.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 
 import { HealthCounts } from './HealthCounts';
-import { IInstanceCounts } from '../domain';
+import type { IInstanceCounts } from '../domain';
 
 describe('<HealthCounts />', () => {
   it('displays nothing when container has no health info', () => {

--- a/packages/core/src/history/recentHistory.service.spec.ts
+++ b/packages/core/src/history/recentHistory.service.spec.ts
@@ -1,7 +1,8 @@
 import { range, some } from 'lodash';
 
 import { RecentHistoryService } from '../history/recentHistory.service';
-import { DeckCacheFactory, ICache } from '../cache/deckCacheFactory';
+import type { ICache } from '../cache/deckCacheFactory';
+import { DeckCacheFactory } from '../cache/deckCacheFactory';
 
 describe('recent history service', () => {
   let backingCache: ICache;

--- a/packages/core/src/history/recentHistory.service.spec.ts
+++ b/packages/core/src/history/recentHistory.service.spec.ts
@@ -1,8 +1,8 @@
 import { range, some } from 'lodash';
 
-import { RecentHistoryService } from '../history/recentHistory.service';
 import type { ICache } from '../cache/deckCacheFactory';
 import { DeckCacheFactory } from '../cache/deckCacheFactory';
+import { RecentHistoryService } from '../history/recentHistory.service';
 
 describe('recent history service', () => {
   let backingCache: ICache;

--- a/packages/core/src/insight/InsightMenu.spec.tsx
+++ b/packages/core/src/insight/InsightMenu.spec.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { mock } from 'angular';
-import { ReactWrapper, mount } from 'enzyme';
-import { IInsightMenuProps, IInsightMenuState, InsightMenu } from './InsightMenu';
-import { IModalService } from 'angular-ui-bootstrap';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
+import type { IInsightMenuProps, IInsightMenuState } from './InsightMenu';
+import { InsightMenu } from './InsightMenu';
+import type { IModalService } from 'angular-ui-bootstrap';
 import { OverrideRegistry } from '../overrideRegistry/override.registry';
-import { CacheInitializerService } from '../cache/cacheInitializer.service';
+import type { CacheInitializerService } from '../cache/cacheInitializer.service';
 import { Button } from 'react-bootstrap';
 
 beforeEach(() => {

--- a/packages/core/src/insight/InsightMenu.spec.tsx
+++ b/packages/core/src/insight/InsightMenu.spec.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
 import { mock } from 'angular';
+import type { IModalService } from 'angular-ui-bootstrap';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
+import React from 'react';
+import { Button } from 'react-bootstrap';
+
 import type { IInsightMenuProps, IInsightMenuState } from './InsightMenu';
 import { InsightMenu } from './InsightMenu';
-import type { IModalService } from 'angular-ui-bootstrap';
-import { OverrideRegistry } from '../overrideRegistry/override.registry';
 import type { CacheInitializerService } from '../cache/cacheInitializer.service';
-import { Button } from 'react-bootstrap';
+import { OverrideRegistry } from '../overrideRegistry/override.registry';
 
 beforeEach(() => {
   mock.module(($provide: any) => {

--- a/packages/core/src/instance/instance.write.service.spec.ts
+++ b/packages/core/src/instance/instance.write.service.spec.ts
@@ -1,15 +1,14 @@
 import { mock } from 'angular';
 
+import type { Application } from '../application/application.model';
+import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { PROVIDER_SERVICE_DELEGATE } from '../cloudProvider';
+import type { IInstance, IServerGroup } from '../domain';
 import type { IMultiInstanceGroup } from './instance.write.service';
 import { InstanceWriter } from './instance.write.service';
-import type { Application } from '../application/application.model';
 import { REACT_MODULE } from '../reactShims';
-import { ApplicationModelBuilder } from '../application/applicationModel.builder';
-import type { IInstance, IServerGroup } from '../domain';
-import * as State from '../state';
-
 import { ServerGroupReader } from '../serverGroup/serverGroupReader.service';
+import * as State from '../state';
 import type { IJob, ITaskCommand } from '../task/taskExecutor';
 import { TaskExecutor } from '../task/taskExecutor';
 

--- a/packages/core/src/instance/instance.write.service.spec.ts
+++ b/packages/core/src/instance/instance.write.service.spec.ts
@@ -1,15 +1,17 @@
 import { mock } from 'angular';
 
 import { PROVIDER_SERVICE_DELEGATE } from '../cloudProvider';
-import { IMultiInstanceGroup, InstanceWriter } from './instance.write.service';
-import { Application } from '../application/application.model';
+import type { IMultiInstanceGroup } from './instance.write.service';
+import { InstanceWriter } from './instance.write.service';
+import type { Application } from '../application/application.model';
 import { REACT_MODULE } from '../reactShims';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
-import { IInstance, IServerGroup } from '../domain';
+import type { IInstance, IServerGroup } from '../domain';
 import * as State from '../state';
 
 import { ServerGroupReader } from '../serverGroup/serverGroupReader.service';
-import { IJob, ITaskCommand, TaskExecutor } from '../task/taskExecutor';
+import type { IJob, ITaskCommand } from '../task/taskExecutor';
+import { TaskExecutor } from '../task/taskExecutor';
 
 describe('Service: instance writer', function () {
   let $q: ng.IQService;

--- a/packages/core/src/instance/instanceTypeService.spec.ts
+++ b/packages/core/src/instance/instanceTypeService.spec.ts
@@ -1,6 +1,7 @@
 import { mock } from 'angular';
 
-import { INSTANCE_TYPE_SERVICE, InstanceTypeService, IInstanceTypeCategory } from './instanceType.service';
+import type { InstanceTypeService, IInstanceTypeCategory } from './instanceType.service';
+import { INSTANCE_TYPE_SERVICE } from './instanceType.service';
 
 describe('Service: instanceTypeService', function () {
   let instanceTypeService: InstanceTypeService, $q: ng.IQService, $scope: ng.IScope;

--- a/packages/core/src/instance/instanceTypeService.spec.ts
+++ b/packages/core/src/instance/instanceTypeService.spec.ts
@@ -1,6 +1,6 @@
 import { mock } from 'angular';
 
-import type { InstanceTypeService, IInstanceTypeCategory } from './instanceType.service';
+import type { IInstanceTypeCategory, InstanceTypeService } from './instanceType.service';
 import { INSTANCE_TYPE_SERVICE } from './instanceType.service';
 
 describe('Service: instanceTypeService', function () {

--- a/packages/core/src/loadBalancer/LoadBalancersTag.spec.tsx
+++ b/packages/core/src/loadBalancer/LoadBalancersTag.spec.tsx
@@ -1,12 +1,14 @@
-import { mock, IQService, IScope } from 'angular';
+import type { IQService, IScope } from 'angular';
+import { mock } from 'angular';
 import React from 'react';
-import { ReactWrapper, mount } from 'enzyme';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 
-import { Application } from '../application/application.model';
+import type { Application } from '../application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
-import { ILoadBalancersTagProps } from './LoadBalancersTagWrapper';
+import type { ILoadBalancersTagProps } from './LoadBalancersTagWrapper';
 import { LoadBalancersTag } from './LoadBalancersTag';
-import { IServerGroup } from '../domain';
+import type { IServerGroup } from '../domain';
 import { HoverablePopover } from '../presentation';
 
 describe('<LoadBalancersTag />', () => {

--- a/packages/core/src/loadBalancer/LoadBalancersTag.spec.tsx
+++ b/packages/core/src/loadBalancer/LoadBalancersTag.spec.tsx
@@ -1,13 +1,13 @@
 import type { IQService, IScope } from 'angular';
 import { mock } from 'angular';
-import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
+import React from 'react';
 
+import { LoadBalancersTag } from './LoadBalancersTag';
+import type { ILoadBalancersTagProps } from './LoadBalancersTagWrapper';
 import type { Application } from '../application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
-import type { ILoadBalancersTagProps } from './LoadBalancersTagWrapper';
-import { LoadBalancersTag } from './LoadBalancersTag';
 import type { IServerGroup } from '../domain';
 import { HoverablePopover } from '../presentation';
 

--- a/packages/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
+++ b/packages/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
@@ -1,6 +1,6 @@
-import { Application } from '../../application/application.model';
+import type { Application } from '../../application/application.model';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import { ILoadBalancer, IServerGroup, ILoadBalancerGroup, IManagedResourceSummary } from '../../domain';
+import type { ILoadBalancer, IServerGroup, ILoadBalancerGroup, IManagedResourceSummary } from '../../domain';
 import { LoadBalancerState } from '../../state';
 
 // Most of this logic has been moved to filter.model.service.js, so these act more as integration tests

--- a/packages/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
+++ b/packages/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
@@ -1,6 +1,6 @@
 import type { Application } from '../../application/application.model';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import type { ILoadBalancer, IServerGroup, ILoadBalancerGroup, IManagedResourceSummary } from '../../domain';
+import type { ILoadBalancer, ILoadBalancerGroup, IManagedResourceSummary, IServerGroup } from '../../domain';
 import { LoadBalancerState } from '../../state';
 
 // Most of this logic has been moved to filter.model.service.js, so these act more as integration tests

--- a/packages/core/src/managed/constraints/AllowedTimes.spec.ts
+++ b/packages/core/src/managed/constraints/AllowedTimes.spec.ts
@@ -1,4 +1,5 @@
-import { groupConsecutiveNumbers, groupDays, groupHours, GroupRange } from './AllowedTimes';
+import type { GroupRange } from './AllowedTimes';
+import { groupConsecutiveNumbers, groupDays, groupHours } from './AllowedTimes';
 
 describe('days and hours grouping', () => {
   it('test grouping', () => {

--- a/packages/core/src/managed/overview/artifact/utils.spec.ts
+++ b/packages/core/src/managed/overview/artifact/utils.spec.ts
@@ -1,4 +1,4 @@
-import { QueryConstraint } from '../types';
+import type { QueryConstraint } from '../types';
 import { getConstraintsStatusSummary } from './utils';
 
 describe('Constraints status summary', () => {

--- a/packages/core/src/manifest/PodNameProvider.spec.ts
+++ b/packages/core/src/manifest/PodNameProvider.spec.ts
@@ -1,5 +1,5 @@
 import { DefaultPodNameProvider, JobEventBasedPodNameProvider } from './PodNameProvider';
-import { IManifest, IManifestEvent } from '../domain';
+import type { IManifest, IManifestEvent } from '../domain';
 
 describe('PodNameProvider', function () {
   describe('DefaultPodNameProvider', function () {

--- a/packages/core/src/navigation/customParamTypes.spec.ts
+++ b/packages/core/src/navigation/customParamTypes.spec.ts
@@ -1,4 +1,4 @@
-import { trueKeyObjectParamType, booleanParamType, inverseBooleanParamType, sortKeyParamType } from './state.provider';
+import { booleanParamType, inverseBooleanParamType, sortKeyParamType, trueKeyObjectParamType } from './state.provider';
 
 describe('custom param types', () => {
   describe('trueKeyObject', () => {

--- a/packages/core/src/pagerDuty/pagerDuty.read.service.spec.ts
+++ b/packages/core/src/pagerDuty/pagerDuty.read.service.spec.ts
@@ -1,5 +1,6 @@
-import { mockHttpClient } from '../api/mock/jasmine';
 import { mock } from 'angular';
+
+import { mockHttpClient } from '../api/mock/jasmine';
 import type { IPagerDutyService } from './pagerDuty.read.service';
 import { PagerDutyReader } from './pagerDuty.read.service';
 

--- a/packages/core/src/pagerDuty/pagerDuty.read.service.spec.ts
+++ b/packages/core/src/pagerDuty/pagerDuty.read.service.spec.ts
@@ -1,6 +1,7 @@
 import { mockHttpClient } from '../api/mock/jasmine';
 import { mock } from 'angular';
-import { IPagerDutyService, PagerDutyReader } from './pagerDuty.read.service';
+import type { IPagerDutyService } from './pagerDuty.read.service';
+import { PagerDutyReader } from './pagerDuty.read.service';
 
 describe('PagerDutyReader', () => {
   beforeEach(mock.module());

--- a/packages/core/src/pagerDuty/pagerDutyTag.component.spec.ts
+++ b/packages/core/src/pagerDuty/pagerDutyTag.component.spec.ts
@@ -1,7 +1,10 @@
 import { of as observableOf } from 'rxjs';
-import { IComponentControllerService, mock } from 'angular';
-import { IPagerDutyService, PagerDutyReader } from './pagerDuty.read.service';
-import { PAGER_DUTY_TAG_COMPONENT, PagerDutyTagComponentController } from './pagerDutyTag.component';
+import type { IComponentControllerService } from 'angular';
+import { mock } from 'angular';
+import type { IPagerDutyService } from './pagerDuty.read.service';
+import { PagerDutyReader } from './pagerDuty.read.service';
+import type { PagerDutyTagComponentController } from './pagerDutyTag.component';
+import { PAGER_DUTY_TAG_COMPONENT } from './pagerDutyTag.component';
 
 describe('PagerDutyTagComponent', () => {
   let $componentController: IComponentControllerService, $ctrl: PagerDutyTagComponentController;

--- a/packages/core/src/pagerDuty/pagerDutyTag.component.spec.ts
+++ b/packages/core/src/pagerDuty/pagerDutyTag.component.spec.ts
@@ -1,6 +1,7 @@
-import { of as observableOf } from 'rxjs';
 import type { IComponentControllerService } from 'angular';
 import { mock } from 'angular';
+import { of as observableOf } from 'rxjs';
+
 import type { IPagerDutyService } from './pagerDuty.read.service';
 import { PagerDutyReader } from './pagerDuty.read.service';
 import type { PagerDutyTagComponentController } from './pagerDutyTag.component';

--- a/packages/core/src/pipeline/config/PipelineRegistry.spec.ts
+++ b/packages/core/src/pipeline/config/PipelineRegistry.spec.ts
@@ -2,12 +2,12 @@ import { mock } from 'angular';
 import { map } from 'lodash';
 import React from 'react';
 
-import { SETTINGS } from '../../config';
-import type { IStage, ITriggerTypeConfig, IStageTypeConfig } from '../../domain';
-import type { IRegion } from '../../account/AccountService';
-import { Registry } from '../../registry';
-import type { ITriggerTemplateComponentProps } from '../manualExecution/TriggerTemplate';
 import { PipelineRegistry } from './PipelineRegistry';
+import type { IRegion } from '../../account/AccountService';
+import { SETTINGS } from '../../config';
+import type { IStage, IStageTypeConfig, ITriggerTypeConfig } from '../../domain';
+import { ITriggerTemplateComponentProps } from '../manualExecution/TriggerTemplate';
+import { Registry } from '../../registry';
 import type { IPreconfiguredJob } from './stages/preconfiguredJob';
 import { makePreconfiguredJobStage, PreconfiguredJobReader } from './stages/preconfiguredJob';
 

--- a/packages/core/src/pipeline/config/PipelineRegistry.spec.ts
+++ b/packages/core/src/pipeline/config/PipelineRegistry.spec.ts
@@ -113,33 +113,33 @@ describe('PipelineRegistry: API', function () {
       mock.inject(function () {
         const CompA = ({}: ITriggerTemplateComponentProps) => React.createElement('a');
         const baseStage = {
-            key: 'c',
-            useBaseProvider: true,
-            description: 'c description',
-            label: 'the c',
-            manualExecutionComponent: CompA,
-          },
-          augmentedA = {
-            key: 'd',
-            provides: 'c',
-            description: 'c description',
-            label: 'the c',
-            manualExecutionComponent: CompA,
-          } as any,
-          augmentedB = {
-            key: 'e',
-            provides: 'c',
-            description: 'c description',
-            label: 'the c',
-            manualExecutionComponent: CompA,
-          },
-          augmentedC = {
-            key: 'c',
-            provides: 'c',
-            description: 'c description',
-            label: 'the c',
-            manualExecutionComponent: CompA,
-          };
+          key: 'c',
+          useBaseProvider: true,
+          description: 'c description',
+          label: 'the c',
+          manualExecutionComponent: CompA,
+        };
+        const augmentedA = {
+          key: 'd',
+          provides: 'c',
+          description: 'c description',
+          label: 'the c',
+          manualExecutionComponent: CompA,
+        } as any;
+        const augmentedB = {
+          key: 'e',
+          provides: 'c',
+          description: 'c description',
+          label: 'the c',
+          manualExecutionComponent: CompA,
+        };
+        const augmentedC = {
+          key: 'c',
+          provides: 'c',
+          description: 'c description',
+          label: 'the c',
+          manualExecutionComponent: CompA,
+        };
         Registry.pipeline.registerStage(baseStage as IStageTypeConfig);
         Registry.pipeline.registerStage({ key: 'd', provides: 'c' } as IStageTypeConfig);
         Registry.pipeline.registerStage({ key: 'e', provides: 'c' } as IStageTypeConfig);

--- a/packages/core/src/pipeline/config/PipelineRegistry.spec.ts
+++ b/packages/core/src/pipeline/config/PipelineRegistry.spec.ts
@@ -111,7 +111,7 @@ describe('PipelineRegistry: API', function () {
     it(
       'augments provider stages with parent keys, labels, manualExecutionComponents, and descriptions',
       mock.inject(function () {
-        const CompA = ({}: ITriggerTemplateComponentProps) => React.createElement('a');
+        const CompA = () => React.createElement('a');
         const baseStage = {
           key: 'c',
           useBaseProvider: true,
@@ -153,8 +153,8 @@ describe('PipelineRegistry: API', function () {
     it(
       'allows provider stages to override of label, description, manualExecutionComponent',
       mock.inject(function () {
-        const CompA = ({}: ITriggerTemplateComponentProps) => React.createElement('a');
-        const CompB = ({}: ITriggerTemplateComponentProps) => React.createElement('b');
+        const CompA = () => React.createElement('a');
+        const CompB = () => React.createElement('b');
         Registry.pipeline.registerStage({
           key: 'a',
           useBaseProvider: true,
@@ -467,7 +467,7 @@ describe('PipelineRegistry: API', function () {
     });
 
     it('hasManualExecutionComponentForTriggerType returns true if declared and available', function () {
-      const CompA = ({}: ITriggerTemplateComponentProps) => React.createElement('a');
+      const CompA = () => React.createElement('a');
       Registry.pipeline.registerTrigger({ key: 'cron', manualExecutionComponent: CompA } as ITriggerTypeConfig);
       expect(Registry.pipeline.hasManualExecutionComponentForTriggerType('cron')).toBe(true);
     });
@@ -479,7 +479,7 @@ describe('PipelineRegistry: API', function () {
     });
 
     it('hasManualExecutionComponentForTriggerType returns handler if declared and available', function () {
-      const CompA = ({}: ITriggerTemplateComponentProps) => React.createElement('a');
+      const CompA = () => React.createElement('a');
       Registry.pipeline.registerTrigger({ key: 'cron', manualExecutionComponent: CompA } as ITriggerTypeConfig);
       expect(Registry.pipeline.getManualExecutionComponentForTriggerType('cron')).toEqual(CompA);
     });

--- a/packages/core/src/pipeline/config/PipelineRegistry.spec.ts
+++ b/packages/core/src/pipeline/config/PipelineRegistry.spec.ts
@@ -3,12 +3,13 @@ import { map } from 'lodash';
 import React from 'react';
 
 import { SETTINGS } from '../../config';
-import { IStage, ITriggerTypeConfig, IStageTypeConfig } from '../../domain';
-import { IRegion } from '../../account/AccountService';
+import type { IStage, ITriggerTypeConfig, IStageTypeConfig } from '../../domain';
+import type { IRegion } from '../../account/AccountService';
 import { Registry } from '../../registry';
-import { ITriggerTemplateComponentProps } from '../manualExecution/TriggerTemplate';
+import type { ITriggerTemplateComponentProps } from '../manualExecution/TriggerTemplate';
 import { PipelineRegistry } from './PipelineRegistry';
-import { IPreconfiguredJob, makePreconfiguredJobStage, PreconfiguredJobReader } from './stages/preconfiguredJob';
+import type { IPreconfiguredJob } from './stages/preconfiguredJob';
+import { makePreconfiguredJobStage, PreconfiguredJobReader } from './stages/preconfiguredJob';
 
 const mockProviderAccount = {
   accountId: 'abc',

--- a/packages/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.spec.tsx
+++ b/packages/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.spec.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
+import { ShowPipelineTemplateJsonModal } from './ShowPipelineTemplateJsonModal';
 import type { IPipeline, IPipelineTemplateV2 } from '../../../../domain';
 import { PipelineTemplateV2Service } from '../../templates/v2/pipelineTemplateV2.service';
-import { ShowPipelineTemplateJsonModal } from './ShowPipelineTemplateJsonModal';
 
 describe('<ShowPipelineTemplateJsonModal />', () => {
   const mockPipeline: Partial<IPipeline> = {

--- a/packages/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.spec.tsx
+++ b/packages/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { IPipeline, IPipelineTemplateV2 } from '../../../../domain';
+import type { IPipeline, IPipelineTemplateV2 } from '../../../../domain';
 import { PipelineTemplateV2Service } from '../../templates/v2/pipelineTemplateV2.service';
 import { ShowPipelineTemplateJsonModal } from './ShowPipelineTemplateJsonModal';
 

--- a/packages/core/src/pipeline/config/pipelineConfigurer.controller.spec.ts
+++ b/packages/core/src/pipeline/config/pipelineConfigurer.controller.spec.ts
@@ -1,8 +1,8 @@
-import { IController, IControllerService, IQService, IRootScopeService, IScope, IWindowService } from 'angular';
+import type { IController, IControllerService, IQService, IRootScopeService, IScope, IWindowService } from 'angular';
 
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import { PipelineConfigService } from './services/PipelineConfigService';
-import {
+import type {
   IDockerTrigger,
   IGitTrigger,
   INotification,

--- a/packages/core/src/pipeline/config/pipelineConfigurer.controller.spec.ts
+++ b/packages/core/src/pipeline/config/pipelineConfigurer.controller.spec.ts
@@ -1,7 +1,6 @@
 import type { IController, IControllerService, IQService, IRootScopeService, IScope, IWindowService } from 'angular';
 
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import { PipelineConfigService } from './services/PipelineConfigService';
 import type {
   IDockerTrigger,
   IGitTrigger,
@@ -10,6 +9,7 @@ import type {
   IPipelineTemplateConfigV2,
   IPipelineTemplatePlanV2,
 } from '../../domain';
+import { PipelineConfigService } from './services/PipelineConfigService';
 
 const githubTrigger: IGitTrigger = {
   branch: 'master',

--- a/packages/core/src/pipeline/config/services/PipelineConfigService.spec.ts
+++ b/packages/core/src/pipeline/config/services/PipelineConfigService.spec.ts
@@ -1,8 +1,9 @@
-import { mockHttpClient } from '../../../api/mock/jasmine';
 import { mock } from 'angular';
-import type { IStage } from '../../../domain/IStage';
-import type { IPipeline } from '../../../domain/IPipeline';
+
 import { PipelineConfigService } from './PipelineConfigService';
+import { mockHttpClient } from '../../../api/mock/jasmine';
+import type { IPipeline } from '../../../domain/IPipeline';
+import type { IStage } from '../../../domain/IStage';
 
 describe('PipelineConfigService', () => {
   let $scope: ng.IScope;

--- a/packages/core/src/pipeline/config/services/PipelineConfigService.spec.ts
+++ b/packages/core/src/pipeline/config/services/PipelineConfigService.spec.ts
@@ -1,7 +1,7 @@
 import { mockHttpClient } from '../../../api/mock/jasmine';
 import { mock } from 'angular';
-import { IStage } from '../../../domain/IStage';
-import { IPipeline } from '../../../domain/IPipeline';
+import type { IStage } from '../../../domain/IStage';
+import type { IPipeline } from '../../../domain/IPipeline';
 import { PipelineConfigService } from './PipelineConfigService';
 
 describe('PipelineConfigService', () => {

--- a/packages/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.spec.tsx
+++ b/packages/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.spec.tsx
@@ -1,16 +1,14 @@
-import React from 'react';
-import { mount } from 'enzyme';
-import type { IStage } from '../../../../../domain';
-import { REACT_MODULE } from '../../../../../reactShims';
 import { mock } from 'angular';
-
-import { ApplicationModelBuilder } from '../../../../../application';
-
-import { AccountService } from '../../../../../account';
+import { mount } from 'enzyme';
+import React from 'react';
 
 import { StageConfigField } from '../../../..';
 import { BakeHelmConfigForm } from './BakeHelmConfigForm';
+import { AccountService } from '../../../../../account';
+import { ApplicationModelBuilder } from '../../../../../application';
+import type { IStage } from '../../../../../domain';
 import { SpinFormik } from '../../../../../presentation';
+import { REACT_MODULE } from '../../../../../reactShims';
 
 describe('<BakeHelmConfigForm />', () => {
   beforeEach(mock.module(REACT_MODULE));

--- a/packages/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.spec.tsx
+++ b/packages/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { IStage } from '../../../../../domain';
+import type { IStage } from '../../../../../domain';
 import { REACT_MODULE } from '../../../../../reactShims';
 import { mock } from 'angular';
 

--- a/packages/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.spec.ts
@@ -1,6 +1,7 @@
 'use strict';
 
-import { IScope, mock } from 'angular';
+import type { IScope } from 'angular';
+import { mock } from 'angular';
 import { FindArtifactFromExecutionCtrl } from './findArtifactFromExecution.controller';
 
 describe('Find Artifact From Execution Controller:', function () {

--- a/packages/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
+++ b/packages/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
@@ -1,8 +1,8 @@
-import { mockHttpClient } from '../../../../api/mock/jasmine';
-import { tick } from '../../../../api/mock/mockHttpUtils';
 import type { IDeferred, IQService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
+import { mockHttpClient } from '../../../../api/mock/jasmine';
+import { tick } from '../../../../api/mock/mockHttpUtils';
 import type { ManualJudgmentService } from './manualJudgment.service';
 import { MANUAL_JUDGMENT_SERVICE } from './manualJudgment.service';
 import type { ExecutionService } from '../../../service/execution.service';

--- a/packages/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
+++ b/packages/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
@@ -1,9 +1,11 @@
 import { mockHttpClient } from '../../../../api/mock/jasmine';
 import { tick } from '../../../../api/mock/mockHttpUtils';
-import { IDeferred, IQService, IRootScopeService, IScope, mock } from 'angular';
+import type { IDeferred, IQService, IRootScopeService, IScope } from 'angular';
+import { mock } from 'angular';
 
-import { MANUAL_JUDGMENT_SERVICE, ManualJudgmentService } from './manualJudgment.service';
-import { ExecutionService } from '../../../service/execution.service';
+import type { ManualJudgmentService } from './manualJudgment.service';
+import { MANUAL_JUDGMENT_SERVICE } from './manualJudgment.service';
+import type { ExecutionService } from '../../../service/execution.service';
 
 describe('Service: manualJudgment', () => {
   let $scope: IScope, service: ManualJudgmentService, $q: IQService, executionService: ExecutionService;

--- a/packages/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.spec.ts
@@ -1,4 +1,5 @@
-import { IScope, IControllerService, IRootScopeService, mock } from 'angular';
+import type { IScope, IControllerService, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
 import { TRAVIS_EXECUTION_DETAILS_CONTROLLER, TravisExecutionDetailsCtrl } from './travisExecutionDetails.controller';
 

--- a/packages/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.spec.ts
@@ -18,7 +18,9 @@ describe('Travis Execution Details Controller:', () => {
     $scope.stage = stage;
     return $ctrl(TravisExecutionDetailsCtrl, {
       $scope,
-      executionDetailsSectionService: { synchronizeSection: ({}, fn: () => any) => fn() },
+      executionDetailsSectionService: {
+        synchronizeSection: (_availableSections: string[], fn: () => any) => fn(),
+      },
     });
   };
 

--- a/packages/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.spec.ts
@@ -1,4 +1,4 @@
-import type { IScope, IControllerService, IRootScopeService } from 'angular';
+import type { IControllerService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
 import { TRAVIS_EXECUTION_DETAILS_CONTROLLER, TravisExecutionDetailsCtrl } from './travisExecutionDetails.controller';

--- a/packages/core/src/pipeline/config/stages/travis/travisStage.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/travis/travisStage.controller.spec.ts
@@ -1,5 +1,5 @@
 import Spy = jasmine.Spy;
-import type { IScope, IQService, IControllerService, IRootScopeService } from 'angular';
+import type { IControllerService, IQService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
 import { IgorService } from '../../../../ci/igor.service';

--- a/packages/core/src/pipeline/config/stages/travis/travisStage.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/travis/travisStage.controller.spec.ts
@@ -1,8 +1,9 @@
 import Spy = jasmine.Spy;
-import { mock, IScope, IQService, IControllerService, IRootScopeService } from 'angular';
+import type { IScope, IQService, IControllerService, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
 import { IgorService } from '../../../../ci/igor.service';
-import { IJobConfig, IParameterDefinitionList } from '../../../../domain';
+import type { IJobConfig, IParameterDefinitionList } from '../../../../domain';
 import { TRAVIS_STAGE, TravisStage } from './travisStage';
 
 describe('Travis Stage Controller', () => {

--- a/packages/core/src/pipeline/config/stages/unmatchedStageTypeStage/unmatchedStageTypeStage.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/unmatchedStageTypeStage/unmatchedStageTypeStage.controller.spec.ts
@@ -1,6 +1,7 @@
 import { mock } from 'angular';
 
-import { UNMATCHED_STAGE_TYPE_STAGE_CTRL, UnmatchedStageTypeStageCtrl } from './unmatchedStageTypeStage.controller';
+import type { UnmatchedStageTypeStageCtrl } from './unmatchedStageTypeStage.controller';
+import { UNMATCHED_STAGE_TYPE_STAGE_CTRL } from './unmatchedStageTypeStage.controller';
 
 describe('Controller: UnmatchedStageTypeStageCtrl', () => {
   let ctrl: UnmatchedStageTypeStageCtrl;

--- a/packages/core/src/pipeline/config/stages/wercker/werckerExecutionDetails.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/wercker/werckerExecutionDetails.controller.spec.ts
@@ -21,7 +21,9 @@ describe('Wercker Execution Details Controller:', () => {
     $scope.stage = stage;
     return $ctrl(WerckerExecutionDetailsCtrl, {
       $scope,
-      executionDetailsSectionService: { synchronizeSection: ({}, fn: () => any) => fn() },
+      executionDetailsSectionService: {
+        synchronizeSection: (_availableSections: string[], fn: () => any) => fn(),
+      },
     });
   };
 

--- a/packages/core/src/pipeline/config/stages/wercker/werckerExecutionDetails.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/wercker/werckerExecutionDetails.controller.spec.ts
@@ -1,4 +1,5 @@
-import { IScope, IControllerService, IRootScopeService, mock } from 'angular';
+import type { IScope, IControllerService, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
 import {
   WERCKER_EXECUTION_DETAILS_CONTROLLER,

--- a/packages/core/src/pipeline/config/stages/wercker/werckerExecutionDetails.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/wercker/werckerExecutionDetails.controller.spec.ts
@@ -1,4 +1,4 @@
-import type { IScope, IControllerService, IRootScopeService } from 'angular';
+import type { IControllerService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
 import {

--- a/packages/core/src/pipeline/config/stages/wercker/werckerStage.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/wercker/werckerStage.controller.spec.ts
@@ -1,5 +1,5 @@
 import Spy = jasmine.Spy;
-import type { IScope, IQService, IControllerService, IRootScopeService } from 'angular';
+import type { IControllerService, IQService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
 import { IgorService } from '../../../../ci/igor.service';

--- a/packages/core/src/pipeline/config/stages/wercker/werckerStage.controller.spec.ts
+++ b/packages/core/src/pipeline/config/stages/wercker/werckerStage.controller.spec.ts
@@ -1,8 +1,9 @@
 import Spy = jasmine.Spy;
-import { mock, IScope, IQService, IControllerService, IRootScopeService } from 'angular';
+import type { IScope, IQService, IControllerService, IRootScopeService } from 'angular';
+import { mock } from 'angular';
 
 import { IgorService } from '../../../../ci/igor.service';
-import { IJobConfig, IParameterDefinitionList } from '../../../../domain';
+import type { IJobConfig, IParameterDefinitionList } from '../../../../domain';
 import { WERCKER_STAGE, WerckerStage } from './werckerStage';
 
 describe('Wercker Stage Controller', () => {

--- a/packages/core/src/pipeline/config/templates/Variable.spec.tsx
+++ b/packages/core/src/pipeline/config/templates/Variable.spec.tsx
@@ -1,12 +1,13 @@
 import { mock } from 'angular';
 import React from 'react';
-import { mount, ReactWrapper } from 'enzyme';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { REACT_MODULE } from '../../../reactShims/react.module';
 import { PIPELINE_TEMPLATE_MODULE } from './pipelineTemplate.module';
 import { Variable } from './Variable';
-import { IVariableError, IVariableProps } from './inputs/variableInput.service';
-import { VariableType } from './PipelineTemplateReader';
+import type { IVariableError, IVariableProps } from './inputs/variableInput.service';
+import type { VariableType } from './PipelineTemplateReader';
 
 describe('Variable component', () => {
   const generateProps = (type: VariableType, value: any) => {

--- a/packages/core/src/pipeline/config/templates/Variable.spec.tsx
+++ b/packages/core/src/pipeline/config/templates/Variable.spec.tsx
@@ -1,13 +1,13 @@
 import { mock } from 'angular';
-import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
+import React from 'react';
 
-import { REACT_MODULE } from '../../../reactShims/react.module';
-import { PIPELINE_TEMPLATE_MODULE } from './pipelineTemplate.module';
+import type { VariableType } from './PipelineTemplateReader';
 import { Variable } from './Variable';
 import type { IVariableError, IVariableProps } from './inputs/variableInput.service';
-import type { VariableType } from './PipelineTemplateReader';
+import { PIPELINE_TEMPLATE_MODULE } from './pipelineTemplate.module';
+import { REACT_MODULE } from '../../../reactShims/react.module';
 
 describe('Variable component', () => {
   const generateProps = (type: VariableType, value: any) => {

--- a/packages/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.spec.ts
+++ b/packages/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.spec.ts
@@ -1,12 +1,11 @@
-import { mock, IScope, IQService } from 'angular';
+import type { IScope, IQService } from 'angular';
+import { mock } from 'angular';
 
-import {
-  CONFIGURE_PIPELINE_TEMPLATE_MODAL_CTRL,
-  ConfigurePipelineTemplateModalController,
-} from './configurePipelineTemplateModal.controller';
-import { IVariable } from './inputs/variableInput.service';
+import type { ConfigurePipelineTemplateModalController } from './configurePipelineTemplateModal.controller';
+import { CONFIGURE_PIPELINE_TEMPLATE_MODAL_CTRL } from './configurePipelineTemplateModal.controller';
+import type { IVariable } from './inputs/variableInput.service';
 import { ApplicationModelBuilder } from '../../../application/applicationModel.builder';
-import { Application } from '../../../application/application.model';
+import type { Application } from '../../../application/application.model';
 import { PIPELINE_TEMPLATE_MODULE } from './pipelineTemplate.module';
 import { PipelineTemplateReader } from './PipelineTemplateReader';
 

--- a/packages/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.spec.ts
+++ b/packages/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.spec.ts
@@ -1,13 +1,13 @@
-import type { IScope, IQService } from 'angular';
+import type { IQService, IScope } from 'angular';
 import { mock } from 'angular';
 
+import { PipelineTemplateReader } from './PipelineTemplateReader';
+import type { Application } from '../../../application/application.model';
+import { ApplicationModelBuilder } from '../../../application/applicationModel.builder';
 import type { ConfigurePipelineTemplateModalController } from './configurePipelineTemplateModal.controller';
 import { CONFIGURE_PIPELINE_TEMPLATE_MODAL_CTRL } from './configurePipelineTemplateModal.controller';
 import type { IVariable } from './inputs/variableInput.service';
-import { ApplicationModelBuilder } from '../../../application/applicationModel.builder';
-import type { Application } from '../../../application/application.model';
 import { PIPELINE_TEMPLATE_MODULE } from './pipelineTemplate.module';
-import { PipelineTemplateReader } from './PipelineTemplateReader';
 
 describe('Controller: ConfigurePipelineTemplateModalCtrl', () => {
   let ctrl: ConfigurePipelineTemplateModalController, $scope: IScope, $q: IQService, application: Application;

--- a/packages/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.spec.ts
+++ b/packages/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.spec.ts
@@ -1,12 +1,11 @@
-import { mock, IScope, IQService } from 'angular';
+import type { IScope, IQService } from 'angular';
+import { mock } from 'angular';
 
-import {
-  CONFIGURE_PIPELINE_TEMPLATE_MODAL_V2_CTRL,
-  ConfigurePipelineTemplateModalV2Controller,
-} from './configurePipelineTemplateModalV2.controller';
-import { IVariable } from '../inputs/variableInput.service';
+import type { ConfigurePipelineTemplateModalV2Controller } from './configurePipelineTemplateModalV2.controller';
+import { CONFIGURE_PIPELINE_TEMPLATE_MODAL_V2_CTRL } from './configurePipelineTemplateModalV2.controller';
+import type { IVariable } from '../inputs/variableInput.service';
 import { ApplicationModelBuilder } from '../../../../application/applicationModel.builder';
-import { Application } from '../../../../application/application.model';
+import type { Application } from '../../../../application/application.model';
 import { PIPELINE_TEMPLATE_MODULE } from '../pipelineTemplate.module';
 import { PipelineTemplateReader } from '../PipelineTemplateReader';
 

--- a/packages/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.spec.ts
+++ b/packages/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.spec.ts
@@ -1,13 +1,13 @@
-import type { IScope, IQService } from 'angular';
+import type { IQService, IScope } from 'angular';
 import { mock } from 'angular';
 
+import { PipelineTemplateReader } from '../PipelineTemplateReader';
+import type { Application } from '../../../../application/application.model';
+import { ApplicationModelBuilder } from '../../../../application/applicationModel.builder';
 import type { ConfigurePipelineTemplateModalV2Controller } from './configurePipelineTemplateModalV2.controller';
 import { CONFIGURE_PIPELINE_TEMPLATE_MODAL_V2_CTRL } from './configurePipelineTemplateModalV2.controller';
 import type { IVariable } from '../inputs/variableInput.service';
-import { ApplicationModelBuilder } from '../../../../application/applicationModel.builder';
-import type { Application } from '../../../../application/application.model';
 import { PIPELINE_TEMPLATE_MODULE } from '../pipelineTemplate.module';
-import { PipelineTemplateReader } from '../PipelineTemplateReader';
 
 describe('Controller: ConfigurePipelineTemplateModalV2Ctrl', () => {
   let ctrl: ConfigurePipelineTemplateModalV2Controller, $scope: IScope, $q: IQService, application: Application;

--- a/packages/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.spec.ts
+++ b/packages/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.spec.ts
@@ -1,6 +1,6 @@
 import { hri as HumanReadableIds } from 'human-readable-ids';
 
-import { IPipeline, IPipelineTemplateV2 } from '../../../../domain';
+import type { IPipeline, IPipelineTemplateV2 } from '../../../../domain';
 import { PipelineTemplateV2Service } from './pipelineTemplateV2.service';
 import { UUIDGenerator } from '../../../../utils';
 

--- a/packages/core/src/pipeline/config/triggers/TriggersPageContent.spec.tsx
+++ b/packages/core/src/pipeline/config/triggers/TriggersPageContent.spec.tsx
@@ -3,10 +3,11 @@ import { mount } from 'enzyme';
 
 import { ApplicationModelBuilder } from '../../../application';
 import { ArtifactReferenceService } from '../../../artifact/ArtifactReferenceService';
-import { IExpectedArtifact, ITrigger } from '../../../domain';
+import type { IExpectedArtifact, ITrigger } from '../../../domain';
 import { Registry } from '../../../registry';
 
-import { ITriggersPageContentProps, TriggersPageContent } from './TriggersPageContent';
+import type { ITriggersPageContentProps } from './TriggersPageContent';
+import { TriggersPageContent } from './TriggersPageContent';
 
 describe('<TriggersPageContent />', () => {
   let removeReferencesFromStagesSpy: jasmine.Spy;

--- a/packages/core/src/pipeline/config/triggers/TriggersPageContent.spec.tsx
+++ b/packages/core/src/pipeline/config/triggers/TriggersPageContent.spec.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
+import type { ITriggersPageContentProps } from './TriggersPageContent';
+import { TriggersPageContent } from './TriggersPageContent';
 import { ApplicationModelBuilder } from '../../../application';
 import { ArtifactReferenceService } from '../../../artifact/ArtifactReferenceService';
 import type { IExpectedArtifact, ITrigger } from '../../../domain';
 import { Registry } from '../../../registry';
-
-import type { ITriggersPageContentProps } from './TriggersPageContent';
-import { TriggersPageContent } from './TriggersPageContent';
 
 describe('<TriggersPageContent />', () => {
   let removeReferencesFromStagesSpy: jasmine.Spy;

--- a/packages/core/src/pipeline/config/triggers/artifacts/docker/defaultDocker.artifact.spec.ts
+++ b/packages/core/src/pipeline/config/triggers/artifacts/docker/defaultDocker.artifact.spec.ts
@@ -1,4 +1,4 @@
-import { IArtifact } from '../../../../../domain';
+import type { IArtifact } from '../../../../../domain';
 
 import { setNameAndVersionFromReference } from './DockerArtifactEditor';
 

--- a/packages/core/src/pipeline/config/triggers/artifacts/docker/defaultDocker.artifact.spec.ts
+++ b/packages/core/src/pipeline/config/triggers/artifacts/docker/defaultDocker.artifact.spec.ts
@@ -1,6 +1,5 @@
-import type { IArtifact } from '../../../../../domain';
-
 import { setNameAndVersionFromReference } from './DockerArtifactEditor';
+import type { IArtifact } from '../../../../../domain';
 
 describe('defaultDocker.artifact', () => {
   it('parses Docker image references correctly', () => {

--- a/packages/core/src/pipeline/config/validation/pipelineConfig.validator.spec.ts
+++ b/packages/core/src/pipeline/config/validation/pipelineConfig.validator.spec.ts
@@ -2,22 +2,21 @@ import { mock } from 'angular';
 import Spy = jasmine.Spy;
 import { SETTINGS } from '../../../config/settings';
 
-import { IPipeline, IStage, IStageTypeConfig } from '../../../domain';
+import type { IPipeline, IStage, IStageTypeConfig } from '../../../domain';
 import { ServiceAccountReader } from '../../../serviceAccount/ServiceAccountReader';
 import { PipelineConfigService } from '../services/PipelineConfigService';
 import { Registry } from '../../../registry';
 
-import {
-  ICustomValidator,
-  IPipelineValidationResults,
-  IValidatorConfig,
-  PipelineConfigValidator,
-} from './PipelineConfigValidator';
-import { IRequiredFieldValidationConfig } from './requiredField.validator';
-import { IServiceAccountAccessValidationConfig, ITriggerWithServiceAccount } from './serviceAccountAccess.validator';
-import { IStageBeforeTypeValidationConfig } from './stageBeforeType.validator';
-import { IStageOrTriggerBeforeTypeValidationConfig } from './stageOrTriggerBeforeType.validator';
-import { ITargetImpedanceValidationConfig } from './targetImpedance.validator';
+import type { ICustomValidator, IPipelineValidationResults, IValidatorConfig } from './PipelineConfigValidator';
+import { PipelineConfigValidator } from './PipelineConfigValidator';
+import type { IRequiredFieldValidationConfig } from './requiredField.validator';
+import type {
+  IServiceAccountAccessValidationConfig,
+  ITriggerWithServiceAccount,
+} from './serviceAccountAccess.validator';
+import type { IStageBeforeTypeValidationConfig } from './stageBeforeType.validator';
+import type { IStageOrTriggerBeforeTypeValidationConfig } from './stageOrTriggerBeforeType.validator';
+import type { ITargetImpedanceValidationConfig } from './targetImpedance.validator';
 
 describe('pipelineConfigValidator', () => {
   let pipeline: IPipeline, validate: () => void, validationResults: IPipelineValidationResults, $q: ng.IQService;

--- a/packages/core/src/pipeline/config/validation/pipelineConfig.validator.spec.ts
+++ b/packages/core/src/pipeline/config/validation/pipelineConfig.validator.spec.ts
@@ -1,22 +1,22 @@
 import { mock } from 'angular';
-import Spy = jasmine.Spy;
-import { SETTINGS } from '../../../config/settings';
-
-import type { IPipeline, IStage, IStageTypeConfig } from '../../../domain';
-import { ServiceAccountReader } from '../../../serviceAccount/ServiceAccountReader';
-import { PipelineConfigService } from '../services/PipelineConfigService';
-import { Registry } from '../../../registry';
 
 import type { ICustomValidator, IPipelineValidationResults, IValidatorConfig } from './PipelineConfigValidator';
 import { PipelineConfigValidator } from './PipelineConfigValidator';
+import { SETTINGS } from '../../../config/settings';
+import type { IPipeline, IStage, IStageTypeConfig } from '../../../domain';
+import { Registry } from '../../../registry';
 import type { IRequiredFieldValidationConfig } from './requiredField.validator';
+import { ServiceAccountReader } from '../../../serviceAccount/ServiceAccountReader';
 import type {
   IServiceAccountAccessValidationConfig,
   ITriggerWithServiceAccount,
 } from './serviceAccountAccess.validator';
+import { PipelineConfigService } from '../services/PipelineConfigService';
 import type { IStageBeforeTypeValidationConfig } from './stageBeforeType.validator';
 import type { IStageOrTriggerBeforeTypeValidationConfig } from './stageOrTriggerBeforeType.validator';
 import type { ITargetImpedanceValidationConfig } from './targetImpedance.validator';
+
+import Spy = jasmine.Spy;
 
 describe('pipelineConfigValidator', () => {
   let pipeline: IPipeline, validate: () => void, validationResults: IPipelineValidationResults, $q: ng.IQService;

--- a/packages/core/src/pipeline/create/CreatePipelineModal.spec.tsx
+++ b/packages/core/src/pipeline/create/CreatePipelineModal.spec.tsx
@@ -1,16 +1,16 @@
 import type { IQService, IScope } from 'angular';
 import { mock } from 'angular';
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 
 import type { ICreatePipelineModalProps } from './CreatePipelineModal';
 import { CreatePipelineModal } from './CreatePipelineModal';
-import { PipelineTemplateReader } from '../config/templates/PipelineTemplateReader';
 import type { Application } from '../../application/application.model';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import type { IPipeline } from '../../domain';
-import { SETTINGS } from '../../config/settings';
 import { PipelineConfigService } from '../config/services/PipelineConfigService';
+import { SETTINGS } from '../../config/settings';
+import { PipelineTemplateReader } from '../config/templates/PipelineTemplateReader';
+import type { IPipeline } from '../../domain';
 
 // Disable CreatePipelineModal tests until enzyme supports React 16 https://github.com/airbnb/enzyme/issues/1553
 // CreatePipelineModal uses Overridable() which uses React.forwardRef

--- a/packages/core/src/pipeline/create/CreatePipelineModal.spec.tsx
+++ b/packages/core/src/pipeline/create/CreatePipelineModal.spec.tsx
@@ -1,12 +1,14 @@
-import { mock, IQService, IScope } from 'angular';
+import type { IQService, IScope } from 'angular';
+import { mock } from 'angular';
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { CreatePipelineModal, ICreatePipelineModalProps } from './CreatePipelineModal';
+import type { ICreatePipelineModalProps } from './CreatePipelineModal';
+import { CreatePipelineModal } from './CreatePipelineModal';
 import { PipelineTemplateReader } from '../config/templates/PipelineTemplateReader';
-import { Application } from '../../application/application.model';
+import type { Application } from '../../application/application.model';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import { IPipeline } from '../../domain';
+import type { IPipeline } from '../../domain';
 import { SETTINGS } from '../../config/settings';
 import { PipelineConfigService } from '../config/services/PipelineConfigService';
 

--- a/packages/core/src/pipeline/details/executionDetailsSection.service.spec.ts
+++ b/packages/core/src/pipeline/details/executionDetailsSection.service.spec.ts
@@ -1,7 +1,8 @@
 import { mock, noop } from 'angular';
-import { StateParams, StateService } from '@uirouter/angularjs';
+import type { StateParams, StateService } from '@uirouter/angularjs';
 
-import { EXECUTION_DETAILS_SECTION_SERVICE, ExecutionDetailsSectionService } from './executionDetailsSection.service';
+import type { ExecutionDetailsSectionService } from './executionDetailsSection.service';
+import { EXECUTION_DETAILS_SECTION_SERVICE } from './executionDetailsSection.service';
 
 describe('executionDetailsSectionService', function () {
   let $state: StateService,

--- a/packages/core/src/pipeline/details/executionDetailsSection.service.spec.ts
+++ b/packages/core/src/pipeline/details/executionDetailsSection.service.spec.ts
@@ -1,5 +1,5 @@
-import { mock, noop } from 'angular';
 import type { StateParams, StateService } from '@uirouter/angularjs';
+import { mock, noop } from 'angular';
 
 import type { ExecutionDetailsSectionService } from './executionDetailsSection.service';
 import { EXECUTION_DETAILS_SECTION_SERVICE } from './executionDetailsSection.service';

--- a/packages/core/src/pipeline/executions/Executions.spec.tsx
+++ b/packages/core/src/pipeline/executions/Executions.spec.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
-import { ReactWrapper, mount } from 'enzyme';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 import { set } from 'lodash';
-import { IScope, mock, noop } from 'angular';
+import type { IScope } from 'angular';
+import { mock, noop } from 'angular';
 
-import { Application } from '../../application';
+import type { Application } from '../../application';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import { INSIGHT_FILTER_STATE_MODEL } from '../../insight/insightFilterState.model';
 import { REACT_MODULE } from '../../reactShims';
 import { OVERRIDE_REGISTRY } from '../../overrideRegistry';
 import * as State from '../../state';
-import { IExecutionsProps, IExecutionsState, Executions } from './Executions';
+import type { IExecutionsProps, IExecutionsState } from './Executions';
+import { Executions } from './Executions';
 import { Spinner } from '../../widgets/spinners/Spinner';
 
 describe('<Executions/>', () => {

--- a/packages/core/src/pipeline/executions/Executions.spec.tsx
+++ b/packages/core/src/pipeline/executions/Executions.spec.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
+import type { IScope } from 'angular';
+import { mock, noop } from 'angular';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 import { set } from 'lodash';
-import type { IScope } from 'angular';
-import { mock, noop } from 'angular';
+import React from 'react';
 
+import type { IExecutionsProps, IExecutionsState } from './Executions';
+import { Executions } from './Executions';
 import type { Application } from '../../application';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import { INSIGHT_FILTER_STATE_MODEL } from '../../insight/insightFilterState.model';
-import { REACT_MODULE } from '../../reactShims';
 import { OVERRIDE_REGISTRY } from '../../overrideRegistry';
+import { REACT_MODULE } from '../../reactShims';
 import * as State from '../../state';
-import type { IExecutionsProps, IExecutionsState } from './Executions';
-import { Executions } from './Executions';
 import { Spinner } from '../../widgets/spinners/Spinner';
 
 describe('<Executions/>', () => {

--- a/packages/core/src/pipeline/executions/executionAction/ExecutionAction.spec.tsx
+++ b/packages/core/src/pipeline/executions/executionAction/ExecutionAction.spec.tsx
@@ -1,5 +1,5 @@
+import { mount, shallow } from 'enzyme';
 import React from 'react';
-import { shallow, mount } from 'enzyme';
 
 import { ExecutionAction } from './ExecutionAction';
 

--- a/packages/core/src/pipeline/filter/executionFilter.service.spec.ts
+++ b/packages/core/src/pipeline/filter/executionFilter.service.spec.ts
@@ -1,5 +1,5 @@
 import { ExecutionFilterService } from './executionFilter.service';
-import { ExecutionFilterModel } from './ExecutionFilterModel';
+import type { ExecutionFilterModel } from './ExecutionFilterModel';
 import { ExecutionState } from '../../state';
 
 describe('ExecutionFilterService', function () {

--- a/packages/core/src/pipeline/filter/executionFilter.service.spec.ts
+++ b/packages/core/src/pipeline/filter/executionFilter.service.spec.ts
@@ -1,5 +1,5 @@
-import { ExecutionFilterService } from './executionFilter.service';
 import type { ExecutionFilterModel } from './ExecutionFilterModel';
+import { ExecutionFilterService } from './executionFilter.service';
 import { ExecutionState } from '../../state';
 
 describe('ExecutionFilterService', function () {

--- a/packages/core/src/pipeline/pipeline.dataSource.spec.ts
+++ b/packages/core/src/pipeline/pipeline.dataSource.spec.ts
@@ -1,6 +1,7 @@
-import { IQProvider, mock } from 'angular';
+import type { IQProvider } from 'angular';
+import { mock } from 'angular';
 
-import { Application } from '../application/application.model';
+import type { Application } from '../application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { EXECUTION_SERVICE } from './service/execution.service';

--- a/packages/core/src/pipeline/pipeline.dataSource.spec.ts
+++ b/packages/core/src/pipeline/pipeline.dataSource.spec.ts
@@ -93,8 +93,8 @@ describe('Pipeline Data Source', function () {
 
     it('sets appropriate flags when executions reload fails; subscriber is responsible for error checking', function () {
       spyOn(executionService, 'getExecutions').and.returnValue($q.reject(null));
-      let errorsHandled = 0,
-        successesHandled = 0;
+      let errorsHandled = 0;
+      let successesHandled = 0;
       configureApplication();
       application.getDataSource('executions').activate();
 
@@ -141,8 +141,8 @@ describe('Pipeline Data Source', function () {
     it('sets appropriate flags when pipeline config reload fails; subscriber is responsible for error checking', function () {
       spyOn(PipelineConfigService, 'getPipelinesForApplication').and.returnValue($q.when([]));
       spyOn(PipelineConfigService, 'getStrategiesForApplication').and.returnValue($q.reject([]));
-      let errorsHandled = 0,
-        successesHandled = 0;
+      let errorsHandled = 0;
+      let successesHandled = 0;
       configureApplication();
       application.getDataSource('pipelineConfigs').activate();
 

--- a/packages/core/src/pipeline/pipeline.dataSource.spec.ts
+++ b/packages/core/src/pipeline/pipeline.dataSource.spec.ts
@@ -4,8 +4,8 @@ import { mock } from 'angular';
 import type { Application } from '../application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
-import { EXECUTION_SERVICE } from './service/execution.service';
 import { PipelineConfigService } from './config/services/PipelineConfigService';
+import { EXECUTION_SERVICE } from './service/execution.service';
 
 describe('Pipeline Data Source', function () {
   let application: Application, executionService: any, $scope: ng.IScope, $q: ng.IQService;

--- a/packages/core/src/pipeline/service/ExecutionsTransformer.spec.ts
+++ b/packages/core/src/pipeline/service/ExecutionsTransformer.spec.ts
@@ -1,7 +1,7 @@
 import { map } from 'lodash';
 
-import type { Application } from '../../application';
 import { ExecutionsTransformer } from './ExecutionsTransformer';
+import type { Application } from '../../application';
 import type { IExecution } from '../../domain';
 
 describe('ExecutionTransformerService', function () {

--- a/packages/core/src/pipeline/service/ExecutionsTransformer.spec.ts
+++ b/packages/core/src/pipeline/service/ExecutionsTransformer.spec.ts
@@ -1,8 +1,8 @@
 import { map } from 'lodash';
 
-import { Application } from '../../application';
+import type { Application } from '../../application';
 import { ExecutionsTransformer } from './ExecutionsTransformer';
-import { IExecution } from '../../domain';
+import type { IExecution } from '../../domain';
 
 describe('ExecutionTransformerService', function () {
   describe('transformExecution', () => {

--- a/packages/core/src/pipeline/service/execution.service.spec.ts
+++ b/packages/core/src/pipeline/service/execution.service.spec.ts
@@ -1,10 +1,12 @@
 import { mockHttpClient } from '../../api/mock/jasmine';
-import { IQProvider, IQService, ITimeoutService, mock, noop } from 'angular';
+import type { IQProvider, IQService, ITimeoutService } from 'angular';
+import { mock, noop } from 'angular';
 import { REACT_MODULE } from '../../reactShims';
 
-import { EXECUTION_SERVICE, ExecutionService } from './execution.service';
-import { IExecution } from '../../domain';
-import { Application } from '../../application';
+import type { ExecutionService } from './execution.service';
+import { EXECUTION_SERVICE } from './execution.service';
+import type { IExecution } from '../../domain';
+import type { Application } from '../../application';
 import * as State from '../../state';
 
 describe('Service: executionService', () => {

--- a/packages/core/src/pipeline/service/execution.service.spec.ts
+++ b/packages/core/src/pipeline/service/execution.service.spec.ts
@@ -1,12 +1,12 @@
-import { mockHttpClient } from '../../api/mock/jasmine';
 import type { IQProvider, IQService, ITimeoutService } from 'angular';
 import { mock, noop } from 'angular';
-import { REACT_MODULE } from '../../reactShims';
 
+import { mockHttpClient } from '../../api/mock/jasmine';
+import type { Application } from '../../application';
+import type { IExecution } from '../../domain';
 import type { ExecutionService } from './execution.service';
 import { EXECUTION_SERVICE } from './execution.service';
-import type { IExecution } from '../../domain';
-import type { Application } from '../../application';
+import { REACT_MODULE } from '../../reactShims';
 import * as State from '../../state';
 
 describe('Service: executionService', () => {

--- a/packages/core/src/pipeline/status/Artifact.spec.tsx
+++ b/packages/core/src/pipeline/status/Artifact.spec.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { ShallowWrapper, shallow } from 'enzyme';
+import type { ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import { mock } from 'angular';
 import { REACT_MODULE } from '../../reactShims';
 
-import { IArtifact } from '../../domain';
+import type { IArtifact } from '../../domain';
 
-import { Artifact, IArtifactProps } from './Artifact';
+import type { IArtifactProps } from './Artifact';
+import { Artifact } from './Artifact';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';

--- a/packages/core/src/pipeline/status/Artifact.spec.tsx
+++ b/packages/core/src/pipeline/status/Artifact.spec.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import { mock } from 'angular';
 import type { ShallowWrapper } from 'enzyme';
 import { shallow } from 'enzyme';
-import { mock } from 'angular';
-import { REACT_MODULE } from '../../reactShims';
-
-import type { IArtifact } from '../../domain';
+import React from 'react';
 
 import type { IArtifactProps } from './Artifact';
 import { Artifact } from './Artifact';
+import type { IArtifact } from '../../domain';
+import { REACT_MODULE } from '../../reactShims';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';

--- a/packages/core/src/pipeline/status/ArtifactList.spec.tsx
+++ b/packages/core/src/pipeline/status/ArtifactList.spec.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
+import { mock } from 'angular';
 import type { ShallowWrapper } from 'enzyme';
 import { shallow } from 'enzyme';
-import { mock } from 'angular';
-import { REACT_MODULE } from '../../reactShims';
-
-import type { IArtifact } from '../../domain';
+import React from 'react';
 
 import { Artifact } from './Artifact';
 import type { IArtifactListProps } from './ArtifactList';
 import { ArtifactList } from './ArtifactList';
+import type { IArtifact } from '../../domain';
+import { REACT_MODULE } from '../../reactShims';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';

--- a/packages/core/src/pipeline/status/ArtifactList.spec.tsx
+++ b/packages/core/src/pipeline/status/ArtifactList.spec.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { ShallowWrapper, shallow } from 'enzyme';
+import type { ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import { mock } from 'angular';
 import { REACT_MODULE } from '../../reactShims';
 
-import { IArtifact } from '../../domain';
+import type { IArtifact } from '../../domain';
 
 import { Artifact } from './Artifact';
-import { ArtifactList, IArtifactListProps } from './ArtifactList';
+import type { IArtifactListProps } from './ArtifactList';
+import { ArtifactList } from './ArtifactList';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';

--- a/packages/core/src/pipeline/status/ExecutionParameters.spec.tsx
+++ b/packages/core/src/pipeline/status/ExecutionParameters.spec.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
+import { mock } from 'angular';
 import type { ShallowWrapper } from 'enzyme';
 import { shallow } from 'enzyme';
-import { mock } from 'angular';
+import React from 'react';
 
-import { REACT_MODULE } from '../../reactShims';
-
-import type { IExecutionParametersProps, IDisplayableParameter } from './ExecutionParameters';
+import type { IDisplayableParameter, IExecutionParametersProps } from './ExecutionParameters';
 import { ExecutionParameters } from './ExecutionParameters';
+import { REACT_MODULE } from '../../reactShims';
 
 describe('<ExecutionParameters/>', () => {
   let component: ShallowWrapper<IExecutionParametersProps>;

--- a/packages/core/src/pipeline/status/ExecutionParameters.spec.tsx
+++ b/packages/core/src/pipeline/status/ExecutionParameters.spec.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { ShallowWrapper, shallow } from 'enzyme';
+import type { ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import { mock } from 'angular';
 
 import { REACT_MODULE } from '../../reactShims';
 
-import { IExecutionParametersProps, ExecutionParameters, IDisplayableParameter } from './ExecutionParameters';
+import type { IExecutionParametersProps, IDisplayableParameter } from './ExecutionParameters';
+import { ExecutionParameters } from './ExecutionParameters';
 
 describe('<ExecutionParameters/>', () => {
   let component: ShallowWrapper<IExecutionParametersProps>;

--- a/packages/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
+++ b/packages/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { ShallowWrapper, shallow } from 'enzyme';
+import type { ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import { mock } from 'angular';
 import { REACT_MODULE } from '../../reactShims';
 
-import { IArtifact, IExpectedArtifact } from '../../domain';
+import type { IArtifact, IExpectedArtifact } from '../../domain';
 import { Artifact } from './Artifact';
 
-import { ResolvedArtifactList, IResolvedArtifactListProps } from './ResolvedArtifactList';
+import type { IResolvedArtifactListProps } from './ResolvedArtifactList';
+import { ResolvedArtifactList } from './ResolvedArtifactList';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';

--- a/packages/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
+++ b/packages/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
+import { mock } from 'angular';
 import type { ShallowWrapper } from 'enzyme';
 import { shallow } from 'enzyme';
-import { mock } from 'angular';
-import { REACT_MODULE } from '../../reactShims';
+import React from 'react';
 
-import type { IArtifact, IExpectedArtifact } from '../../domain';
 import { Artifact } from './Artifact';
-
 import type { IResolvedArtifactListProps } from './ResolvedArtifactList';
 import { ResolvedArtifactList } from './ResolvedArtifactList';
+import type { IArtifact, IExpectedArtifact } from '../../domain';
+import { REACT_MODULE } from '../../reactShims';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';

--- a/packages/core/src/plugins/deck.plugin.spec.ts
+++ b/packages/core/src/plugins/deck.plugin.spec.ts
@@ -1,9 +1,9 @@
-import type { SearchResultType } from '../search/searchResult';
-import { searchResultTypeRegistry } from '../search/searchResult';
 import type { IDeckPlugin } from './deck.plugin';
 import { registerPluginExtensions } from './deck.plugin';
 import { HelpContentsRegistry } from '../help';
 import { Registry } from '../registry';
+import type { SearchResultType } from '../search/searchResult';
+import { searchResultTypeRegistry } from '../search/searchResult';
 
 describe('deck plugin registerPluginExtensions', () => {
   it('returns a promise', async () => {

--- a/packages/core/src/plugins/deck.plugin.spec.ts
+++ b/packages/core/src/plugins/deck.plugin.spec.ts
@@ -1,5 +1,7 @@
-import { SearchResultType, searchResultTypeRegistry } from '../search/searchResult';
-import { IDeckPlugin, registerPluginExtensions } from './deck.plugin';
+import type { SearchResultType } from '../search/searchResult';
+import { searchResultTypeRegistry } from '../search/searchResult';
+import type { IDeckPlugin } from './deck.plugin';
+import { registerPluginExtensions } from './deck.plugin';
 import { HelpContentsRegistry } from '../help';
 import { Registry } from '../registry';
 

--- a/packages/core/src/plugins/plugin.registry.spec.ts
+++ b/packages/core/src/plugins/plugin.registry.spec.ts
@@ -1,7 +1,8 @@
-import { IStageTypeConfig } from '../domain';
-import { IDeckPlugin } from './deck.plugin';
+import type { IStageTypeConfig } from '../domain';
+import type { IDeckPlugin } from './deck.plugin';
 import { RequestBuilder } from '../api';
-import { IPluginMetaData, PluginRegistry } from './plugin.registry';
+import type { IPluginMetaData } from './plugin.registry';
+import { PluginRegistry } from './plugin.registry';
 import { Registry } from '../registry';
 import { mock } from 'angular';
 

--- a/packages/core/src/plugins/plugin.registry.spec.ts
+++ b/packages/core/src/plugins/plugin.registry.spec.ts
@@ -1,10 +1,11 @@
-import type { IStageTypeConfig } from '../domain';
-import type { IDeckPlugin } from './deck.plugin';
+import { mock } from 'angular';
+
 import { RequestBuilder } from '../api';
+import type { IDeckPlugin } from './deck.plugin';
+import type { IStageTypeConfig } from '../domain';
 import type { IPluginMetaData } from './plugin.registry';
 import { PluginRegistry } from './plugin.registry';
 import { Registry } from '../registry';
-import { mock } from 'angular';
 
 const fakePromise = (result: any = undefined) => () => new Promise((resolve) => resolve(result));
 

--- a/packages/core/src/presentation/forms/SpinFormik.spec.tsx
+++ b/packages/core/src/presentation/forms/SpinFormik.spec.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
 import { mount } from 'enzyme';
 import type { FormikProps } from 'formik';
+import React from 'react';
+
 import { SpinFormik } from './SpinFormik';
 
 describe('SpinFormik', () => {

--- a/packages/core/src/presentation/forms/SpinFormik.spec.tsx
+++ b/packages/core/src/presentation/forms/SpinFormik.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { FormikProps } from 'formik';
+import type { FormikProps } from 'formik';
 import { SpinFormik } from './SpinFormik';
 
 describe('SpinFormik', () => {

--- a/packages/core/src/presentation/forms/fields/FormikFormField.spec.tsx
+++ b/packages/core/src/presentation/forms/fields/FormikFormField.spec.tsx
@@ -1,6 +1,6 @@
+import { mount } from 'enzyme';
 import type { FormikProps } from 'formik/dist/types';
 import React from 'react';
-import { mount } from 'enzyme';
 
 import type { IFormInputProps } from '../..';
 import {

--- a/packages/core/src/presentation/forms/fields/FormikFormField.spec.tsx
+++ b/packages/core/src/presentation/forms/fields/FormikFormField.spec.tsx
@@ -1,11 +1,11 @@
-import { FormikProps } from 'formik/dist/types';
+import type { FormikProps } from 'formik/dist/types';
 import React from 'react';
 import { mount } from 'enzyme';
 
+import type { IFormInputProps } from '../..';
 import {
   FormikFormField,
   FormikSpelContextProvider,
-  IFormInputProps,
   ReactSelectInput,
   SpelToggle,
   SpinFormik,

--- a/packages/core/src/presentation/forms/hooks/useSaveRestoreMutuallyExclusiveFields.hook.spec.tsx
+++ b/packages/core/src/presentation/forms/hooks/useSaveRestoreMutuallyExclusiveFields.hook.spec.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 import { useSaveRestoreMutuallyExclusiveFields } from './useSaveRestoreMutuallyExclusiveFields.hook';
-import { Formik, FormikProps } from 'formik';
+import type { Formik, FormikProps } from 'formik';
 import React from 'react';
 import { FormikFormField } from '../fields';
 import { SelectInput } from '../inputs';

--- a/packages/core/src/presentation/forms/hooks/useSaveRestoreMutuallyExclusiveFields.hook.spec.tsx
+++ b/packages/core/src/presentation/forms/hooks/useSaveRestoreMutuallyExclusiveFields.hook.spec.tsx
@@ -1,10 +1,11 @@
 import { mount } from 'enzyme';
-import { useSaveRestoreMutuallyExclusiveFields } from './useSaveRestoreMutuallyExclusiveFields.hook';
 import type { Formik, FormikProps } from 'formik';
 import React from 'react';
+
+import { SpinFormik } from '../SpinFormik';
 import { FormikFormField } from '../fields';
 import { SelectInput } from '../inputs';
-import { SpinFormik } from '../SpinFormik';
+import { useSaveRestoreMutuallyExclusiveFields } from './useSaveRestoreMutuallyExclusiveFields.hook';
 
 function PizzaComponent() {
   return (

--- a/packages/core/src/presentation/forms/inputs/ChecklistInput.spec.tsx
+++ b/packages/core/src/presentation/forms/inputs/ChecklistInput.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
 import { ChecklistInput } from './ChecklistInput';
 

--- a/packages/core/src/presentation/forms/inputs/RadioButtonInput.spec.tsx
+++ b/packages/core/src/presentation/forms/inputs/RadioButtonInput.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import { RadioButtonInput } from './RadioButtonInput';
 
 const noop = () => {};

--- a/packages/core/src/presentation/forms/inputs/SelectInput.spec.tsx
+++ b/packages/core/src/presentation/forms/inputs/SelectInput.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import { SelectInput } from './SelectInput';
 
 const noop = () => {};

--- a/packages/core/src/presentation/forms/inputs/hooks/useInternalValidator.hook.spec.tsx
+++ b/packages/core/src/presentation/forms/inputs/hooks/useInternalValidator.hook.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { IValidator } from '../../../forms/validation';
-import { IFormInputProps, IFormInputValidation } from '../interface';
+import type { IValidator } from '../../../forms/validation';
+import type { IFormInputProps, IFormInputValidation } from '../interface';
 import { useInternalValidator } from './useInternalValidator.hook';
 
 function TestInputComponent(props: IFormInputProps & { validator?: IValidator; revalidateDeps?: any[] }) {

--- a/packages/core/src/presentation/forms/inputs/hooks/useInternalValidator.hook.spec.tsx
+++ b/packages/core/src/presentation/forms/inputs/hooks/useInternalValidator.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import type { IValidator } from '../../../forms/validation';
 import type { IFormInputProps, IFormInputValidation } from '../interface';
 import { useInternalValidator } from './useInternalValidator.hook';

--- a/packages/core/src/presentation/forms/validation/FormValidator.spec.ts
+++ b/packages/core/src/presentation/forms/validation/FormValidator.spec.ts
@@ -1,6 +1,6 @@
 import { Validators } from './validators';
 import { FormValidator } from './FormValidator';
-import { IValidator, IArrayItemValidator } from './validation';
+import type { IValidator, IArrayItemValidator } from './validation';
 
 const { maxValue, arrayNotEmpty } = Validators;
 

--- a/packages/core/src/presentation/forms/validation/FormValidator.spec.ts
+++ b/packages/core/src/presentation/forms/validation/FormValidator.spec.ts
@@ -1,6 +1,6 @@
-import { Validators } from './validators';
 import { FormValidator } from './FormValidator';
-import type { IValidator, IArrayItemValidator } from './validation';
+import type { IArrayItemValidator, IValidator } from './validation';
+import { Validators } from './validators';
 
 const { maxValue, arrayNotEmpty } = Validators;
 

--- a/packages/core/src/presentation/forms/validation/useValidationData.spec.tsx
+++ b/packages/core/src/presentation/forms/validation/useValidationData.spec.tsx
@@ -2,7 +2,8 @@ import { asyncMessage, errorMessage, infoMessage, messageMessage, successMessage
 import React from 'react';
 
 import { mount } from 'enzyme';
-import { IValidationData, useValidationData } from './useValidationData';
+import type { IValidationData } from './useValidationData';
+import { useValidationData } from './useValidationData';
 
 interface IComponentProps {
   validationMessage: React.ReactNode;

--- a/packages/core/src/presentation/forms/validation/useValidationData.spec.tsx
+++ b/packages/core/src/presentation/forms/validation/useValidationData.spec.tsx
@@ -1,7 +1,7 @@
-import { asyncMessage, errorMessage, infoMessage, messageMessage, successMessage, warningMessage } from './categories';
+import { mount } from 'enzyme';
 import React from 'react';
 
-import { mount } from 'enzyme';
+import { asyncMessage, errorMessage, infoMessage, messageMessage, successMessage, warningMessage } from './categories';
 import type { IValidationData } from './useValidationData';
 import { useValidationData } from './useValidationData';
 

--- a/packages/core/src/presentation/hooks/useContainerClassNames.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useContainerClassNames.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import { useContainerClassNames } from './useContainerClassNames.hook';
 
 const TestComponent = ({ classNames }: { classNames: string[] }) => {

--- a/packages/core/src/presentation/hooks/useData.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useData.hook.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { IUseLatestPromiseResult } from './useLatestPromise.hook';
+import type { IUseLatestPromiseResult } from './useLatestPromise.hook';
 import { useData } from './useData.hook';
 
 describe('useData hook', () => {

--- a/packages/core/src/presentation/hooks/useData.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useData.hook.spec.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
 import { mount } from 'enzyme';
-import type { IUseLatestPromiseResult } from './useLatestPromise.hook';
+import React from 'react';
+
 import { useData } from './useData.hook';
+import type { IUseLatestPromiseResult } from './useLatestPromise.hook';
 
 describe('useData hook', () => {
   function TestComponent(props: any) {

--- a/packages/core/src/presentation/hooks/useDebouncedValue.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useDebouncedValue.hook.spec.tsx
@@ -1,7 +1,7 @@
+import { mount } from 'enzyme';
 import React from 'react';
 
 import { useDebouncedValue } from './useDebouncedValue.hook';
-import { mount } from 'enzyme';
 
 describe('useDebouncedValue hook', () => {
   beforeEach(() => jasmine.clock().install());

--- a/packages/core/src/presentation/hooks/useDeepObjectDiff.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useDeepObjectDiff.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import { useDeepObjectDiff } from './useDeepObjectDiff.hook';
 
 const { useEffect } = React;

--- a/packages/core/src/presentation/hooks/useEventListener.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useEventListener.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import { useEventListener } from './useEventListener.hook';
 
 const TestComponent = ({

--- a/packages/core/src/presentation/hooks/useForceUpdate.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useForceUpdate.hook.spec.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 import { Subject } from 'rxjs';
+
 import { useForceUpdate } from '..';
 
 describe('useForceUpdate', () => {

--- a/packages/core/src/presentation/hooks/useInterval.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useInterval.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import { useInterval } from './useInterval.hook';
 
 describe('useInterval hook', () => {

--- a/packages/core/src/presentation/hooks/useIsMountedRef.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useIsMountedRef.hook.spec.tsx
@@ -1,7 +1,7 @@
+import { mount } from 'enzyme';
 import React from 'react';
 
 import { useIsMountedRef } from '..';
-import { mount } from 'enzyme';
 
 describe('useIsMountedRef hook', () => {
   let useIsMountedRefSpy: jasmine.Spy;

--- a/packages/core/src/presentation/hooks/useLatestCallback.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useLatestCallback.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import { useLatestCallback } from './useLatestCallback.hook';
 
 const TestComponent = ({

--- a/packages/core/src/presentation/hooks/useLatestPromise.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useLatestPromise.hook.spec.tsx
@@ -68,9 +68,13 @@ describe('useLatestPromise hook', () => {
     expect(spy).toHaveBeenCalledTimes(2);
 
     deferred.reject('error');
+    let caught = false;
     try {
       await deferred.promise;
-    } catch (error) {}
+    } catch (error) {
+      caught = true;
+    }
+    expect(caught).toBe(true);
     component.setProps({});
 
     expect(spy).toHaveBeenCalledTimes(3);

--- a/packages/core/src/presentation/hooks/useLatestPromise.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useLatestPromise.hook.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { IUseLatestPromiseResult, useLatestPromise } from './useLatestPromise.hook';
+import type { IUseLatestPromiseResult } from './useLatestPromise.hook';
+import { useLatestPromise } from './useLatestPromise.hook';
 
 describe('useLatestPromise hook', () => {
   // Remove the the refresh function for .isEqual assertions

--- a/packages/core/src/presentation/hooks/useLatestPromise.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useLatestPromise.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import type { IUseLatestPromiseResult } from './useLatestPromise.hook';
 import { useLatestPromise } from './useLatestPromise.hook';
 

--- a/packages/core/src/presentation/hooks/useMountStatusRef.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useMountStatusRef.hook.spec.tsx
@@ -1,4 +1,5 @@
-import React, { RefObject } from 'react';
+import type { RefObject } from 'react';
+import React from 'react';
 import { mount } from 'enzyme';
 import { useMountStatusRef } from './useMountStatusRef.hook';
 

--- a/packages/core/src/presentation/hooks/useMountStatusRef.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/useMountStatusRef.hook.spec.tsx
@@ -1,6 +1,7 @@
+import { mount } from 'enzyme';
 import type { RefObject } from 'react';
 import React from 'react';
-import { mount } from 'enzyme';
+
 import { useMountStatusRef } from './useMountStatusRef.hook';
 
 describe('useMountStatusRef', () => {

--- a/packages/core/src/presentation/hooks/usePollingData.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/usePollingData.hook.spec.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { mount } from 'enzyme';
-import { IUseLatestPromiseResult } from './useLatestPromise.hook';
+import type { IUseLatestPromiseResult } from './useLatestPromise.hook';
 import { usePollingData } from './usePollingData.hook';
 
 describe('usePollingData hook', () => {

--- a/packages/core/src/presentation/hooks/usePollingData.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/usePollingData.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react';
 import { mount } from 'enzyme';
+import React, { useEffect } from 'react';
+
 import type { IUseLatestPromiseResult } from './useLatestPromise.hook';
 import { usePollingData } from './usePollingData.hook';
 

--- a/packages/core/src/presentation/hooks/usePrevious.hook.spec.tsx
+++ b/packages/core/src/presentation/hooks/usePrevious.hook.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import { usePrevious } from './usePrevious.hook';
 
 const TestComponent = ({ value, valueCallback }: { value: any; valueCallback: (value: any) => any }) => {

--- a/packages/core/src/presentation/navigation/pageNavigator.component.spec.ts
+++ b/packages/core/src/presentation/navigation/pageNavigator.component.spec.ts
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import { mock } from 'angular';
 
 import { PAGE_NAVIGATOR_COMPONENT } from './pageNavigator.component';
-import { INavigationPage } from './PageNavigationState';
+import type { INavigationPage } from './PageNavigationState';
 import { ScrollToService } from '../../utils/scrollTo/scrollTo.service';
 import UI_ROUTER from '@uirouter/angularjs';
 

--- a/packages/core/src/presentation/navigation/pageNavigator.component.spec.ts
+++ b/packages/core/src/presentation/navigation/pageNavigator.component.spec.ts
@@ -1,10 +1,10 @@
-import $ from 'jquery';
-import { mock } from 'angular';
-
-import { PAGE_NAVIGATOR_COMPONENT } from './pageNavigator.component';
-import type { INavigationPage } from './PageNavigationState';
-import { ScrollToService } from '../../utils/scrollTo/scrollTo.service';
 import UI_ROUTER from '@uirouter/angularjs';
+import { mock } from 'angular';
+import $ from 'jquery';
+
+import type { INavigationPage } from './PageNavigationState';
+import { PAGE_NAVIGATOR_COMPONENT } from './pageNavigator.component';
+import { ScrollToService } from '../../utils/scrollTo/scrollTo.service';
 
 describe('Component: Page Navigator', () => {
   let $compile: ng.ICompileService, $scope: ng.IScope, $timeout: ng.ITimeoutService, elem: JQuery;

--- a/packages/core/src/presentation/spel/SpelInput.spec.tsx
+++ b/packages/core/src/presentation/spel/SpelInput.spec.tsx
@@ -208,10 +208,14 @@ describe('<SpelInput/>', () => {
       expect(mockValidate).toHaveBeenCalledTimes(1);
       expect(mockValidate.calls.mostRecent().returnValue).toMatch('Async: ');
 
+      let caught = false;
       deferred.reject('something bad happened');
       try {
         await deferred.promise;
-      } catch (error) {}
+      } catch (error) {
+        caught = true;
+      }
+      expect(caught).toBe(true);
       component.setProps({});
 
       expect(mockValidate).toHaveBeenCalledTimes(2);

--- a/packages/core/src/presentation/spel/SpelInput.spec.tsx
+++ b/packages/core/src/presentation/spel/SpelInput.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { IFormInputProps, IStageForSpelPreview, IValidator } from '..';
+import type { IFormInputProps, IStageForSpelPreview, IValidator } from '..';
 import { SpelService } from './SpelService';
 import { SpelInput } from './SpelInput';
 

--- a/packages/core/src/presentation/spel/SpelInput.spec.tsx
+++ b/packages/core/src/presentation/spel/SpelInput.spec.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
+
 import type { IFormInputProps, IStageForSpelPreview, IValidator } from '..';
-import { SpelService } from './SpelService';
 import { SpelInput } from './SpelInput';
+import { SpelService } from './SpelService';
 
 function defer() {
   let resolve: Function, reject: Function;

--- a/packages/core/src/presentation/spel/SpelService.spec.ts
+++ b/packages/core/src/presentation/spel/SpelService.spec.ts
@@ -1,5 +1,5 @@
-import { RequestBuilder } from '../../api';
 import { SpelService } from './SpelService';
+import { RequestBuilder } from '../../api';
 
 describe('SpelService', () => {
   it('extracts "result" from the payload', async () => {

--- a/packages/core/src/scheduler/SchedulerFactory.spec.ts
+++ b/packages/core/src/scheduler/SchedulerFactory.spec.ts
@@ -1,5 +1,6 @@
 import * as angular from 'angular';
-import { ITimeoutService, mock } from 'angular';
+import type { ITimeoutService } from 'angular';
+import { mock } from 'angular';
 import { SchedulerFactory } from './SchedulerFactory';
 
 describe('scheduler', function () {

--- a/packages/core/src/search/widgets/Filter.spec.tsx
+++ b/packages/core/src/search/widgets/Filter.spec.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
+import React from 'react';
 
 import type { IFilterProps } from './Filter';
 import { Filter } from './Filter';

--- a/packages/core/src/search/widgets/Filter.spec.tsx
+++ b/packages/core/src/search/widgets/Filter.spec.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { ReactWrapper, mount } from 'enzyme';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 
-import { IFilterProps, Filter } from './Filter';
-import { IFilterType } from './SearchFilterTypeRegistry';
+import type { IFilterProps } from './Filter';
+import { Filter } from './Filter';
+import type { IFilterType } from './SearchFilterTypeRegistry';
 
 describe('<Filter/>', () => {
   let component: ReactWrapper<IFilterProps, any>;

--- a/packages/core/src/search/widgets/Filters.spec.tsx
+++ b/packages/core/src/search/widgets/Filters.spec.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
+import React from 'react';
 
-import type { IFilterType } from './SearchFilterTypeRegistry';
 import type { IFiltersLayout, IFiltersProps } from './Filters';
 import { Filters } from './Filters';
+import type { IFilterType } from './SearchFilterTypeRegistry';
 
 describe('<Filters/>', () => {
   let component: ReactWrapper<IFiltersProps, any>;

--- a/packages/core/src/search/widgets/Filters.spec.tsx
+++ b/packages/core/src/search/widgets/Filters.spec.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { ReactWrapper, mount } from 'enzyme';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 
-import { IFilterType } from './SearchFilterTypeRegistry';
-import { IFiltersLayout, IFiltersProps, Filters } from './Filters';
+import type { IFilterType } from './SearchFilterTypeRegistry';
+import type { IFiltersLayout, IFiltersProps } from './Filters';
+import { Filters } from './Filters';
 
 describe('<Filters/>', () => {
   let component: ReactWrapper<IFiltersProps, any>;

--- a/packages/core/src/search/widgets/Search.spec.tsx
+++ b/packages/core/src/search/widgets/Search.spec.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
+import React from 'react';
 
-import { SearchFilterTypeRegistry } from './SearchFilterTypeRegistry';
 import type { ISearchProps } from './Search';
 import { Search } from './Search';
+import { SearchFilterTypeRegistry } from './SearchFilterTypeRegistry';
 
 describe('<Search/>', () => {
   SearchFilterTypeRegistry.register({ key: 'account', name: 'Account' });

--- a/packages/core/src/search/widgets/Search.spec.tsx
+++ b/packages/core/src/search/widgets/Search.spec.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { ReactWrapper, mount } from 'enzyme';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { SearchFilterTypeRegistry } from './SearchFilterTypeRegistry';
-import { ISearchProps, Search } from './Search';
+import type { ISearchProps } from './Search';
+import { Search } from './Search';
 
 describe('<Search/>', () => {
   SearchFilterTypeRegistry.register({ key: 'account', name: 'Account' });

--- a/packages/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/packages/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -1,14 +1,14 @@
-import { mockHttpClient } from '../api/mock/jasmine';
 import { mock } from 'angular';
 
+import { mockHttpClient } from '../api/mock/jasmine';
 import type { Application } from '../application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { InfrastructureCaches } from '../cache';
 import type { ISecurityGroup } from '../domain';
 import type {
   ISecurityGroupDetail,
-  SecurityGroupReader,
   ISecurityGroupsByAccountSourceData,
+  SecurityGroupReader,
 } from './securityGroupReader.service';
 import { SECURITY_GROUP_READER } from './securityGroupReader.service';
 import type { SecurityGroupTransformerService } from './securityGroupTransformer.service';

--- a/packages/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/packages/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -1,20 +1,18 @@
 import { mockHttpClient } from '../api/mock/jasmine';
 import { mock } from 'angular';
 
-import { Application } from '../application/application.model';
+import type { Application } from '../application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { InfrastructureCaches } from '../cache';
-import { ISecurityGroup } from '../domain';
-import {
+import type { ISecurityGroup } from '../domain';
+import type {
   ISecurityGroupDetail,
-  SECURITY_GROUP_READER,
   SecurityGroupReader,
   ISecurityGroupsByAccountSourceData,
 } from './securityGroupReader.service';
-import {
-  SECURITY_GROUP_TRANSFORMER_SERVICE,
-  SecurityGroupTransformerService,
-} from './securityGroupTransformer.service';
+import { SECURITY_GROUP_READER } from './securityGroupReader.service';
+import type { SecurityGroupTransformerService } from './securityGroupTransformer.service';
+import { SECURITY_GROUP_TRANSFORMER_SERVICE } from './securityGroupTransformer.service';
 
 describe('Service: securityGroupReader', function () {
   let $q: ng.IQService, $scope: ng.IRootScopeService, reader: SecurityGroupReader;

--- a/packages/core/src/serverGroup/configure/common/deployInitializer.component.spec.ts
+++ b/packages/core/src/serverGroup/configure/common/deployInitializer.component.spec.ts
@@ -1,6 +1,9 @@
-import { IComponentControllerService, mock } from 'angular';
-import { DeployInitializerController, DEPLOY_INITIALIZER_COMPONENT } from './deployInitializer.component';
-import { Application, ApplicationModelBuilder } from '../../../application';
+import type { IComponentControllerService } from 'angular';
+import { mock } from 'angular';
+import type { DeployInitializerController } from './deployInitializer.component';
+import { DEPLOY_INITIALIZER_COMPONENT } from './deployInitializer.component';
+import type { Application } from '../../../application';
+import { ApplicationModelBuilder } from '../../../application';
 
 describe('Component: deployInitializer', () => {
   let ctrl: DeployInitializerController, $componentController: IComponentControllerService, application: Application;

--- a/packages/core/src/serverGroup/configure/common/deployInitializer.component.spec.ts
+++ b/packages/core/src/serverGroup/configure/common/deployInitializer.component.spec.ts
@@ -1,9 +1,10 @@
 import type { IComponentControllerService } from 'angular';
 import { mock } from 'angular';
-import type { DeployInitializerController } from './deployInitializer.component';
-import { DEPLOY_INITIALIZER_COMPONENT } from './deployInitializer.component';
+
 import type { Application } from '../../../application';
 import { ApplicationModelBuilder } from '../../../application';
+import type { DeployInitializerController } from './deployInitializer.component';
+import { DEPLOY_INITIALIZER_COMPONENT } from './deployInitializer.component';
 
 describe('Component: deployInitializer', () => {
   let ctrl: DeployInitializerController, $componentController: IComponentControllerService, application: Application;

--- a/packages/core/src/serverGroup/details/capacity/CapacityDetailsSection.spec.tsx
+++ b/packages/core/src/serverGroup/details/capacity/CapacityDetailsSection.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
 import { CapacityDetailsSection } from './CapacityDetailsSection';
 

--- a/packages/core/src/serverGroup/details/scalingActivities/ScalingActivitiesModal.spec.ts
+++ b/packages/core/src/serverGroup/details/scalingActivities/ScalingActivitiesModal.spec.ts
@@ -1,4 +1,5 @@
-import { groupScalingActivities, IScalingEventSummary } from './ScalingActivitiesModal';
+import type { IScalingEventSummary } from './ScalingActivitiesModal';
+import { groupScalingActivities } from './ScalingActivitiesModal';
 
 describe('Group Scaling Activities', () => {
   it('groups activities by cause, parsing availability zone from details, sorted by start date, newest first', () => {

--- a/packages/core/src/serverGroup/details/serverGroupWarningMessage.service.spec.ts
+++ b/packages/core/src/serverGroup/details/serverGroupWarningMessage.service.spec.ts
@@ -1,8 +1,8 @@
-import { ServerGroupWarningMessageService } from './serverGroupWarningMessage.service';
-import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import type { IServerGroup } from '../../domain';
 import type { Application } from '../../application/application.model';
+import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import type { IConfirmationModalParams } from '../../confirmationModal/confirmationModal.service';
+import type { IServerGroup } from '../../domain';
+import { ServerGroupWarningMessageService } from './serverGroupWarningMessage.service';
 
 describe('ServerGroupWarningMessageService', () => {
   let app: Application, serverGroup: IServerGroup;

--- a/packages/core/src/serverGroup/details/serverGroupWarningMessage.service.spec.ts
+++ b/packages/core/src/serverGroup/details/serverGroupWarningMessage.service.spec.ts
@@ -1,8 +1,8 @@
 import { ServerGroupWarningMessageService } from './serverGroupWarningMessage.service';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
-import { IServerGroup } from '../../domain';
-import { Application } from '../../application/application.model';
-import { IConfirmationModalParams } from '../../confirmationModal/confirmationModal.service';
+import type { IServerGroup } from '../../domain';
+import type { Application } from '../../application/application.model';
+import type { IConfirmationModalParams } from '../../confirmationModal/confirmationModal.service';
 
 describe('ServerGroupWarningMessageService', () => {
   let app: Application, serverGroup: IServerGroup;

--- a/packages/core/src/serverGroup/serverGroupWriter.service.spec.ts
+++ b/packages/core/src/serverGroup/serverGroupWriter.service.spec.ts
@@ -1,16 +1,17 @@
-import { mockHttpClient } from '../api/mock/jasmine';
 import { mock, noop } from 'angular';
+
+import { mockHttpClient } from '../api/mock/jasmine';
 import type { MockHttpClient } from '../api/mock/mockHttpClient';
-import type { ServerGroupWriter } from './serverGroupWriter.service';
-import { SERVER_GROUP_WRITER } from './serverGroupWriter.service';
+import { Application } from '../application/application.model';
+import { ApplicationModelBuilder } from '../application/applicationModel.builder';
+import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import type {
   IServerGroupCommand,
   IServerGroupCommandViewState,
 } from './configure/common/serverGroupCommandBuilder.service';
+import type { ServerGroupWriter } from './serverGroupWriter.service';
+import { SERVER_GROUP_WRITER } from './serverGroupWriter.service';
 import type { ITaskCommand } from '../task/taskExecutor';
-import { Application } from '../application/application.model';
-import { ApplicationModelBuilder } from '../application/applicationModel.builder';
-import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 
 interface IApplicationTask {
   refresh: () => void;

--- a/packages/core/src/serverGroup/serverGroupWriter.service.spec.ts
+++ b/packages/core/src/serverGroup/serverGroupWriter.service.spec.ts
@@ -1,12 +1,13 @@
 import { mockHttpClient } from '../api/mock/jasmine';
 import { mock, noop } from 'angular';
-import { MockHttpClient } from '../api/mock/mockHttpClient';
-import { SERVER_GROUP_WRITER, ServerGroupWriter } from './serverGroupWriter.service';
-import {
+import type { MockHttpClient } from '../api/mock/mockHttpClient';
+import type { ServerGroupWriter } from './serverGroupWriter.service';
+import { SERVER_GROUP_WRITER } from './serverGroupWriter.service';
+import type {
   IServerGroupCommand,
   IServerGroupCommandViewState,
 } from './configure/common/serverGroupCommandBuilder.service';
-import { ITaskCommand } from '../task/taskExecutor';
+import type { ITaskCommand } from '../task/taskExecutor';
 import { Application } from '../application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';

--- a/packages/core/src/slack/SlackReader.spec.ts
+++ b/packages/core/src/slack/SlackReader.spec.ts
@@ -1,5 +1,6 @@
 import { mockHttpClient } from '../api/mock/jasmine';
-import { ISlackChannel, SlackReader } from './SlackReader';
+import type { ISlackChannel } from './SlackReader';
+import { SlackReader } from './SlackReader';
 
 const mockSlackChannels: ISlackChannel[] = [
   {

--- a/packages/core/src/slack/SlackReader.spec.ts
+++ b/packages/core/src/slack/SlackReader.spec.ts
@@ -1,6 +1,6 @@
-import { mockHttpClient } from '../api/mock/jasmine';
 import type { ISlackChannel } from './SlackReader';
 import { SlackReader } from './SlackReader';
+import { mockHttpClient } from '../api/mock/jasmine';
 
 const mockSlackChannels: ISlackChannel[] = [
   {

--- a/packages/core/src/subnet/subnet.read.service.spec.ts
+++ b/packages/core/src/subnet/subnet.read.service.spec.ts
@@ -1,9 +1,9 @@
-import { mockHttpClient } from '../api/mock/jasmine';
 import type { IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
-import { SubnetReader } from './subnet.read.service';
+import { mockHttpClient } from '../api/mock/jasmine';
 import type { ISubnet } from '../domain';
+import { SubnetReader } from './subnet.read.service';
 
 describe('SubnetReader', function () {
   let $scope: IScope;

--- a/packages/core/src/subnet/subnet.read.service.spec.ts
+++ b/packages/core/src/subnet/subnet.read.service.spec.ts
@@ -1,8 +1,9 @@
 import { mockHttpClient } from '../api/mock/jasmine';
-import { mock, IRootScopeService, IScope } from 'angular';
+import type { IRootScopeService, IScope } from 'angular';
+import { mock } from 'angular';
 
 import { SubnetReader } from './subnet.read.service';
-import { ISubnet } from '../domain';
+import type { ISubnet } from '../domain';
 
 describe('SubnetReader', function () {
   let $scope: IScope;

--- a/packages/core/src/task/monitor/taskMonitor.spec.ts
+++ b/packages/core/src/task/monitor/taskMonitor.spec.ts
@@ -1,10 +1,10 @@
 import { mockHttpClient } from '../../api/mock/jasmine';
 import { mock } from 'angular';
-import { IModalServiceInstance } from 'angular-ui-bootstrap';
+import type { IModalServiceInstance } from 'angular-ui-bootstrap';
 import { $q, $timeout } from 'ngimport';
 import Spy = jasmine.Spy;
 
-import { ITask } from '../../domain';
+import type { ITask } from '../../domain';
 import { TaskMonitor } from './TaskMonitor';
 import { OrchestratedItemTransformer } from '../../orchestratedItem/orchestratedItem.transformer';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';

--- a/packages/core/src/task/monitor/taskMonitor.spec.ts
+++ b/packages/core/src/task/monitor/taskMonitor.spec.ts
@@ -1,13 +1,14 @@
-import { mockHttpClient } from '../../api/mock/jasmine';
 import { mock } from 'angular';
 import type { IModalServiceInstance } from 'angular-ui-bootstrap';
 import { $q, $timeout } from 'ngimport';
-import Spy = jasmine.Spy;
 
-import type { ITask } from '../../domain';
 import { TaskMonitor } from './TaskMonitor';
-import { OrchestratedItemTransformer } from '../../orchestratedItem/orchestratedItem.transformer';
+import { mockHttpClient } from '../../api/mock/jasmine';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
+import type { ITask } from '../../domain';
+import { OrchestratedItemTransformer } from '../../orchestratedItem/orchestratedItem.transformer';
+
+import Spy = jasmine.Spy;
 
 describe('TaskMonitor', () => {
   let $scope: ng.IScope;

--- a/packages/core/src/task/task.dataSource.spec.ts
+++ b/packages/core/src/task/task.dataSource.spec.ts
@@ -1,6 +1,7 @@
-import { mock, IQService } from 'angular';
+import type { IQService } from 'angular';
+import { mock } from 'angular';
 
-import { Application } from '../application/application.model';
+import type { Application } from '../application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { TaskReader } from './task.read.service';

--- a/packages/core/src/task/task.dataSource.spec.ts
+++ b/packages/core/src/task/task.dataSource.spec.ts
@@ -79,8 +79,8 @@ describe('Task Data Source', function () {
 
     it('sets appropriate flags when task reload fails; subscriber is responsible for error checking', function () {
       spyOn(TaskReader, 'getTasks').and.callFake(() => $q.reject(null));
-      let errorsHandled = 0,
-        successesHandled = 0;
+      let errorsHandled = 0;
+      let successesHandled = 0;
       configureApplication();
       application.getDataSource('tasks').onRefresh(
         $scope,

--- a/packages/core/src/task/task.write.service.spec.ts
+++ b/packages/core/src/task/task.write.service.spec.ts
@@ -1,5 +1,6 @@
 import { mockHttpClient } from '../api/mock/jasmine';
-import { mock, ITimeoutService } from 'angular';
+import type { ITimeoutService } from 'angular';
+import { mock } from 'angular';
 import { TaskWriter } from './task.write.service';
 
 describe('Service: TaskWriter', () => {

--- a/packages/core/src/task/task.write.service.spec.ts
+++ b/packages/core/src/task/task.write.service.spec.ts
@@ -1,6 +1,7 @@
-import { mockHttpClient } from '../api/mock/jasmine';
 import type { ITimeoutService } from 'angular';
 import { mock } from 'angular';
+
+import { mockHttpClient } from '../api/mock/jasmine';
 import { TaskWriter } from './task.write.service';
 
 describe('Service: TaskWriter', () => {

--- a/packages/core/src/utils/clipboard/CopyToClipboard.spec.tsx
+++ b/packages/core/src/utils/clipboard/CopyToClipboard.spec.tsx
@@ -1,7 +1,8 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import { logger } from '../Logger';
+
 import { CopyToClipboard } from './CopyToClipboard';
+import { logger } from '../Logger';
 
 describe('<CopyToClipboard />', () => {
   beforeEach(() => spyOn(logger, 'log'));

--- a/packages/core/src/utils/json/json.utility.service.spec.ts
+++ b/packages/core/src/utils/json/json.utility.service.spec.ts
@@ -1,4 +1,5 @@
-import { JsonUtils, IJsonDiff } from './JsonUtils';
+import type { IJsonDiff } from './JsonUtils';
+import { JsonUtils } from './JsonUtils';
 
 describe('JsonUtilityService', () => {
   it('generates a nice alphabetized diff', () => {

--- a/packages/core/src/utils/timeFormatters.spec.ts
+++ b/packages/core/src/utils/timeFormatters.spec.ts
@@ -1,9 +1,9 @@
 import type { IFilterService } from 'angular';
 import { mock } from 'angular';
+import { DateTime, Settings } from 'luxon';
 
 import { SETTINGS } from '../config/settings';
 import { duration, timeDiffToString } from './timeFormatters';
-import { DateTime, Settings } from 'luxon';
 
 describe('Filter: timeFormatters', function () {
   beforeEach(function () {

--- a/packages/core/src/utils/timeFormatters.spec.ts
+++ b/packages/core/src/utils/timeFormatters.spec.ts
@@ -1,4 +1,5 @@
-import { IFilterService, mock } from 'angular';
+import type { IFilterService } from 'angular';
+import { mock } from 'angular';
 
 import { SETTINGS } from '../config/settings';
 import { duration, timeDiffToString } from './timeFormatters';

--- a/packages/core/src/utils/workerPool.spec.ts
+++ b/packages/core/src/utils/workerPool.spec.ts
@@ -1,4 +1,5 @@
-import { Task, WorkerPool } from './workerPool';
+import type { Task } from './workerPool';
+import { WorkerPool } from './workerPool';
 
 const delay = (millis = 0) => new Promise<void>((resolve) => setTimeout(resolve, millis));
 

--- a/packages/core/src/widgets/ApplicationsPickerInput.spec.tsx
+++ b/packages/core/src/widgets/ApplicationsPickerInput.spec.tsx
@@ -1,5 +1,5 @@
 import { ApplicationReader } from '../application';
-import { IValidator } from '../presentation';
+import type { IValidator } from '../presentation';
 import { mount } from 'enzyme';
 import React from 'react';
 import { ApplicationsPickerInput } from './ApplicationsPickerInput';

--- a/packages/core/src/widgets/ApplicationsPickerInput.spec.tsx
+++ b/packages/core/src/widgets/ApplicationsPickerInput.spec.tsx
@@ -1,8 +1,9 @@
-import { ApplicationReader } from '../application';
-import type { IValidator } from '../presentation';
 import { mount } from 'enzyme';
 import React from 'react';
+
 import { ApplicationsPickerInput } from './ApplicationsPickerInput';
+import { ApplicationReader } from '../application';
+import type { IValidator } from '../presentation';
 
 describe('ApplicationsPickerInput', () => {
   function listApplicationsSpy() {

--- a/packages/core/src/widgets/spelText/SpelAutocompleteService.spec.ts
+++ b/packages/core/src/widgets/spelText/SpelAutocompleteService.spec.ts
@@ -1,7 +1,8 @@
-import { SpelAutocompleteService } from './SpelAutocompleteService';
 import { $q } from 'ngimport';
-import type { ExecutionService } from '../../pipeline';
+
+import { SpelAutocompleteService } from './SpelAutocompleteService';
 import type { IExecution, IPipeline, IStage } from '../../domain';
+import type { ExecutionService } from '../../pipeline';
 
 describe('SpelAutocompleteService', () => {
   describe('addPipelineInfo', () => {

--- a/packages/core/src/widgets/spelText/SpelAutocompleteService.spec.ts
+++ b/packages/core/src/widgets/spelText/SpelAutocompleteService.spec.ts
@@ -1,7 +1,7 @@
 import { SpelAutocompleteService } from './SpelAutocompleteService';
 import { $q } from 'ngimport';
-import { ExecutionService } from '../../pipeline';
-import { IExecution, IPipeline, IStage } from '../../domain';
+import type { ExecutionService } from '../../pipeline';
+import type { IExecution, IPipeline, IStage } from '../../domain';
 
 describe('SpelAutocompleteService', () => {
   describe('addPipelineInfo', () => {

--- a/packages/core/src/widgets/tags/Tag.spec.tsx
+++ b/packages/core/src/widgets/tags/Tag.spec.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
+import React from 'react';
 
 import { Key } from '../Keys';
 import type { ITag, ITagProps } from './Tag';

--- a/packages/core/src/widgets/tags/Tag.spec.tsx
+++ b/packages/core/src/widgets/tags/Tag.spec.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { mount, ReactWrapper } from 'enzyme';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { Key } from '../Keys';
-import { DeleteType, ITag, ITagProps, Tag } from './Tag';
+import type { ITag, ITagProps } from './Tag';
+import { DeleteType, Tag } from './Tag';
 
 describe('<Tag/>', () => {
   let component: ReactWrapper<ITagProps, any>;

--- a/packages/core/src/widgets/tags/TagList.spec.tsx
+++ b/packages/core/src/widgets/tags/TagList.spec.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { ReactWrapper, mount } from 'enzyme';
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
 
-import { ITag } from './Tag';
-import { ITagListProps, TagList } from './TagList';
+import type { ITag } from './Tag';
+import type { ITagListProps } from './TagList';
+import { TagList } from './TagList';
 
 describe('<TagList/>', () => {
   let component: ReactWrapper<ITagListProps, any>;

--- a/packages/core/src/widgets/tags/TagList.spec.tsx
+++ b/packages/core/src/widgets/tags/TagList.spec.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
+import React from 'react';
 
 import type { ITag } from './Tag';
 import type { ITagListProps } from './TagList';

--- a/packages/core/src/yamlEditor/yamlEditorUtils.spec.ts
+++ b/packages/core/src/yamlEditor/yamlEditorUtils.spec.ts
@@ -1,4 +1,4 @@
-import { yamlStringToDocuments, yamlDocumentsToString } from './yamlEditorUtils';
+import { yamlDocumentsToString, yamlStringToDocuments } from './yamlEditorUtils';
 
 describe('YAML editor utils', () => {
   describe('yamlStringToDocuments', () => {

--- a/packages/dcos/src/pipeline/stages/runJob/dockerImageAndTagSelector.component.spec.ts
+++ b/packages/dcos/src/pipeline/stages/runJob/dockerImageAndTagSelector.component.spec.ts
@@ -1,13 +1,14 @@
-import { IComponentControllerService, mock } from 'angular';
+import type { IComponentControllerService } from 'angular';
+import { mock } from 'angular';
 import { $q } from 'ngimport';
 
-import { AccountService, IAccount } from '@spinnaker/core';
+import type { IAccount } from '@spinnaker/core';
+import { AccountService } from '@spinnaker/core';
 
-import { DockerImageReader, IDockerImage } from '@spinnaker/docker';
-import {
-  DOCKER_IMAGE_AND_TAG_SELECTOR_COMPONENT,
-  DockerImageAndTagSelectorController,
-} from './dockerImageAndTagSelector.component';
+import type { IDockerImage } from '@spinnaker/docker';
+import { DockerImageReader } from '@spinnaker/docker';
+import type { DockerImageAndTagSelectorController } from './dockerImageAndTagSelector.component';
+import { DOCKER_IMAGE_AND_TAG_SELECTOR_COMPONENT } from './dockerImageAndTagSelector.component';
 
 describe('dockerImageAndTagSelector controller', () => {
   let $ctrl: DockerImageAndTagSelectorController, $componentController: IComponentControllerService, $scope: ng.IScope;

--- a/packages/dcos/src/pipeline/stages/runJob/dockerImageAndTagSelector.component.spec.ts
+++ b/packages/dcos/src/pipeline/stages/runJob/dockerImageAndTagSelector.component.spec.ts
@@ -14,8 +14,8 @@ describe('dockerImageAndTagSelector controller', () => {
 
   let organization: string, registry: string, repository: string, showRegistry: boolean;
 
-  const tag: string = undefined,
-    account: string = undefined;
+  const tag: string = undefined;
+  const account: string = undefined;
 
   beforeEach(mock.module(DOCKER_IMAGE_AND_TAG_SELECTOR_COMPONENT));
 

--- a/packages/ecs/src/serverGroup/serverGroup.transformer.spec.ts
+++ b/packages/ecs/src/serverGroup/serverGroup.transformer.spec.ts
@@ -1,7 +1,10 @@
-import { mock, IQService, IRootScopeService, IScope } from 'angular';
+import type { IQService, IRootScopeService, IScope } from 'angular';
+import { mock } from 'angular';
 
-import { ECS_SERVER_GROUP_TRANSFORMER, EcsServerGroupTransformer } from './serverGroup.transformer';
-import { IScalingPolicyAlarmView, IAmazonServerGroup, IStepAdjustment, VpcReader } from '@spinnaker/amazon';
+import type { EcsServerGroupTransformer } from './serverGroup.transformer';
+import { ECS_SERVER_GROUP_TRANSFORMER } from './serverGroup.transformer';
+import type { IScalingPolicyAlarmView, IAmazonServerGroup, IStepAdjustment } from '@spinnaker/amazon';
+import { VpcReader } from '@spinnaker/amazon';
 
 describe('ecsServerGroupTransformer', () => {
   let transformer: EcsServerGroupTransformer, $q: IQService, $scope: IScope;

--- a/packages/ecs/src/serverGroup/serverGroup.transformer.spec.ts
+++ b/packages/ecs/src/serverGroup/serverGroup.transformer.spec.ts
@@ -1,10 +1,11 @@
 import type { IQService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
 
+import type { IAmazonServerGroup, IScalingPolicyAlarmView, IStepAdjustment } from '@spinnaker/amazon';
+import { VpcReader } from '@spinnaker/amazon';
+
 import type { EcsServerGroupTransformer } from './serverGroup.transformer';
 import { ECS_SERVER_GROUP_TRANSFORMER } from './serverGroup.transformer';
-import type { IScalingPolicyAlarmView, IAmazonServerGroup, IStepAdjustment } from '@spinnaker/amazon';
-import { VpcReader } from '@spinnaker/amazon';
 
 describe('ecsServerGroupTransformer', () => {
   let transformer: EcsServerGroupTransformer, $q: IQService, $scope: IScope;

--- a/packages/eslint-plugin/rules/api-deprecation.spec.ts
+++ b/packages/eslint-plugin/rules/api-deprecation.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './api-deprecation';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('api-deprecation', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/api-no-slashes.spec.ts
+++ b/packages/eslint-plugin/rules/api-no-slashes.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './api-no-slashes';
+import ruleTester from '../utils/ruleTester';
 const errorMessage =
   `Do not include slashes in API.one() or API.all() calls because arguments to .one() and .all() get url encoded.` +
   `Instead, of API.one('foo/bar'), split into multiple arguments: API.one('foo', 'bar').`;

--- a/packages/eslint-plugin/rules/api-no-unused-chaining.spec.ts
+++ b/packages/eslint-plugin/rules/api-no-unused-chaining.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from '../rules/api-no-unused-chaining';
+import ruleTester from '../utils/ruleTester';
 const errorMessage = (text) => `Unused API.xyz() method chaining no longer works. Re-assign the result of: ${text}`;
 
 ruleTester.run('api-no-slashes', rule, {

--- a/packages/eslint-plugin/rules/import-from-alias-not-npm.spec.ts
+++ b/packages/eslint-plugin/rules/import-from-alias-not-npm.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './import-from-alias-not-npm';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('import-from-alias-not-npm', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/import-from-npm-not-alias.spec.ts
+++ b/packages/eslint-plugin/rules/import-from-npm-not-alias.spec.ts
@@ -1,6 +1,6 @@
+import rule from './import-from-npm-not-alias';
 import '../utils/import-aliases.mock';
 import ruleTester from '../utils/ruleTester';
-import rule from './import-from-npm-not-alias';
 
 ruleTester.run('import-from-npm-not-alias', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/import-from-npm-not-relative.spec.ts
+++ b/packages/eslint-plugin/rules/import-from-npm-not-relative.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './import-from-npm-not-relative';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('import-from-npm-not-relative', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/import-from-presentation-not-core.spec.ts
+++ b/packages/eslint-plugin/rules/import-from-presentation-not-core.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './import-from-presentation-not-core';
+import ruleTester from '../utils/ruleTester';
 const errorMessage = (moduleName) => `${moduleName} must be imported from @spinnaker/presentation`;
 
 ruleTester.run('import-from-presentation-not-core', rule, {

--- a/packages/eslint-plugin/rules/import-relative-within-subpackage.spec.ts
+++ b/packages/eslint-plugin/rules/import-relative-within-subpackage.spec.ts
@@ -1,6 +1,6 @@
+import rule from './import-relative-within-subpackage';
 import '../utils/import-aliases.mock';
 import ruleTester from '../utils/ruleTester';
-import rule from './import-relative-within-subpackage';
 
 ruleTester.run('import-relative-within-subpackage', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/import-sort.spec.ts
+++ b/packages/eslint-plugin/rules/import-sort.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './import-sort';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('import-sort', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/migrate-to-mock-http-client.spec.ts
+++ b/packages/eslint-plugin/rules/migrate-to-mock-http-client.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './migrate-to-mock-http-client';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('migrate-to-mock-http-client', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/ng-no-component-class.spec.ts
+++ b/packages/eslint-plugin/rules/ng-no-component-class.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './ng-no-component-class';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('ng-no-component-class', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/ng-no-module-export.spec.ts
+++ b/packages/eslint-plugin/rules/ng-no-module-export.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './ng-no-module-export';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('ng-no-module-export', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/ng-no-require-angularjs.spec.ts
+++ b/packages/eslint-plugin/rules/ng-no-require-angularjs.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './ng-no-require-angularjs';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('ng-no-require-angularjs', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/ng-no-require-module-deps.spec.ts
+++ b/packages/eslint-plugin/rules/ng-no-require-module-deps.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './ng-no-require-module-deps';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('ng-no-require-module-deps', rule, {
   valid: [

--- a/packages/eslint-plugin/rules/ng-strictdi.spec.ts
+++ b/packages/eslint-plugin/rules/ng-strictdi.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './ng-strictdi';
+import ruleTester from '../utils/ruleTester';
 ruleTester.run('ng-strictdi', rule, {
   valid: [
     {

--- a/packages/eslint-plugin/rules/prefer-promise-like.spec.ts
+++ b/packages/eslint-plugin/rules/prefer-promise-like.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './prefer-promise-like';
+import ruleTester from '../utils/ruleTester';
 const errorMessage = `Prefer using PromiseLike type instead of AngularJS IPromise.`;
 const unusedImportErrorMessage = `Unused IPromise import`;
 

--- a/packages/eslint-plugin/rules/react2angular-with-error-boundary.spec.ts
+++ b/packages/eslint-plugin/rules/react2angular-with-error-boundary.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './react2angular-with-error-boundary';
+import ruleTester from '../utils/ruleTester';
 const errorMessage = `Wrap react2angular components in an error boundary using 'withErrorBoundary()'`;
 
 ruleTester.run('api-no-slashes', rule, {

--- a/packages/eslint-plugin/rules/rest-prefer-static-strings-in-initializer.spec.ts
+++ b/packages/eslint-plugin/rules/rest-prefer-static-strings-in-initializer.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './rest-prefer-static-strings-in-initializer';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('rest-prefer-static-strings-in-initializer', rule, {
   valid: [

--- a/packages/eslint-plugin/template/template-rule.spec.ts
+++ b/packages/eslint-plugin/template/template-rule.spec.ts
@@ -1,5 +1,5 @@
-import ruleTester from '../utils/ruleTester';
 import rule from './RULENAME';
+import ruleTester from '../utils/ruleTester';
 
 ruleTester.run('RULENAME', rule, {
   valid: [

--- a/packages/google/src/healthCheck/healthCheckUtils.spec.ts
+++ b/packages/google/src/healthCheck/healthCheckUtils.spec.ts
@@ -1,4 +1,5 @@
-import { IGceHealthCheck, IGceHealthCheckKind } from '../domain';
+import type { IGceHealthCheck } from '../domain';
+import { IGceHealthCheckKind } from '../domain';
 import { parseHealthCheckUrl, getHealthCheckOptions, getDuplicateHealthCheckNames } from './healthCheckUtils';
 
 describe('Health check display utils', () => {

--- a/packages/google/src/healthCheck/healthCheckUtils.spec.ts
+++ b/packages/google/src/healthCheck/healthCheckUtils.spec.ts
@@ -1,6 +1,6 @@
 import type { IGceHealthCheck } from '../domain';
 import { IGceHealthCheckKind } from '../domain';
-import { parseHealthCheckUrl, getHealthCheckOptions, getDuplicateHealthCheckNames } from './healthCheckUtils';
+import { getDuplicateHealthCheckNames, getHealthCheckOptions, parseHealthCheckUrl } from './healthCheckUtils';
 
 describe('Health check display utils', () => {
   let healthChecks: IGceHealthCheck[];

--- a/packages/google/src/securityGroup/securityGroupHelpText.service.spec.ts
+++ b/packages/google/src/securityGroup/securityGroupHelpText.service.spec.ts
@@ -1,5 +1,6 @@
 import { mock } from 'angular';
-import { GCE_SECURITY_GROUP_HELP_TEXT_SERVICE, GceSecurityGroupHelpTextService } from './securityGroupHelpText.service';
+import type { GceSecurityGroupHelpTextService } from './securityGroupHelpText.service';
+import { GCE_SECURITY_GROUP_HELP_TEXT_SERVICE } from './securityGroupHelpText.service';
 
 describe('Service: gceSecurityGroupHelpTextService', () => {
   let $q: ng.IQService;

--- a/packages/google/src/serverGroup/configure/wizard/advancedSettings/gceAccelerator.service.spec.ts
+++ b/packages/google/src/serverGroup/configure/wizard/advancedSettings/gceAccelerator.service.spec.ts
@@ -1,4 +1,5 @@
-import { GceAcceleratorService, IGceAcceleratorCommand, IGceAcceleratorTypeRaw } from './gceAccelerator.service';
+import type { IGceAcceleratorCommand, IGceAcceleratorTypeRaw } from './gceAccelerator.service';
+import { GceAcceleratorService } from './gceAccelerator.service';
 
 describe('GceAcceleratorService', () => {
   const acceleratorA: IGceAcceleratorTypeRaw = {

--- a/packages/kubernetes/src/manifest/ManifestImageDetails.spec.tsx
+++ b/packages/kubernetes/src/manifest/ManifestImageDetails.spec.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
 import { mount } from 'enzyme';
 import { load } from 'js-yaml';
+import React from 'react';
+
 import { ManifestImageDetails } from '../manifest/ManifestImageDetails';
 
 describe('<ManifestImageDetails />', () => {

--- a/packages/kubernetes/src/manifest/selector/ManifestSelector.spec.tsx
+++ b/packages/kubernetes/src/manifest/selector/ManifestSelector.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import Select, { Creatable, Option } from 'react-select';
+import type { Option } from 'react-select';
+import Select, { Creatable } from 'react-select';
 import { $q } from 'ngimport';
 import Spy = jasmine.Spy;
 
@@ -13,10 +14,11 @@ import {
 } from '@spinnaker/core';
 
 import { ManifestKindSearchService } from '../ManifestKindSearch';
-import { ManifestSelector, IManifestSelectorState } from './ManifestSelector';
+import type { IManifestSelectorState } from './ManifestSelector';
+import { ManifestSelector } from './ManifestSelector';
 import { SelectorMode } from './IManifestSelector';
 import LabelEditor from './labelEditor/LabelEditor';
-import { IManifestLabelSelector } from './IManifestLabelSelector';
+import type { IManifestLabelSelector } from './IManifestLabelSelector';
 
 describe('<ManifestSelector />', () => {
   let searchService: Spy;

--- a/packages/kubernetes/src/manifest/selector/ManifestSelector.spec.tsx
+++ b/packages/kubernetes/src/manifest/selector/ManifestSelector.spec.tsx
@@ -1,24 +1,25 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import { $q } from 'ngimport';
+import React from 'react';
 import type { Option } from 'react-select';
 import Select, { Creatable } from 'react-select';
-import { $q } from 'ngimport';
-import Spy = jasmine.Spy;
 
 import {
   AccountSelectInput,
   AccountService,
-  ScopeClusterSelector,
   createFakeReactSyntheticEvent,
   noop,
+  ScopeClusterSelector,
 } from '@spinnaker/core';
 
+import type { IManifestLabelSelector } from './IManifestLabelSelector';
+import { SelectorMode } from './IManifestSelector';
 import { ManifestKindSearchService } from '../ManifestKindSearch';
 import type { IManifestSelectorState } from './ManifestSelector';
 import { ManifestSelector } from './ManifestSelector';
-import { SelectorMode } from './IManifestSelector';
 import LabelEditor from './labelEditor/LabelEditor';
-import type { IManifestLabelSelector } from './IManifestLabelSelector';
+
+import Spy = jasmine.Spy;
 
 describe('<ManifestSelector />', () => {
   let searchService: Spy;

--- a/packages/kubernetes/src/manifest/selector/labelEditor/LabelEditor.spec.tsx
+++ b/packages/kubernetes/src/manifest/selector/labelEditor/LabelEditor.spec.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import type { ShallowWrapper } from 'enzyme';
 import { shallow } from 'enzyme';
+import React from 'react';
 
 import type { ILabelEditorProps } from './LabelEditor';
 import LabelEditor from './LabelEditor';

--- a/packages/kubernetes/src/manifest/selector/labelEditor/LabelEditor.spec.tsx
+++ b/packages/kubernetes/src/manifest/selector/labelEditor/LabelEditor.spec.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import type { ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 
-import LabelEditor, { ILabelEditorProps } from './LabelEditor';
+import type { ILabelEditorProps } from './LabelEditor';
+import LabelEditor from './LabelEditor';
 
 describe('<LabelEditor />', () => {
   let onChangeSpy: jasmine.Spy;

--- a/packages/kubernetes/src/pipelines/stages/deleteManifest/DeleteManifestOptionsForm.spec.tsx
+++ b/packages/kubernetes/src/pipelines/stages/deleteManifest/DeleteManifestOptionsForm.spec.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import type { ShallowWrapper } from 'enzyme';
 import { shallow } from 'enzyme';
+import React from 'react';
 
 import { StageConfigField } from '@spinnaker/core';
 

--- a/packages/kubernetes/src/pipelines/stages/deleteManifest/DeleteManifestOptionsForm.spec.tsx
+++ b/packages/kubernetes/src/pipelines/stages/deleteManifest/DeleteManifestOptionsForm.spec.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import type { ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { StageConfigField } from '@spinnaker/core';
 
-import DeleteManifestOptionsForm, { IDeleteManifestOptionsFormProps } from './DeleteManifestOptionsForm';
+import type { IDeleteManifestOptionsFormProps } from './DeleteManifestOptionsForm';
+import DeleteManifestOptionsForm from './DeleteManifestOptionsForm';
 
 describe('<DeleteManifestOptionsForm />', () => {
   let onChangeSpy: jasmine.Spy;

--- a/packages/kubernetes/src/pipelines/stages/deployManifest/ManifestCopier.spec.ts
+++ b/packages/kubernetes/src/pipelines/stages/deployManifest/ManifestCopier.spec.ts
@@ -1,6 +1,8 @@
-import { IQService, IScope, mock } from 'angular';
+import type { IQService, IScope } from 'angular';
+import { mock } from 'angular';
 
-import { ApplicationModelBuilder, Application, noop } from '@spinnaker/core';
+import type { Application } from '@spinnaker/core';
+import { ApplicationModelBuilder, noop } from '@spinnaker/core';
 import { ManifestCopier } from './ManifestCopier';
 
 describe('<ManifestCopier />', () => {

--- a/packages/kubernetes/src/pipelines/stages/deployManifest/ManifestDeploymentOptions.spec.tsx
+++ b/packages/kubernetes/src/pipelines/stages/deployManifest/ManifestDeploymentOptions.spec.tsx
@@ -3,11 +3,8 @@ import { shallow } from 'enzyme';
 
 import { StageConfigField } from '@spinnaker/core';
 
-import {
-  IManifestDeploymentOptionsProps,
-  ManifestDeploymentOptions,
-  defaultTrafficManagementConfig,
-} from './ManifestDeploymentOptions';
+import type { IManifestDeploymentOptionsProps } from './ManifestDeploymentOptions';
+import { ManifestDeploymentOptions, defaultTrafficManagementConfig } from './ManifestDeploymentOptions';
 
 describe('<ManifestDeploymentOptions />', () => {
   const onConfigChangeSpy = jasmine.createSpy('onConfigChangeSpy');

--- a/packages/kubernetes/src/pipelines/stages/deployManifest/ManifestDeploymentOptions.spec.tsx
+++ b/packages/kubernetes/src/pipelines/stages/deployManifest/ManifestDeploymentOptions.spec.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 
 import { StageConfigField } from '@spinnaker/core';
 
 import type { IManifestDeploymentOptionsProps } from './ManifestDeploymentOptions';
-import { ManifestDeploymentOptions, defaultTrafficManagementConfig } from './ManifestDeploymentOptions';
+import { defaultTrafficManagementConfig, ManifestDeploymentOptions } from './ManifestDeploymentOptions';
 
 describe('<ManifestDeploymentOptions />', () => {
   const onConfigChangeSpy = jasmine.createSpy('onConfigChangeSpy');

--- a/packages/kubernetes/src/serverGroup/serverGroupTransformer.service.spec.ts
+++ b/packages/kubernetes/src/serverGroup/serverGroupTransformer.service.spec.ts
@@ -1,6 +1,7 @@
-import { KubernetesV2ServerGroupTransformer } from './serverGroupTransformer.service';
 import { Application } from '@spinnaker/core';
+
 import type { IKubernetesServerGroup } from '../interfaces';
+import { KubernetesV2ServerGroupTransformer } from './serverGroupTransformer.service';
 
 describe('KubernetesV2ServerGroupTransformer', function () {
   it('normalizes server group name', async () => {

--- a/packages/kubernetes/src/serverGroup/serverGroupTransformer.service.spec.ts
+++ b/packages/kubernetes/src/serverGroup/serverGroupTransformer.service.spec.ts
@@ -1,6 +1,6 @@
 import { KubernetesV2ServerGroupTransformer } from './serverGroupTransformer.service';
 import { Application } from '@spinnaker/core';
-import { IKubernetesServerGroup } from '../interfaces';
+import type { IKubernetesServerGroup } from '../interfaces';
 
 describe('KubernetesV2ServerGroupTransformer', function () {
   it('normalizes server group name', async () => {

--- a/packages/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/packages/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -1,4 +1,5 @@
-import { mockHttpClient } from 'core/api/mock/jasmine';
+// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
+import { mockHttpClient } from '../../../../core/src/api/mock/jasmine';
 import type { IControllerService, IRootScopeService, IScope } from 'angular';
 import { mock, noop } from 'angular';
 import type { StateService } from '@uirouter/core';

--- a/packages/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/packages/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -1,11 +1,11 @@
-// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
 import type { StateService } from '@uirouter/core';
 import type { IControllerService, IRootScopeService, IScope } from 'angular';
 import { mock, noop } from 'angular';
 
 import { ApplicationModelBuilder } from '@spinnaker/core';
 
-import { mockHttpClient } from '@spinnaker/core';
+// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
+import { mockHttpClient } from '../../../../core/src/api/mock/jasmine';
 import { ORACLE_LOAD_BALANCER_CREATE_CONTROLLER, OracleLoadBalancerController } from './createLoadBalancer.controller';
 import type { IOracleLoadBalancer, IOracleLoadBalancerUpsertCommand } from '../../domain/IOracleLoadBalancer';
 import { LoadBalancingPolicy } from '../../domain/IOracleLoadBalancer';

--- a/packages/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/packages/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -1,15 +1,13 @@
 import { mockHttpClient } from 'core/api/mock/jasmine';
-import { IControllerService, IRootScopeService, IScope, mock, noop } from 'angular';
-import { StateService } from '@uirouter/core';
+import type { IControllerService, IRootScopeService, IScope } from 'angular';
+import { mock, noop } from 'angular';
+import type { StateService } from '@uirouter/core';
 
 import { ApplicationModelBuilder } from '@spinnaker/core';
 
 import { ORACLE_LOAD_BALANCER_CREATE_CONTROLLER, OracleLoadBalancerController } from './createLoadBalancer.controller';
-import {
-  IOracleLoadBalancer,
-  IOracleLoadBalancerUpsertCommand,
-  LoadBalancingPolicy,
-} from '../../domain/IOracleLoadBalancer';
+import type { IOracleLoadBalancer, IOracleLoadBalancerUpsertCommand } from '../../domain/IOracleLoadBalancer';
+import { LoadBalancingPolicy } from '../../domain/IOracleLoadBalancer';
 import { OracleProviderSettings } from '../../oracle.settings';
 
 describe('Controller: oracleCreateLoadBalancerCtrl', function () {

--- a/packages/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/packages/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -1,11 +1,11 @@
 // eslint-disable-next-line @spinnaker/import-from-npm-not-relative
-import { mockHttpClient } from '../../../../core/src/api/mock/jasmine';
+import type { StateService } from '@uirouter/core';
 import type { IControllerService, IRootScopeService, IScope } from 'angular';
 import { mock, noop } from 'angular';
-import type { StateService } from '@uirouter/core';
 
 import { ApplicationModelBuilder } from '@spinnaker/core';
 
+import { mockHttpClient } from '@spinnaker/core';
 import { ORACLE_LOAD_BALANCER_CREATE_CONTROLLER, OracleLoadBalancerController } from './createLoadBalancer.controller';
 import type { IOracleLoadBalancer, IOracleLoadBalancerUpsertCommand } from '../../domain/IOracleLoadBalancer';
 import { LoadBalancingPolicy } from '../../domain/IOracleLoadBalancer';

--- a/packages/oracle/src/loadBalancer/details/loadBalancerDetail.controller.spec.ts
+++ b/packages/oracle/src/loadBalancer/details/loadBalancerDetail.controller.spec.ts
@@ -1,16 +1,10 @@
-import {
-  OracleLoadBalancerDetailController,
-  ORACLE_LOAD_BALANCER_DETAIL_CONTROLLER,
-} from './loadBalancerDetail.controller';
-import { IControllerService, IRootScopeService, IScope, mock } from 'angular';
-import { StateService } from '@uirouter/angularjs';
-import {
-  ApplicationModelBuilder,
-  SECURITY_GROUP_READER,
-  SecurityGroupReader,
-  LOAD_BALANCER_READ_SERVICE,
-  LoadBalancerReader,
-} from '@spinnaker/core';
+import type { OracleLoadBalancerDetailController } from './loadBalancerDetail.controller';
+import { ORACLE_LOAD_BALANCER_DETAIL_CONTROLLER } from './loadBalancerDetail.controller';
+import type { IControllerService, IRootScopeService, IScope } from 'angular';
+import { mock } from 'angular';
+import type { StateService } from '@uirouter/angularjs';
+import type { SecurityGroupReader, LoadBalancerReader } from '@spinnaker/core';
+import { ApplicationModelBuilder, SECURITY_GROUP_READER, LOAD_BALANCER_READ_SERVICE } from '@spinnaker/core';
 
 describe('Controller: oracleLoadBalancerDetailCtrl', function () {
   let controller: OracleLoadBalancerDetailController;

--- a/packages/oracle/src/loadBalancer/details/loadBalancerDetail.controller.spec.ts
+++ b/packages/oracle/src/loadBalancer/details/loadBalancerDetail.controller.spec.ts
@@ -1,10 +1,12 @@
-import type { OracleLoadBalancerDetailController } from './loadBalancerDetail.controller';
-import { ORACLE_LOAD_BALANCER_DETAIL_CONTROLLER } from './loadBalancerDetail.controller';
+import type { StateService } from '@uirouter/angularjs';
 import type { IControllerService, IRootScopeService, IScope } from 'angular';
 import { mock } from 'angular';
-import type { StateService } from '@uirouter/angularjs';
-import type { SecurityGroupReader, LoadBalancerReader } from '@spinnaker/core';
-import { ApplicationModelBuilder, SECURITY_GROUP_READER, LOAD_BALANCER_READ_SERVICE } from '@spinnaker/core';
+
+import type { LoadBalancerReader, SecurityGroupReader } from '@spinnaker/core';
+import { ApplicationModelBuilder, LOAD_BALANCER_READ_SERVICE, SECURITY_GROUP_READER } from '@spinnaker/core';
+
+import type { OracleLoadBalancerDetailController } from './loadBalancerDetail.controller';
+import { ORACLE_LOAD_BALANCER_DETAIL_CONTROLLER } from './loadBalancerDetail.controller';
 
 describe('Controller: oracleLoadBalancerDetailCtrl', function () {
   let controller: OracleLoadBalancerDetailController;

--- a/packages/scripts/helpers/rollup-plugin-angularjs-template-loader.js
+++ b/packages/scripts/helpers/rollup-plugin-angularjs-template-loader.js
@@ -12,7 +12,7 @@ module.exports = function angularJsTemplateLoader(options = {}) {
   return {
     name: 'angularJSTemplateLoader',
     transform(originalCode, id) {
-      let code = originalCode;
+      const code = originalCode;
       const templateRegex = /require\(['"]([^'"]+\.html)['"]\)/g;
 
       // look for things like require('./template.html')
@@ -38,7 +38,7 @@ module.exports = function angularJsTemplateLoader(options = {}) {
         return;
       }
 
-      let magicString = new MagicString(code);
+      const magicString = new MagicString(code);
 
       while (match) {
         // i.e., './template.html'

--- a/packages/scripts/index.js
+++ b/packages/scripts/index.js
@@ -127,7 +127,7 @@ const startHandler = async ({ file, push }) => {
 };
 
 const printBundleStart = (option) => {
-  let message = option.output.map((output) => `${option.input} -> ${output.dir}...`).join('\n');
+  const message = option.output.map((output) => `${option.input} -> ${output.dir}...`).join('\n');
   console.log(chalk.blue.bold(message));
 };
 const printBundleComplete = (option, completedTimeInMS) => {

--- a/packages/scripts/read-write-json.js
+++ b/packages/scripts/read-write-json.js
@@ -46,7 +46,7 @@ const configureCli = () => {
           throw new Error(`Cannot parse ${value} as a boolean`);
         }
       } else if (type === 'number') {
-        let newvalue = Number(value);
+        const newvalue = Number(value);
         if (isNaN(newvalue)) {
           throw new Error(`Cannot parse ${value} as a number`);
         }

--- a/packages/titus/src/instance/details/titusInstanceDetailsUtils.spec.ts
+++ b/packages/titus/src/instance/details/titusInstanceDetailsUtils.spec.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   IAmazonApplicationLoadBalancer,
   IAmazonHealth,
   IAmazonTargetGroupHealth,
   ITargetGroup,
 } from '@spinnaker/amazon';
-import { Application } from '@spinnaker/core';
+import type { Application } from '@spinnaker/core';
 import { mockHealth, mockInstance, mockLoadBalancer, mockLoadBalancerHealth } from '@spinnaker/mocks';
 import {
   applyTargetGroupInfoToHealthMetric,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2760,14 +2760,6 @@
   resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.549.tgz#e7246140825705e6d295c30010de4f71a78d1670"
   integrity sha512-8EDwICoaqOtWFYQHvSNrTNh0ksIEVp9i/GueClvHbrcSRxYOqPDxQcSs3RGihxahjlfXIi7zjqvK0aDvSYBo0w==
 
-"@spinnaker/eslint-plugin@^1.0.13":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@spinnaker/eslint-plugin/-/eslint-plugin-1.1.1.tgz#d07fc8cc201bbcf255fc82d5c93c12ea0b2718fa"
-  integrity sha512-qZbDc8O33rPaUhrz37mIOA+0uTYI1Kg1RMFyLSmwAQ4B90xsh1JlGz4n+oiAqDASzUXZTN+lAo58/MQFg1dWiw==
-  dependencies:
-    lodash "^4.17.20"
-    ts-node "*"
-
 "@spinnaker/kayenta@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@spinnaker/kayenta/-/kayenta-2.0.0.tgz#0fc18a641ee2577c21c0bdf5eb24ac1a5ab1caf5"


### PR DESCRIPTION
I was wondering why the linter wasn't fixing my tests, well it's because the test files were ignored in `.eslintignore`.  I changed the ignore to only ignore `*.spec.js` files and fixed all the lint violations in `*.spec.tsx?`