### PR TITLE
fix(cf): return credentials in an array

### DIFF
--- a/packages/cloudfoundry/src/pipeline/stages/runJob/cloudFoundryRunJob.module.ts
+++ b/packages/cloudfoundry/src/pipeline/stages/runJob/cloudFoundryRunJob.module.ts
@@ -5,7 +5,7 @@ import { CloudFoundryRunJobStageConfig } from './CloudFoundryRunJobStageConfig';
 import { RunJobExecutionDetails } from './RunJobExecutionDetails';
 
 Registry.pipeline.registerStage({
-  accountExtractor: (stage: IStage) => stage.context.credentials,
+  accountExtractor: (stage: IStage) => [stage.context.credentials],
   component: CloudFoundryRunJobStageConfig,
   configAccountExtractor: (stage: IStage) => [stage.credentials],
   cloudProvider: 'cloudfoundry',


### PR DESCRIPTION
Account extractor is [supposed to return an array](https://github.com/spinnaker/deck/blob/554367925d9111c88e04610adb1097236ce48646/packages/core/src/domain/IStageTypeConfig.ts#L10) but this stage returns a string, which breaks the execution history parsing in Deck.