### PR TITLE
feat(core): HTML5 Routing

### DIFF
--- a/docker/spinnaker.conf.gen
+++ b/docker/spinnaker.conf.gen
@@ -1,5 +1,6 @@
 <VirtualHost {%DECK_HOST%}:{%DECK_PORT%}>
   DocumentRoot /opt/deck/html
+  FallbackResource /index.html
 
   ProxyPass "/gate" "{%API_HOST%}" retry=0
   ProxyPassReverse "/gate" "{%API_HOST%}"

--- a/docker/spinnaker.conf.ssl
+++ b/docker/spinnaker.conf.ssl
@@ -2,8 +2,9 @@
   SSLEngine on
   SSLCertificateFile "{%DECK_CERT_PATH%}"
   SSLCertificateKeyFile "{%DECK_KEY_PATH%}"
-  
+
   DocumentRoot /opt/deck/html
+  FallbackResource /index.html
 
   ProxyPass "/gate" "{%API_HOST%}" retry=0
   ProxyPassReverse "/gate" "{%API_HOST%}"

--- a/packages/app/index.deck
+++ b/packages/app/index.deck
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">
+  <base href="/">
 
   <!-- Sample loading styles -->
   <style>

--- a/packages/app/src/settings.js
+++ b/packages/app/src/settings.js
@@ -38,6 +38,7 @@ const gceScaleDownControlsEnabled =
   import.meta.env.VITE_GCE_SCALE_DOWN_CONTROLS_ENABLED === 'true' ||
   process.env.GCE_SCALE_DOWN_CONTROLS_ENABLED === 'true' ||
   false;
+const html5Routing = import.meta.env.VITE_HTML5_ROUTING === 'true' || process.env.HTML5_ROUTING === 'true' || false;
 const iapRefresherEnabled =
   import.meta.env.VITE_IAP_REFRESHER_ENABLED === 'true' || process.env.IAP_REFRESHER_ENABLED === 'true' || false;
 const managedDeliveryEnabled =
@@ -110,6 +111,7 @@ window.spinnakerSettings = {
     entityTags: entityTagsEnabled,
     executionMarkerInformationModal: false,
     fiatEnabled: fiatEnabled,
+    html5Routing: html5Routing,
     iapRefresherEnabled: iapRefresherEnabled,
     managedDelivery: managedDeliveryEnabled,
     mdGitIntegration: mdGitIntegrationEnabled,

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -186,6 +186,9 @@ function configure(env, webpackOpts) {
     devServer: {
       hot: true,
       disableHostCheck: true,
+      historyApiFallback: {
+        index: '/',
+      },
       port: process.env.DECK_PORT || 9000,
       host: process.env.DECK_HOST || 'localhost',
       https: process.env.DECK_HTTPS === 'true',

--- a/packages/core/src/bootstrap/angular.config.ts
+++ b/packages/core/src/bootstrap/angular.config.ts
@@ -35,6 +35,9 @@ bootstrapModule.config([
   '$locationProvider',
   ($locationProvider: ILocationProvider) => {
     $locationProvider.hashPrefix('');
-    $locationProvider.html5Mode({ enabled: false, rewriteLinks: false });
+    $locationProvider.html5Mode({
+      enabled: SETTINGS.feature.html5Routing,
+      rewriteLinks: false,
+    });
   },
 ]);


### PR DESCRIPTION
This adds configuration to enable HTML5 (aka path-based, not hash-based) routing for Deck.

The default remains unchanged, and is still hash-based.

To enable this feature:
- Add `window.spinnakerSettings.feature.html5Routing = true;` to your `settings-local.js` file.
- Or, set `HTML5_ROUTING=true` in your Deck container, in whichever way you prefer.