### PR TITLE
fix(scripts): update rollup-plugin-esbuild

### DIFF
--- a/packages/scripts/config/rollup.config.base.js
+++ b/packages/scripts/config/rollup.config.base.js
@@ -9,7 +9,7 @@ const svgr = require('@svgr/rollup').default;
 const autoPrefixer = require('autoprefixer');
 const postCssColorFix = require('postcss-colorfix');
 const postCssUrl = require('postcss-url');
-const esbuild = require('rollup-plugin-esbuild');
+const esbuild = require('rollup-plugin-esbuild').default;
 const { terser } = require('rollup-plugin-terser');
 const { visualizer } = require('rollup-plugin-visualizer');
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -29,7 +29,7 @@
     "postcss-colorfix": "0.0.5",
     "postcss-url": "9.0.0",
     "rollup": "^2.35.1",
-    "rollup-plugin-esbuild": "^4.5.0",
+    "rollup-plugin-esbuild": "^4.8.2",
     "rollup-plugin-external-globals": "0.6.1",
     "rollup-plugin-less": "1.1.3",
     "rollup-plugin-postcss": "3.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2721,7 +2721,7 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@rollup/pluginutils@^4.0.0", "@rollup/pluginutils@^4.1.0", "@rollup/pluginutils@^4.1.1":
+"@rollup/pluginutils@^4.0.0", "@rollup/pluginutils@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.1.1.tgz#1d4da86dd4eded15656a57d933fda2b9a08d47ec"
   integrity sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==
@@ -7261,6 +7261,11 @@ es-abstract@^1.10.0, es-abstract@^1.12.0, es-abstract@^1.17.0-next.1, es-abstrac
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
+
+es-module-lexer@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
+  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -14935,12 +14940,14 @@ rollup-plugin-copy@^3.4.0:
     globby "10.0.1"
     is-plain-object "^3.0.0"
 
-rollup-plugin-esbuild@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.5.0.tgz#0fbcb6d2d651d87dc540c4fc3b2db669f48da1f0"
-  integrity sha512-ieUd3AoYWsN6Tfp0LBNnC+QpdhKjDEaH4NK3ghuEXOH56/7TAtD+hMbD9vSWZgsGSbaqCkrn4j6PaUj1vOSt1g==
+rollup-plugin-esbuild@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.8.2.tgz#c097b93cd4b622e62206cadb5797589f548cf48c"
+  integrity sha512-wsaYNOjzTb6dN1qCIZsMZ7Q0LWiPJklYs2TDI8vJA2LUbvtPUY+17TC8C0vSat3jPMInfR9XWKdA7ttuwkjsGQ==
   dependencies:
-    "@rollup/pluginutils" "^4.1.0"
+    "@rollup/pluginutils" "^4.1.1"
+    debug "^4.3.3"
+    es-module-lexer "^0.9.3"
     joycon "^3.0.1"
     jsonc-parser "^3.0.0"
 


### PR DESCRIPTION
`rollup-plugin-esbuild` changed their exports in version 4.6.0, which meant any plugin that didn't explicitly pin it to `4.5.0` would fail to build. Bumping the version and fixing the import allows builds to succeed.

Thanks to @vigneshm for helping find the issue!