### PR TITLE
Fix(core/pipelines): Fix syntax error on ui-select causing stage configuration to not load

### DIFF
--- a/packages/core/src/pipeline/config/stages/stage.html
+++ b/packages/core/src/pipeline/config/stages/stage.html
@@ -16,7 +16,7 @@
           style="width: 250px"
           class="form-control input-sm"
           autofocus
-          onselect="stageConfigCtrl.selectStageType($item)"
+          on-select="stageConfigCtrl.selectStageType($item)"
         >
           <ui-select-match>
             <strong>{{$select.selected.label}}</strong>


### PR DESCRIPTION
Small change:
* Changed `ui-select` property from "onselect" to "on-select". This was changed about a month ago and seems to cause stage configurations to not render when a new stage is selected. Based on the ui-select documentation the actual property is meant to be "on-select" and this is likely what caused it to break.

Similarly, ui-select tags use "on-select" everywhere else in the repo.
Example: 
![Screen Shot 2022-09-09 at 3 08 46 pm](https://user-images.githubusercontent.com/75234625/189275960-7cb1911c-b87c-4b33-9aa8-632388ae27d9.png)

