### PR TITLE
fix(azure): Register Azure Bake Execution Details Controller

### DIFF
--- a/packages/azure/src/pipeline/stages/bake/azureBakeStage.js
+++ b/packages/azure/src/pipeline/stages/bake/azureBakeStage.js
@@ -13,6 +13,7 @@ import {
   SETTINGS,
 } from '@spinnaker/core';
 
+import { AZURE_PIPELINE_STAGES_BAKE_BAKEEXECUTIONDETAILS_CONTROLLER } from './bakeExecutionDetails.controller';
 import { AZURE_IMAGE_IMAGE_READER } from '../../../image/image.reader';
 import { AZURE_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER_SERVICE } from './../../../serverGroup/configure/serverGroupCommandBuilder.service';
 
@@ -21,6 +22,7 @@ export const name = AZURE_PIPELINE_STAGES_BAKE_AZUREBAKESTAGE; // for backwards 
 module(AZURE_PIPELINE_STAGES_BAKE_AZUREBAKESTAGE, [
   AZURE_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER_SERVICE,
   AZURE_IMAGE_IMAGE_READER,
+  AZURE_PIPELINE_STAGES_BAKE_BAKEEXECUTIONDETAILS_CONTROLLER,
 ])
   .config(function () {
     Registry.pipeline.registerStage({


### PR DESCRIPTION
Deck was throwing an error when clicking on the Azure Bake details and the details were blank. Console error:

```
Error: [$controller:ctrlreg] The controller with the name 'azureBakeExecutionDetailsCtrl' is not registered.
https://errors.angularjs.org/1.8.0/$controller/ctrlreg?p0=azureBakeExecutionDetailsCtrl
    at angular.js:138:1
    at $controller (angular.js:11745:1)
    at setupControllers (angular.js:10776:1)
    at nodeLinkFn (angular.js:10561:1)
    at compositeLinkFn (angular.js:9900:1)
    at publicLinkFn (angular.js:9765:1)
    at Object.link (angular.js:29889:1)
    at angular.js:1391:1
    at invokeLinkFn (angular.js:11334:1)
    at nodeLinkFn (angular.js:10653:1) '<div ng-include="$ctrl.sourceUrl" class="ng-scope">'
```

After applying this fix, the details are shown:
![image](https://user-images.githubusercontent.com/9091122/210441474-5531f236-5fe4-41a4-ba4c-c1458a5b8193.png)
