### PR TITLE
fix(core): Do not set static document base URL

### DIFF
--- a/packages/app/index.deck
+++ b/packages/app/index.deck
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">
-  <base href="/">
 
   <!-- Sample loading styles -->
   <style>

--- a/packages/core/src/bootstrap/angular.config.ts
+++ b/packages/core/src/bootstrap/angular.config.ts
@@ -35,6 +35,7 @@ bootstrapModule.config([
     $locationProvider.html5Mode({
       enabled: SETTINGS.feature.html5Routing,
       rewriteLinks: false,
+      requireBase: false,
     });
   },
 ]);


### PR DESCRIPTION
The previous change to enable optional path-based routing (#9802) added a `<base>` tag, which regressed serving hash-based routing at non-root public paths.

This change returns to AngularJS's default behavior when using hash-based routing.  Note that path-based routing will continue to only function when served from a domain root.

Resolves spinnaker/spinnaker#6723
