### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ env:
   CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
   NODE_VERSION: 12.16.0
 
+permissions:
+  contents: read
+
 jobs:
   branch-build:
     # Only run this on repositories in the 'spinnaker' org, not on forks.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,9 @@ env:
   CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
   NODE_VERSION: 12.16.0
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,13 @@ on:
 env:
   NODE_VERSION: 12.16.0
 
+permissions:
+  contents: read
+
 jobs:
   publish:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
