### PR TITLE
chore(gha): Fix bump packages script

### DIFF
--- a/scripts/gha_bump_packages.sh
+++ b/scripts/gha_bump_packages.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
 cd "$SCRIPT_DIR/.."
 
 # bump versions of packages
-npx lerna version --yes --no-push --conventional-commits -m $PACKAGE_BUMP_COMMIT_MSG
+npx lerna version --yes --no-push --conventional-commits -m "$PACKAGE_BUMP_COMMIT_MSG"
 if [[ $(git rev-list --count @{u}..HEAD) -ne 0 ]] ; then
   # Synchronize @spinnaker/pluginsdk-peerdeps
   cd packages/pluginsdk-peerdeps
@@ -25,5 +25,5 @@ if [[ $(git rev-list --count @{u}..HEAD) -ne 0 ]] ; then
   git commit -m "feat(peerdep-sync): Synchronize peerdependencies"
 
   # bump version of @spinnaker/pluginsdk-peerdeps
-  npx lerna version --yes --no-push --conventional-commits -m $PEERDEP_BUMP_COMMIT_MSG
+  npx lerna version --yes --no-push --conventional-commits -m "$PEERDEP_BUMP_COMMIT_MSG"
 fi

--- a/scripts/gha_common.sh
+++ b/scripts/gha_common.sh
@@ -11,6 +11,6 @@ export PACKAGE_BUMP_COMMIT_HASH=""
 export PEERDEP_BUMP_COMMIT_HASH=""
 
 function updateBumpHashes() {
-  export PACKAGE_BUMP_COMMIT_HASH=$(git log -1 --grep=$PACKAGE_BUMP_COMMIT_MSG --format=%H)
-  export PEERDEP_BUMP_COMMIT_HASH=$(git log -1 --grep=$PEERDEP_BUMP_COMMIT_MSG --format=%H)
+  export PACKAGE_BUMP_COMMIT_HASH=$(git log -1 --grep="$PACKAGE_BUMP_COMMIT_MSG" --format=%H)
+  export PEERDEP_BUMP_COMMIT_HASH=$(git log -1 --grep="$PEERDEP_BUMP_COMMIT_MSG" --format=%H)
 }

--- a/scripts/gha_output_bumped_packages.sh
+++ b/scripts/gha_output_bumped_packages.sh
@@ -10,10 +10,10 @@ cd "$SCRIPT_DIR/.."
 updateBumpHashes()
 
 if [ ! -z "$PACKAGE_BUMP_COMMIT_HASH" ]; then
-  BUMPS=$(git log -1 $PACKAGE_BUMP_COMMIT_HASH --pretty=%B | grep "^ - " | sed -e 's/^ - //' -e 's/^@spinnaker\///');
+  BUMPS=$(git log -1 "$PACKAGE_BUMP_COMMIT_HASH" --pretty=%B | grep "^ - " | sed -e 's/^ - //' -e 's/^@spinnaker\///');
 
   if [ ! -z "$PEERDEP_BUMP_COMMIT_HASH" ]; then
-    BUMPS+=$(git log -1 $PEERDEP_BUMP_COMMIT_HASH --pretty=%B | grep "^ - " | sed -e 's/^ - //' -e 's/^@spinnaker\///');
+    BUMPS+=$(git log -1 "$PEERDEP_BUMP_COMMIT_HASH" --pretty=%B | grep "^ - " | sed -e 's/^ - //' -e 's/^@spinnaker\///');
   fi
 
   echo ::set-output name=bumps::${BUMPS}

--- a/scripts/gha_output_changelog.sh
+++ b/scripts/gha_output_changelog.sh
@@ -11,7 +11,7 @@ cd "$SCRIPT_DIR/.."
 function changelog() {
   hash=$1
 
-  git diff -u $hash packages/*/CHANGELOG.md  | \
+  git diff -u "$hash" packages/*/CHANGELOG.md  | \
     # Only process added or changed lines
     grep "^\+" | \
     # Remove the leading + characters from 'diff -u'


### PR DESCRIPTION
The script logged an error,

> ERR! lerna bump must be an explicit version string _or_ one of: 'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', or 'prerelease'.

Testing locally found this was because the commit message had the word publish in it and lerna was trying to treat it as a command.

Quoting all variables resolved the issue locally.