### PR TITLE
perf(pipelinegraph): Improve the performance of the pipeline graph rendering 

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "lodash": "4.17.21",
     "lodash-decorators": "4.5.0",
     "luxon": "1.23.0",
-    "memoize-one": "4.0.2",
+    "memoize-one": "6.0.0",
     "ngimport": "0.6.1",
     "prop-types": "15.6.1",
     "react": "16.14.0",

--- a/packages/core/src/pipeline/config/graph/PipelineGraph.tsx
+++ b/packages/core/src/pipeline/config/graph/PipelineGraph.tsx
@@ -117,7 +117,19 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
     if (!node.children.length) {
       return node.phase;
     }
-    return max(node.children.map((n) => this.getLastPhase(n)));
+    const result: number[] = [];
+    this.collect(node.children, result);
+    return max(result);
+  }
+
+  private collect(nodes: IPipelineGraphNode[], result: number[]) {
+    nodes.forEach((node) => {
+      if (node.children.length) {
+        this.collect(node.children, result);
+      } else {
+        result.push(node.phase);
+      }
+    });
   }
 
   private createNodes(props: IPipelineGraphProps): IPipelineGraphNode[] {
@@ -574,7 +586,7 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
                   </a>
                 </p>
               )}
-              {/* The SVG and Placholder elements need to be in the DOM even 
+              {/* The SVG and Placholder elements need to be in the DOM even
               when minimized because applyNodeHeights needs the width values */}
               <svg
                 className="pipeline-graph"

--- a/packages/core/src/pipeline/config/stages/stage.html
+++ b/packages/core/src/pipeline/config/stages/stage.html
@@ -16,7 +16,7 @@
           style="width: 250px"
           class="form-control input-sm"
           autofocus
-          on-select="stageConfigCtrl.selectStageType($item)"
+          onselect="stageConfigCtrl.selectStageType($item)"
         >
           <ui-select-match>
             <strong>{{$select.selected.label}}</strong>

--- a/packages/core/src/pipeline/config/stages/stage.module.js
+++ b/packages/core/src/pipeline/config/stages/stage.module.js
@@ -1,7 +1,8 @@
 'use strict';
 
 import { module } from 'angular';
-import { defaultsDeep, extend, omit, union } from 'lodash';
+import { defaultsDeep, extend, isEqual, omit, union } from 'lodash';
+import memoizeOne from 'memoize-one';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -111,12 +112,12 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
           $scope.stage.expectedArtifacts = artifacts;
         });
       };
-
+      const memoizedGetDependencyCandidateStages = memoizeOne(
+        PipelineConfigService.getDependencyCandidateStages,
+        isEqual,
+      );
       $scope.updateAvailableDependencyStages = function () {
-        const availableDependencyStages = PipelineConfigService.getDependencyCandidateStages(
-          $scope.pipeline,
-          $scope.stage,
-        );
+        const availableDependencyStages = memoizedGetDependencyCandidateStages($scope.pipeline, $scope.stage);
         $scope.options.dependencies = availableDependencyStages.map(function (stage) {
           return {
             name: stage.name,


### PR DESCRIPTION
Change how the downstream stages are computed: 

- In the current implementation, the recursive method `PipelineConfigService.getDownstreamStageIds` filtered the complete stages list on every call. The process was slow when dealing with many stages and links between them. 

- With my implementation, I group the list of stages into a `map`. The map's key is the child ref id, and the value is an array containing the child's parents. 
With this approach, retrieval/searching is much faster than the list filtering on each call of the recursive function. 

I also decided to memoize the result of the getDependencyCandidateStages (in stage.module.js). I did it because the method is called four times (with the same input) when clicking on a stage. 
