### PR TITLE
fix(core): ensure that users are not warned of their success

### DIFF
--- a/packages/core/src/pipeline/details/StageFailureMessage.tsx
+++ b/packages/core/src/pipeline/details/StageFailureMessage.tsx
@@ -74,7 +74,7 @@ export class StageFailureMessage extends React.Component<IStageFailureMessagePro
     const { message, messages, stage } = this.props;
     const { isFailed, failedTask, failedExecutionId, failedStageName, failedStageId } = this.state;
 
-    let stageMessages = message || !messages.length ? [message] : messages;
+    let stageMessages = message && !messages.length ? [message] : messages;
     if (stageMessages.length > 0) {
       const exceptionTitle = isFailed ? (messages.length ? 'Exceptions' : 'Exception') : 'Warning';
 


### PR DESCRIPTION
The ternary as written would allow a singleton list containing a single
`null` to propagate throughout the render method of this warning
message. This would result in a menacing "warning: no reason provided"
message appearing on all stage executions.

The assignment now states that a singleton list will only be provided
iff `message` is non null and the `messages` array is empty.