### PR TITLE
Publish packages to NPM

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.2.1](https://github.com/spinnaker/deck/compare/deck-app@2.2.0...deck-app@2.2.1) (2022-03-04)
+
+**Note:** Version bump only for package deck-app
+
+
+
+
+
 # [2.2.0](https://github.com/spinnaker/deck/compare/deck-app@2.1.8...deck-app@2.2.0) (2022-01-22)
 
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deck-app",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@spinnaker/amazon": "^0.12.6",
     "@spinnaker/appengine": "^0.0.80",
-    "@spinnaker/cloudfoundry": "^0.0.167",
+    "@spinnaker/cloudfoundry": "^0.0.168",
     "@spinnaker/core": "^0.19.0",
     "@spinnaker/docker": "^0.0.126",
     "@spinnaker/ecs": "^0.0.342",

--- a/packages/cloudfoundry/CHANGELOG.md
+++ b/packages/cloudfoundry/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.168](https://github.com/spinnaker/deck/compare/@spinnaker/cloudfoundry@0.0.167...@spinnaker/cloudfoundry@0.0.168) (2022-03-04)
+
+
+### Bug Fixes
+
+* **cf:** return credentials in an array ([#9812](https://github.com/spinnaker/deck/issues/9812)) ([c96faa5](https://github.com/spinnaker/deck/commit/c96faa581482d251c07132bdcc023e04fc8e869b))
+
+
+
+
+
 ## [0.0.167](https://github.com/spinnaker/deck/compare/@spinnaker/cloudfoundry@0.0.166...@spinnaker/cloudfoundry@0.0.167) (2022-01-22)
 
 **Note:** Version bump only for package @spinnaker/cloudfoundry

--- a/packages/cloudfoundry/package.json
+++ b/packages/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.167",
+  "version": "0.0.168",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.

## app [2.2.1](https://github.com/spinnaker/deck/compare/deck-app@2.2.0...deck-app@2.2.1) (2022-03-04)

**Note:** Version bump only for package deck-app





## cloudfoundry [0.0.168](https://github.com/spinnaker/deck/compare/@spinnaker/cloudfoundry@0.0.167...@spinnaker/cloudfoundry@0.0.168) (2022-03-04)


### Bug Fixes

* **cf:** return credentials in an array ([#9812](https://github.com/spinnaker/deck/issues/9812)) ([c96faa5](https://github.com/spinnaker/deck/commit/c96faa581482d251c07132bdcc023e04fc8e869b))

---

This Pr bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_