### PR TITLE
fix(deck): Apache user should own the settings-local.js file, not spi…

### DIFF
--- a/docker/run-apache2.sh
+++ b/docker/run-apache2.sh
@@ -78,6 +78,8 @@ fi
 if [ -e /opt/spinnaker/config/settings-local.js ];
 then 
 	cp /opt/spinnaker/config/settings-local.js /opt/deck/html/settings-local.js
+	# Apache user must be the owner of settings-local.js file, not spinnaker user, so that it can display custom profiles features on Deck UI
+	chown www-data /opt/deck/html/settings-local.js
 fi
 
 if [ -e /opt/spinnaker/config/plugin-manifest.json ];


### PR DESCRIPTION
When we enable AWS EC2 Launch templates using custom profiles([Enabling Launch Templates](https://spinnaker.io/docs/setup/other_config/server-group-launch-settings/aws-ec2/launch-templates-setup/)), DeckUI is not displaying the additional features mentioned in `settings-local.js` file because the Apache user `www-data` does not have the necessary permissions on that file.The file `settings.js` has the appropriate permissions.

Please refer to the screenshot below,

<img width="638" alt="image" src="https://user-images.githubusercontent.com/50112467/215169782-1575a60b-285d-4df5-9990-91efbb9c7853.png">


This change is related to https://github.com/spinnaker/spinnaker/issues/6771
