### PR TITLE
fix(search): Error thrown when search version 2 is enabled

### DIFF
--- a/packages/core/src/navigation/UrlBuilder.ts
+++ b/packages/core/src/navigation/UrlBuilder.ts
@@ -89,7 +89,7 @@ class UrlBuilderUtils {
       });
     });
 
-    if (parts.length > 0) {
+    if (parts.length > 0 && url) {
       url += (url.includes('?') ? '&' : '?') + parts.join('&');
     }
 

--- a/packages/core/src/search/infrastructure/infrastructureSearchV2.service.ts
+++ b/packages/core/src/search/infrastructure/infrastructureSearchV2.service.ts
@@ -38,7 +38,7 @@ export class InfrastructureSearchServiceV2 {
     const makeResultSet = (searchResults: ISearchResults<any>, type: SearchResultType): ISearchResultSet => {
       // Add URLs to each search result (discard duplicate results)
       const results = uniqBy(
-        searchResults.results.map((result) => addComputedAttributes(result, type)),
+        searchResults.results.map((result) => addComputedAttributes(result, type)).filter((r) => r.href),
         (r) => r.href,
       );
       const query: string = apiParams.key as string;


### PR DESCRIPTION
For some results, when building the URL in `UrlBuilderUtils.buildUrl` an error is thrown when the URL is undefined.

If there is no URL value, we should try to build the href URL. 

Current behavior 
![current](https://user-images.githubusercontent.com/105648914/190625746-5e4a8e6d-ebc0-402d-abbe-69e5bb5250c8.gif)

Behavior after fix

![fix](https://user-images.githubusercontent.com/105648914/190626012-af3e3862-f95a-4ef0-b21d-41467a22f6b7.gif)
