### PR TITLE
fix(core): Missing config elements after Angular 1.8 update

### DIFF
--- a/packages/core/src/widgets/accountNamespaceClusterSelector.component.js
+++ b/packages/core/src/widgets/accountNamespaceClusterSelector.component.js
@@ -25,74 +25,76 @@ module(CORE_WIDGETS_ACCOUNTNAMESPACECLUSTERSELECTOR_COMPONENT, []).directive(
       templateUrl: require('./accountNamespaceClusterSelector.component.html'),
       controllerAs: 'vm',
       controller: function controller() {
-        this.clusterField = this.clusterField || 'cluster';
+        this.$onInit = () => {
+          this.clusterField = this.clusterField || 'cluster';
 
-        const vm = this;
-        let isTextInputForClusterFiled;
+          const vm = this;
+          let isTextInputForClusterFiled;
 
-        let namespaces;
+          let namespaces;
 
-        const setNamespaceList = () => {
-          const accountFilter = (cluster) => (cluster ? cluster.account === vm.component.credentials : true);
-          // TODO(lwander): Move away from regions to namespaces here.
-          const namespaceList = AppListExtractor.getRegions([vm.application], accountFilter);
-          vm.namespaces = namespaceList.length ? namespaceList : namespaces;
-        };
+          const setNamespaceList = () => {
+            const accountFilter = (cluster) => (cluster ? cluster.account === vm.component.credentials : true);
+            // TODO(lwander): Move away from regions to namespaces here.
+            const namespaceList = AppListExtractor.getRegions([vm.application], accountFilter);
+            vm.namespaces = namespaceList.length ? namespaceList : namespaces;
+          };
 
-        const setClusterList = () => {
-          const namespaceField = vm.component.namespaces;
-          // TODO(lwander): Move away from regions to namespaces here.
-          const clusterFilter = AppListExtractor.clusterFilterForCredentialsAndRegion(
-            vm.component.credentials,
-            namespaceField,
-          );
-          vm.clusterList = AppListExtractor.getClusters([vm.application], clusterFilter);
-        };
+          const setClusterList = () => {
+            const namespaceField = vm.component.namespaces;
+            // TODO(lwander): Move away from regions to namespaces here.
+            const clusterFilter = AppListExtractor.clusterFilterForCredentialsAndRegion(
+              vm.component.credentials,
+              namespaceField,
+            );
+            vm.clusterList = AppListExtractor.getClusters([vm.application], clusterFilter);
+          };
 
-        vm.namespaceChanged = () => {
-          setClusterList();
-          if (!isTextInputForClusterFiled && !_.includes(vm.clusterList, vm.component[this.clusterField])) {
+          vm.namespaceChanged = () => {
+            setClusterList();
+            if (!isTextInputForClusterFiled && !_.includes(vm.clusterList, vm.component[this.clusterField])) {
+              vm.component[this.clusterField] = undefined;
+            }
+          };
+
+          const setToggledState = () => {
+            vm.namespaces = namespaces;
+            isTextInputForClusterFiled = true;
+          };
+
+          const setUnToggledState = () => {
             vm.component[this.clusterField] = undefined;
-          }
-        };
+            isTextInputForClusterFiled = false;
+            setNamespaceList();
+          };
 
-        const setToggledState = () => {
-          vm.namespaces = namespaces;
-          isTextInputForClusterFiled = true;
-        };
+          vm.clusterSelectInputToggled = (isToggled) => {
+            isToggled ? setToggledState() : setUnToggledState();
+          };
 
-        const setUnToggledState = () => {
-          vm.component[this.clusterField] = undefined;
-          isTextInputForClusterFiled = false;
-          setNamespaceList();
-        };
+          vm.accountUpdated = () => {
+            vm.component[this.clusterField] = undefined;
+            setNamespaceList();
+            setClusterList();
+          };
 
-        vm.clusterSelectInputToggled = (isToggled) => {
-          isToggled ? setToggledState() : setUnToggledState();
-        };
+          const init = () => {
+            AccountService.getUniqueAttributeForAllAccounts(vm.component.cloudProviderType, 'namespaces')
+              .then((allNamespaces) => {
+                namespaces = allNamespaces;
+                return allNamespaces;
+              })
+              .then((allNamespaces) => {
+                setNamespaceList();
+                setClusterList();
+                vm.namespaces = _.includes(vm.clusterList, vm.component[this.clusterField])
+                  ? vm.namespaces
+                  : allNamespaces;
+              });
+          };
 
-        vm.accountUpdated = () => {
-          vm.component[this.clusterField] = undefined;
-          setNamespaceList();
-          setClusterList();
+          init();
         };
-
-        const init = () => {
-          AccountService.getUniqueAttributeForAllAccounts(vm.component.cloudProviderType, 'namespaces')
-            .then((allNamespaces) => {
-              namespaces = allNamespaces;
-              return allNamespaces;
-            })
-            .then((allNamespaces) => {
-              setNamespaceList();
-              setClusterList();
-              vm.namespaces = _.includes(vm.clusterList, vm.component[this.clusterField])
-                ? vm.namespaces
-                : allNamespaces;
-            });
-        };
-
-        init();
       },
     };
   },

