### PR TITLE
feat(core/pipeline): Add missing flag `skipDownstreamOutput` in pipeline stage

### DIFF
--- a/packages/core/src/help/help.contents.ts
+++ b/packages/core/src/help/help.contents.ts
@@ -470,6 +470,8 @@ const helpContents: { [key: string]: string } = {
       Typing into this verification field is annoying! But it serves as a reminder that you are
       changing something in an account deemed important, and prevents you from accidentally changing something
       when you meant to click on the "Cancel" button.`,
+  'pipeline.skipDownstreamOutput':
+    'when checked, the output of the child pipeline is not added to the pipeline context',
   'pipeline.waitForCompletion':
     'if unchecked, marks the stage as successful right away without waiting for the pipeline to complete',
   'jenkins.waitForCompletion':

--- a/packages/core/src/pipeline/config/stages/pipeline/pipelineStage.html
+++ b/packages/core/src/pipeline/config/stages/pipeline/pipelineStage.html
@@ -105,6 +105,9 @@
       </div>
     </div>
   </div>
+  <stage-config-field label="Skip downstream output" help-key="pipeline.skipDownstreamOutput">
+    <input type="checkbox" class="input-sm" name="skipDownstreamOutput" ng-model="stage.skipDownstreamOutput" />
+  </stage-config-field>
   <stage-config-field label="Wait for results" help-key="pipeline.waitForCompletion">
     <input type="checkbox" class="input-sm" name="waitForCompletion" ng-model="stage.waitForCompletion" />
   </stage-config-field>


### PR DESCRIPTION
The https://github.com/spinnaker/orca/pull/3989 introduced a flag to opt-out from passing outputs to child executions. 

However, Deck does not provide any option to select this flag from the UI. 

This PR adds a new checkbox to select if skipping the output from child pipelines in the pipeline stage config settings.

<img width="1806" alt="image" src="https://user-images.githubusercontent.com/20127271/207667633-31d627c0-9d3f-477b-8b6f-a76d42f87154.png">

The checkbox is disabled by default for backward compatibility and the field `skipDownstreamOutput` is not set unless the user selects the checkbox.

<img width="488" alt="image" src="https://user-images.githubusercontent.com/20127271/207668356-c5d140f8-ab92-44ee-8da1-4157025f6506.png">
