### PR TITLE
fix(aws): Fix Create Server Group button

### DIFF
--- a/packages/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/packages/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -65,8 +65,10 @@ angular
     ) {
       function buildNewServerGroupCommand(
         application: Application,
-        defaults: { account?: string; region?: string; subnet?: string; mode?: string } = {},
+        defaults: { account?: string; region?: string; subnet?: string; mode?: string },
       ) {
+        defaults = defaults || {};
+
         const credentialsLoader = AccountService.getCredentialsKeyedByAccount('aws');
 
         const defaultCredentials =


### PR DESCRIPTION
This line `defaults: { account?: string; region?: string; subnet?: string; mode?: string } = {}` was not creating an empty object when `buildNewServerGroupCommand()` was being called, causing `defaults` to be `null` and break the whole function. 

This adds the manual check and sets `defaults` to empty `{}`if it's null or undefined.