### PR TITLE
chore(deps):  bump select2 to npm versions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "@uirouter/react-hybrid": "1.0.2",
     "@uirouter/rx": "0.6.5",
     "@uirouter/visualizer": "7.2.1",
-    "Select2": "git://github.com/select2/select2.git#3.4.8",
+    "select2": "3.5.1",
     "angular": "1.6.10",
     "angular-messages": "1.6.10",
     "angular-sanitize": "1.6.10",
@@ -77,7 +77,7 @@
     "react2angular": "3.2.1",
     "recoil": "0.0.10",
     "rxjs": "6.6.7",
-    "select2-bootstrap-css": "git://github.com/t0m/select2-bootstrap-css.git#v1.3.1",
+    "select2-bootstrap-css": "1.4.6",
     "source-sans": "3.46.0",
     "spel2js": "0.2.6",
     "ui-select": "0.19.8"

--- a/packages/core/src/core.module.ts
+++ b/packages/core/src/core.module.ts
@@ -12,7 +12,7 @@ import 'react-virtualized/styles.css';
 import 'react-virtualized-select/styles.css';
 import 'ui-select/dist/select.css';
 import '@spinnaker/styleguide/public/styleguide.min.css';
-import 'Select2/select2.css';
+import 'select2/select2.css';
 import 'select2-bootstrap-css/select2-bootstrap.css';
 import 'source-sans/source-sans-3.css';
 import './fonts/icons.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3751,10 +3751,6 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-"Select2@git://github.com/select2/select2.git#3.4.8":
-  version "3.4.8"
-  resolved "git://github.com/select2/select2.git#b5f3b2839c48c53f9641d6bb1bccafc5260c7620"
-
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -15150,9 +15146,15 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-"select2-bootstrap-css@git://github.com/t0m/select2-bootstrap-css.git#v1.3.1":
-  version "1.3.1"
-  resolved "git://github.com/t0m/select2-bootstrap-css.git#c3cb2590a6947e006df761071cd4bd83ed05730c"
+select2-bootstrap-css@1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/select2-bootstrap-css/-/select2-bootstrap-css-1.4.6.tgz#5cfb68246f5299ca1858e01efd788804c734997e"
+  integrity sha1-XPtoJG9SmcoYWOAe/XiIBMc0mX4=
+
+select2@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/select2/-/select2-3.5.1.tgz#f2819489bbc65fd6d328be72bbe2b95dd7e87cfe"
+  integrity sha1-8oGUibvGX9bTKL5yu+K5XdfofP4=
 
 select@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Bumping select2 dependencies to versions that are in NPM. I couldn't get an answer on why these are currently fixed at Git tags, so please let me know if you know why.