### PR TITLE
Publish packages to NPM

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.2.6](https://github.com/spinnaker/deck/compare/deck-app@2.2.5...deck-app@2.2.6) (2022-05-13)
+
+**Note:** Version bump only for package deck-app
+
+
+
+
+
 ## [2.2.5](https://github.com/spinnaker/deck/compare/deck-app@2.2.4...deck-app@2.2.5) (2022-05-05)
 
 **Note:** Version bump only for package deck-app

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deck-app",
   "private": true,
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@spinnaker/amazon": "^0.12.10",
     "@spinnaker/appengine": "^0.0.84",
-    "@spinnaker/cloudfoundry": "^0.0.172",
+    "@spinnaker/cloudfoundry": "^0.0.173",
     "@spinnaker/core": "^0.19.4",
     "@spinnaker/docker": "^0.0.130",
     "@spinnaker/ecs": "^0.0.346",

--- a/packages/cloudfoundry/CHANGELOG.md
+++ b/packages/cloudfoundry/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.173](https://github.com/spinnaker/deck/compare/@spinnaker/cloudfoundry@0.0.172...@spinnaker/cloudfoundry@0.0.173) (2022-05-13)
+
+
+### Bug Fixes
+
+* **cf:** extract service name from context for execution details ([#9843](https://github.com/spinnaker/deck/issues/9843)) ([f8b704c](https://github.com/spinnaker/deck/commit/f8b704c831e4c90b3257740e93c214f74e9ee06f))
+
+
+
+
+
 ## [0.0.172](https://github.com/spinnaker/deck/compare/@spinnaker/cloudfoundry@0.0.171...@spinnaker/cloudfoundry@0.0.172) (2022-05-05)
 
 **Note:** Version bump only for package @spinnaker/cloudfoundry

--- a/packages/cloudfoundry/package.json
+++ b/packages/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.172",
+  "version": "0.0.173",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.

## app [2.2.6](https://github.com/spinnaker/deck/compare/deck-app@2.2.5...deck-app@2.2.6) (2022-05-13)

**Note:** Version bump only for package deck-app





## cloudfoundry [0.0.173](https://github.com/spinnaker/deck/compare/@spinnaker/cloudfoundry@0.0.172...@spinnaker/cloudfoundry@0.0.173) (2022-05-13)


### Bug Fixes

* **cf:** extract service name from context for execution details ([#9843](https://github.com/spinnaker/deck/issues/9843)) ([f8b704c](https://github.com/spinnaker/deck/commit/f8b704c831e4c90b3257740e93c214f74e9ee06f))

---

This PR bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_