### PR TITLE
feat(core): Synchronize the verticalNavExpandedAtom using an atom effect

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,7 +74,7 @@
     "react-virtualized": "9.18.5",
     "react-virtualized-select": "3.1.3",
     "react2angular": "3.2.1",
-    "recoil": "0.0.10",
+    "recoil": "0.7.2",
     "rxjs": "6.6.7",
     "select2": "3.5.1",
     "select2-bootstrap-css": "1.4.6",

--- a/packages/core/src/application/nav/navAtoms.ts
+++ b/packages/core/src/application/nav/navAtoms.ts
@@ -1,7 +1,25 @@
 import { atom } from 'recoil';
-import { CollapsibleSectionStateCache } from '../../cache/collapsibleSectionStateCache';
+import { CollapsibleSectionStateCache } from '../../cache';
 
 export const verticalNavExpandedAtom = atom({
   key: 'verticalNavExpanded',
   default: !CollapsibleSectionStateCache.isSet('verticalNav') || CollapsibleSectionStateCache.isExpanded('verticalNav'),
+  effects: [
+    ({ setSelf, trigger }) => {
+      if (trigger === 'get') {
+        // Avoid expensive initialization
+        setSelf(
+          !CollapsibleSectionStateCache.isSet('verticalNav') || CollapsibleSectionStateCache.isExpanded('verticalNav'),
+        );
+      }
+      CollapsibleSectionStateCache.onChange('verticalNav', (expanded: boolean) => {
+        setSelf(expanded);
+      });
+
+      return () => {
+        // clean up
+        CollapsibleSectionStateCache.onChange('verticalNav', null);
+      };
+    },
+  ],
 });

--- a/packages/core/src/cache/collapsibleSectionStateCache.ts
+++ b/packages/core/src/cache/collapsibleSectionStateCache.ts
@@ -5,6 +5,7 @@ export class CollapsibleSectionStateCacheInternal {
   private cacheFactory = new CacheFactory();
   private cacheId = 'collapsibleSectionStateCache';
   private stateCache: Cache;
+  private handlers = new Map();
 
   constructor() {
     try {
@@ -31,6 +32,16 @@ export class CollapsibleSectionStateCacheInternal {
   public setExpanded(heading: string, expanded: boolean) {
     if (heading) {
       this.stateCache.put(heading, !!expanded);
+      const handler = this.handlers.get(heading);
+      if (handler) {
+        handler(!CollapsibleSectionStateCache.isSet(heading) || CollapsibleSectionStateCache.isExpanded(heading));
+      }
+    }
+  }
+
+  public onChange(heading: string, listener: Function) {
+    if (!this.handlers.get(heading)) {
+      this.handlers.set(heading, listener);
     }
   }
 }


### PR DESCRIPTION
Introduce an atom effect which is registering as a listener to CollapsibleSectionStateCache. If there is a listener for the key, the handler function will be called to update the atom value