### PR TITLE
fix(core): apps always display as unconfigured

### DIFF
--- a/packages/core/src/application/config/applicationAttributes.directive.html
+++ b/packages/core/src/application/config/applicationAttributes.directive.html
@@ -1,4 +1,4 @@
-<dl class="dl-horizontal" ng-if="(config.application.attributes && config.application.attributes.email)">
+<dl class="dl-horizontal" ng-if="(vm.application.attributes && vm.application.attributes.email)">
   <dt>Owner</dt>
   <dd>{{vm.application.attributes.email}}</dd>
   <dt ng-if="vm.application.attributes.appGroup">App Group <help-field key="application.group"></help-field></dt>
@@ -55,11 +55,11 @@
     <dd>{{vm.permissions}}</dd>
   </render-if-feature>
 </dl>
-<p ng-if="(!config.application.attributes || !config.application.attributes.email)">
+<p ng-if="(!vm.application.attributes || !vm.application.attributes.email)">
   This application has not been configured.
 </p>
 <button class="btn btn-link" ng-click="vm.editApplication()">
   <span class="glyphicon glyphicon-cog"></span>
-  {{ (!config.application.attributes || !config.application.attributes.email) ? "Create Application" : "Edit Application
+  {{ (!vm.application.attributes || !vm.application.attributes.email) ? "Create Application" : "Edit Application
   Attributes"}}
 </button>


### PR DESCRIPTION
Applications in the config view always show up as unconfigured, fix the
broken reference to the controller so applications properly display
their attributes.

https://github.com/spinnaker/deck/blob/master/packages/core/src/application/config/applicationAttributes.directive.js#L31