### PR TITLE
chore(build): update Mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,63 +1,51 @@
+queue_rules:
+  - name: default
+    conditions:
+      - base=master
+      - status-success=Deck CI
+  - name: backport
+    conditions:
+      - base~=^release-
+      - status-success=Deck CI
+
 pull_request_rules:
   - name: Automatically merge on CI success and review
     conditions:
-      - base=master
-      - status-success=Deck CI
       - 'label=ready to merge'
       - 'approved-reviews-by=@oss-approvers'
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
   - name: Automatically self merge on CI success
     conditions:
-      - base=master
-      - status-success=Deck CI
       - 'label=ready to merge'
       - 'label=self merge'
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
   - name: Automatically rebase and merge on CI success and review
     conditions:
-      - base=master
-      - status-success=Deck CI
       - 'label=ready to rebase'
       - 'approved-reviews-by=@oss-approvers'
     actions:
-      merge:
+      queue:
         method: rebase
-        strict: smart
+        name: default
   - name: Automatically rebase and self merge on CI success
     conditions:
-      - base=master
-      - status-success=Deck CI
       - 'label=ready to rebase'
       - 'label=self merge'
     actions:
-      merge:
+      queue:
         method: rebase
-        strict: smart
+        name: default
   - name: Automatically merge release branch changes on Travis CI success and release manager review
     conditions:
-      - base~=^release-
-      - status-success=Deck CI
       - 'label=ready to merge'
       - 'approved-reviews-by=@release-managers'
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
-  # This rule exists to handle release branches that are still building using Travis CI instead of
-  # using Github actions. It can be deleted once all active release branches are running Github actions.
-  - name: Automatically merge release branch changes on Travis CI success and release manager review
-    conditions:
-      - base~=^release-
-      - status-success=continuous-integration/travis-ci/pr
-      - 'label=ready to merge'
-      - 'approved-reviews-by=@release-managers'
-    actions:
-      merge:
-        method: squash
-        strict: smart
+        name: backport


### PR DESCRIPTION
The strict option is deprecated (brownout today). I think this config should be equivalent.