### PR TITLE
fix(md): hide deployment status if currently deploying

### DIFF
--- a/packages/core/src/managed/versionMetadata/MetadataComponents.tsx
+++ b/packages/core/src/managed/versionMetadata/MetadataComponents.tsx
@@ -287,7 +287,7 @@ export const LifecycleEventDetails = ({
   );
 };
 
-type IDeploymentStatusProps = Pick<IVersionMetadataProps, 'deployedAt' | 'isPending' | 'isCurrent'>;
+type IDeploymentStatusProps = Pick<IVersionMetadataProps, 'deployedAt' | 'isPending' | 'isCurrent' | 'isDeploying'>;
 
 const statusToProps = {
   CURRENT: {
@@ -308,7 +308,8 @@ const statusToProps = {
   },
 } as const;
 
-export const DeploymentStatus = ({ deployedAt, isCurrent, isPending }: IDeploymentStatusProps) => {
+export const DeploymentStatus = ({ deployedAt, isCurrent, isPending, isDeploying }: IDeploymentStatusProps) => {
+  if (!deployedAt && isDeploying) return null; // We'll show the deploying badge so no reason to show this component if this version is being deployed for the first time
   const props = statusToProps[deployedAt ? (isCurrent ? 'CURRENT' : 'PREVIOUS') : isPending ? 'PENDING' : 'SKIPPED'];
   return (
     <MetadataElement>

--- a/packages/core/src/managed/versionMetadata/VersionMetadata.tsx
+++ b/packages/core/src/managed/versionMetadata/VersionMetadata.tsx
@@ -71,7 +71,7 @@ export const VersionMetadata = ({
       )}
       {build?.buildNumber && <VersionBuilds builds={[build]} />}
       <VersionAuthor author={author} />
-      <DeploymentStatus {...{ deployedAt, isCurrent, isPending }} />
+      <DeploymentStatus {...{ deployedAt, isCurrent, isPending, isDeploying }} />
       {bake?.duration && (
         <MetadataElement>
           <HoverablePopover


### PR DESCRIPTION
We're already showing the deploying badge so we can remove the status component 