### PR TITLE
fix(ci): Build yarn modules before building eslint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install Dependencies
         run: yarn --frozen-lockfile
+      - name: Build Modules
+        run: yarn modules
       - name: Eslint Plugin Build
         run: |
           cd packages/eslint-plugin
@@ -44,8 +46,6 @@ jobs:
         run: yarn lint
       - name: Assert - code is formatted
         run: yarn prettier:check
-      - name: Build Modules
-        run: yarn modules
       - name: Unit Tests
         run: yarn test --single-run
       - name: Functional Tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,8 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install Dependencies
         run: yarn --frozen-lockfile
+      - name: Build Modules
+        run: yarn modules
       - name: Eslint Plugin Build
         run: |
           cd packages/eslint-plugin
@@ -37,8 +39,6 @@ jobs:
         run: yarn lint
       - name: Assert - code is formatted
         run: yarn prettier:check
-      - name: Build Modules
-        run: yarn modules
       - name: Unit Tests
         run: yarn test --single-run
       - name: Functional Tests


### PR DESCRIPTION
Noticed in `release-1.27.x` branch PR CI that eslint was unable to be
built.
Building eslint's dependencies enabled it to run and PASS/FAIL tests.

```
Run cd packages/eslint-plugin
yarn run v1.22.17
$ /home/runner/work/deck/deck/node_modules/.bin/tsc
../../app/scripts/modules/app/src/app.ts:6:29 - error TS2307: Cannot find module '@spinnaker/core' or its corresponding type declarations.

6 import { CORE_MODULE } from '@spinnaker/core';
```