### PR TITLE
feat(kubernetes): Introduce blue/green traffic management strategy

### DIFF
--- a/packages/kubernetes/src/pipelines/stages/deployManifest/ManifestDeploymentOptions.spec.tsx
+++ b/packages/kubernetes/src/pipelines/stages/deployManifest/ManifestDeploymentOptions.spec.tsx
@@ -49,5 +49,27 @@ describe('<ManifestDeploymentOptions />', () => {
       wrapper = shallow(<ManifestDeploymentOptions {...props} />);
       expect(wrapper.find('input[type="checkbox"]').at(1).props().disabled).toEqual(true);
     });
+    it('disables the traffic checkbox when blue/green rollout strategy is selected', () => {
+      props.config.options.strategy = 'bluegreen';
+      wrapper = shallow(<ManifestDeploymentOptions {...props} />);
+      expect(wrapper.find('input[type="checkbox"]').at(1).props().disabled).toEqual(true);
+    });
+
+    it('strategy bluegreen should not display warning label', () => {
+      props.config.options.strategy = 'bluegreen';
+      wrapper = shallow(<ManifestDeploymentOptions {...props} />);
+      expect(wrapper.find('p[id="redBlackWarning"]').exists()).toEqual(false);
+    });
+    it('strategy highlander should not display warning label', () => {
+      props.config.options.strategy = 'highlander';
+      wrapper = shallow(<ManifestDeploymentOptions {...props} />);
+      expect(wrapper.find('p[id="redBlackWarning"]').exists()).toEqual(false);
+    });
+
+    it('strategy redblack should display warning label', () => {
+      props.config.options.strategy = 'redblack';
+      wrapper = shallow(<ManifestDeploymentOptions {...props} />);
+      expect(wrapper.find('p[id="redBlackWarning"]').exists()).toEqual(true);
+    });
   });
 });

--- a/packages/kubernetes/src/rolloutStrategy/bluegreen.strategy.ts
+++ b/packages/kubernetes/src/rolloutStrategy/bluegreen.strategy.ts
@@ -1,7 +1,7 @@
 import type { IDeploymentStrategy } from '@spinnaker/core';
 
-export const strategyRedBlack: IDeploymentStrategy = {
-  label: 'Red/Black (Deprecated)',
+export const strategyBlueGreen: IDeploymentStrategy = {
+  label: 'Blue/Green',
   description: 'Disables <i>all</i> previous ReplicaSets in the cluster as soon as the new ReplicaSet is ready',
-  key: 'redblack',
+  key: 'bluegreen',
 };

--- a/packages/kubernetes/src/rolloutStrategy/index.ts
+++ b/packages/kubernetes/src/rolloutStrategy/index.ts
@@ -1,5 +1,6 @@
+import { strategyBlueGreen } from './bluegreen.strategy';
 import { strategyHighlander } from './highlander.strategy';
 import { strategyNone } from './none.strategy';
 import { strategyRedBlack } from './redblack.strategy';
 
-export const rolloutStrategies = [strategyNone, strategyRedBlack, strategyHighlander];
+export const rolloutStrategies = [strategyNone, strategyRedBlack, strategyHighlander, strategyBlueGreen];


### PR DESCRIPTION
Introduce blue/green strategy as this is a terminology used more often in the industry compared to the Neflix-specific phrasing Display a warning label if red/black is selected from the dropdown

**Red/Black** selection displays a warning label and **blue/green** is selected instead

![image](https://user-images.githubusercontent.com/105648914/201656324-d27256d3-7e2f-4eef-9302-69b81eb0b62e.png)

For any other selection, there is no warning label displayed
![image](https://user-images.githubusercontent.com/105648914/201656510-c5792a30-8753-4305-87fc-6d93de29b6f5.png)
![image](https://user-images.githubusercontent.com/105648914/201656556-a893bcb0-551d-4b21-84a7-4f3ccd78b3d7.png)

Relates to: 
https://github.com/spinnaker/clouddriver/pull/5811
https://github.com/spinnaker/orca/pull/4332
https://github.com/spinnaker/front50/pull/1176