### PR TITLE
Publish packages to NPM

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.4](https://github.com/spinnaker/deck/compare/deck-app@2.1.3...deck-app@2.1.4) (2021-11-30)
+
+**Note:** Version bump only for package deck-app
+
+
+
+
+
 ## [2.1.3](https://github.com/spinnaker/deck/compare/deck-app@2.1.2...deck-app@2.1.3) (2021-11-12)
 
 **Note:** Version bump only for package deck-app

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deck-app",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "@spinnaker/google": "^0.1.1",
     "@spinnaker/kayenta": "2.0.0",
     "@spinnaker/kubernetes": "^0.2.4",
-    "@spinnaker/oracle": "^0.0.64",
+    "@spinnaker/oracle": "^0.0.65",
     "@spinnaker/styleguide": "^1.0.26",
     "@spinnaker/titus": "^0.5.16",
     "@uirouter/angularjs": "1.0.26",

--- a/packages/oracle/CHANGELOG.md
+++ b/packages/oracle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.65](https://github.com/spinnaker/deck/compare/@spinnaker/oracle@0.0.64...@spinnaker/oracle@0.0.65) (2021-11-30)
+
+**Note:** Version bump only for package @spinnaker/oracle
+
+
+
+
+
 ## [0.0.64](https://github.com/spinnaker/deck/compare/@spinnaker/oracle@0.0.63...@spinnaker/oracle@0.0.64) (2021-11-12)
 
 **Note:** Version bump only for package @spinnaker/oracle

--- a/packages/oracle/package.json
+++ b/packages/oracle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/oracle",
   "license": "Apache-2.0",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.

## app [2.1.4](https://github.com/spinnaker/deck/compare/deck-app@2.1.3...deck-app@2.1.4) (2021-11-30)

**Note:** Version bump only for package deck-app





## oracle [0.0.65](https://github.com/spinnaker/deck/compare/@spinnaker/oracle@0.0.64...@spinnaker/oracle@0.0.65) (2021-11-30)

**Note:** Version bump only for package @spinnaker/oracle

---

This Pr bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_