### PR TITLE
chore(dependencies): Updating Formik in @spinnaker/presentation

### DIFF
--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -26,7 +26,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "formik": "^1.4.1"
+    "formik": "2.2.9"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8872,7 +8872,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formik@1.5.1, formik@^1.4.1:
+formik@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/formik/-/formik-1.5.1.tgz#ef5687e1ade5b1fe5f1d51435b422238aad107e9"
   integrity sha512-FBWGBKQkcCE4d5b5l2fKccD9d1QxNxw/0bQTRvp3EjzA8Bnjmsm9H/Oy0375UA8P3FPmfJkF4cXLLdEqK7fP5A==
@@ -8886,6 +8886,19 @@ formik@1.5.1, formik@^1.4.1:
     react-fast-compare "^2.0.1"
     tiny-warning "^1.0.2"
     tslib "^1.9.3"
+
+formik@2.2.9:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.9.tgz#8594ba9c5e2e5cf1f42c5704128e119fc46232d0"
+  integrity sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -12009,7 +12022,7 @@ lodash-es@4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
-lodash-es@^4.17.11, lodash-es@^4.2.1:
+lodash-es@^4.17.11, lodash-es@^4.17.21, lodash-es@^4.2.1:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==


### PR DESCRIPTION
Bumping Formik in Presentation module to address Lodash vulnerability

See:
https://snyk.io/vuln/SNYK-JS-LODASH-567746

Note:
Other modules might also have this vulnerability, but I had difficulty patching them due to Formik migrating to functional components and it interfering with usage of SpinFormik component in other modules (I'm not very prolific in front-end). However, this is not the case in the presentation module. 

If anyone fancys giving that a go at least in the core module that would be much appreciated!