--- a/packages/core/src/widgets/accountRegionClusterSelector.component.js
+++ b/packages/core/src/widgets/accountRegionClusterSelector.component.js
@@ -2,6 +2,7 @@
 
 import { module } from 'angular';
 import _ from 'lodash';
+import { $log } from 'ngimport';
 
 import { AccountService } from '../account/AccountService';
 import { AppListExtractor } from '../application/listExtractor/AppListExtractor';
@@ -27,104 +28,106 @@ module(CORE_WIDGETS_ACCOUNTREGIONCLUSTERSELECTOR_COMPONENT, []).directive('accou
     templateUrl: require('./accountRegionClusterSelector.component.html'),
     controllerAs: 'vm',
     controller: function controller() {
-      this.clusterField = this.clusterField || 'cluster';
+      this.$onInit = () => {
+        this.clusterField = this.clusterField || 'cluster';
 
-      const vm = this;
+        const vm = this;
 
-      if (vm.showClusterSelect === undefined) {
-        vm.showClusterSelect = true;
-      }
+        if (vm.showClusterSelect === undefined) {
+          vm.showClusterSelect = true;
+        }
 
-      const showAllRegions = vm.showAllRegions || false;
+        const showAllRegions = vm.showAllRegions || false;
 
-      let isTextInputForClusterFiled;
+        let isTextInputForClusterFiled;
 
-      let regions;
+        let regions;
 
-      const setRegionList = () => {
-        const accountFilter = (cluster) => (cluster ? cluster.account === vm.component.credentials : true);
-        const regionList = AppListExtractor.getRegions([vm.application], accountFilter);
-        vm.regions = showAllRegions ? regions : regionList.length ? regionList : regions;
-        (vm.regions || []).sort();
-      };
+        const setRegionList = () => {
+          const accountFilter = (cluster) => (cluster ? cluster.account === vm.component.credentials : true);
+          const regionList = AppListExtractor.getRegions([vm.application], accountFilter);
+          vm.regions = showAllRegions ? regions : regionList.length ? regionList : regions;
+          (vm.regions || []).sort();
+        };
 
-      const setClusterList = () => {
-        const regionField = this.singleRegion ? vm.component.region : vm.component.regions;
-        const clusterFilter = AppListExtractor.clusterFilterForCredentialsAndRegion(
-          vm.component.credentials,
-          regionField,
-        );
-        vm.clusterList = AppListExtractor.getClusters([vm.application], clusterFilter);
-      };
+        const setClusterList = () => {
+          const regionField = this.singleRegion ? vm.component.region : vm.component.regions;
+          const clusterFilter = AppListExtractor.clusterFilterForCredentialsAndRegion(
+            vm.component.credentials,
+            regionField,
+          );
+          vm.clusterList = AppListExtractor.getClusters([vm.application], clusterFilter);
+        };
 
-      vm.regionChanged = () => {
-        setClusterList();
-        if (!isTextInputForClusterFiled && !_.includes(vm.clusterList, vm.component[this.clusterField])) {
+        vm.regionChanged = () => {
+          setClusterList();
+          if (!isTextInputForClusterFiled && !_.includes(vm.clusterList, vm.component[this.clusterField])) {
+            vm.component[this.clusterField] = undefined;
+          }
+        };
+
+        const setToggledState = () => {
+          vm.regions = regions;
+          isTextInputForClusterFiled = true;
+        };
+
+        const setUnToggledState = () => {
           vm.component[this.clusterField] = undefined;
-        }
+          isTextInputForClusterFiled = false;
+          setRegionList();
+        };
+
+        vm.clusterSelectInputToggled = (isToggled) => {
+          isToggled ? setToggledState() : setUnToggledState();
+        };
+
+        vm.clusterChanged = (clusterName) => {
+          const filterByCluster = AppListExtractor.monikerClusterNameFilter(clusterName);
+          const clusterMoniker = _.first(_.uniq(AppListExtractor.getMonikers([vm.application], filterByCluster)));
+          if (_.isNil(clusterMoniker)) {
+            //remove the moniker from the stage if one doesn't exist.
+            vm.component.moniker = undefined;
+          } else {
+            //clusters don't contain sequences, so null it out.
+            clusterMoniker.sequence = null;
+            vm.component.moniker = clusterMoniker;
+          }
+        };
+
+        vm.accountUpdated = () => {
+          vm.component[this.clusterField] = undefined;
+          setRegionList();
+          setClusterList();
+          if (vm.onAccountUpdate) {
+            vm.onAccountUpdate();
+          }
+        };
+
+        const init = () => {
+          AccountService.getUniqueAttributeForAllAccounts(vm.component.cloudProviderType, 'regions')
+            .then((allRegions) => {
+              regions = allRegions;
+
+              // TODO(duftler): Remove this once we finish deprecating the old style regions/zones in clouddriver GCE credentials.
+              const regionObjs = _.filter(regions, (region) => _.isObject(region));
+              if (regionObjs.length) {
+                const oldStyleRegions = _.chain(regionObjs)
+                  .map((regionObj) => _.keys(regionObj))
+                  .flatten()
+                  .value();
+                regions = _.chain(regions).difference(regionObjs).union(oldStyleRegions).value();
+              }
+              return regions.sort();
+            })
+            .then((allRegions) => {
+              setRegionList();
+              setClusterList();
+              vm.regions = _.includes(vm.clusterList, vm.component[this.clusterField]) ? vm.regions : allRegions;
+            });
+        };
+
+        init();
       };
-
-      const setToggledState = () => {
-        vm.regions = regions;
-        isTextInputForClusterFiled = true;
-      };
-
-      const setUnToggledState = () => {
-        vm.component[this.clusterField] = undefined;
-        isTextInputForClusterFiled = false;
-        setRegionList();
-      };
-
-      vm.clusterSelectInputToggled = (isToggled) => {
-        isToggled ? setToggledState() : setUnToggledState();
-      };
-
-      vm.clusterChanged = (clusterName) => {
-        const filterByCluster = AppListExtractor.monikerClusterNameFilter(clusterName);
-        const clusterMoniker = _.first(_.uniq(AppListExtractor.getMonikers([vm.application], filterByCluster)));
-        if (_.isNil(clusterMoniker)) {
-          //remove the moniker from the stage if one doesn't exist.
-          vm.component.moniker = undefined;
-        } else {
-          //clusters don't contain sequences, so null it out.
-          clusterMoniker.sequence = null;
-          vm.component.moniker = clusterMoniker;
-        }
-      };
-
-      vm.accountUpdated = () => {
-        vm.component[this.clusterField] = undefined;
-        setRegionList();
-        setClusterList();
-        if (vm.onAccountUpdate) {
-          vm.onAccountUpdate();
-        }
-      };
-
-      const init = () => {
-        AccountService.getUniqueAttributeForAllAccounts(vm.component.cloudProviderType, 'regions')
-          .then((allRegions) => {
-            regions = allRegions;
-
-            // TODO(duftler): Remove this once we finish deprecating the old style regions/zones in clouddriver GCE credentials.
-            const regionObjs = _.filter(regions, (region) => _.isObject(region));
-            if (regionObjs.length) {
-              const oldStyleRegions = _.chain(regionObjs)
-                .map((regionObj) => _.keys(regionObj))
-                .flatten()
-                .value();
-              regions = _.chain(regions).difference(regionObjs).union(oldStyleRegions).value();
-            }
-            return regions.sort();
-          })
-          .then((allRegions) => {
-            setRegionList();
-            setClusterList();
-            vm.regions = _.includes(vm.clusterList, vm.component[this.clusterField]) ? vm.regions : allRegions;
-          });
-      };
-
-      init();
     },
   };
 });


### PR DESCRIPTION
After the upgrade to Angular 1.8 in #9836, the account/regions/cluster picker was missing (e.g. in the Scale Down Cluster stage and the Resize Server Group stage). Quick fix was to wrap the existing controller code in an `$onInit` function.