### PR TITLE
fix(ecs): skip checking for upstream stages for ECS deploy

### DIFF
--- a/packages/ecs/src/ecs.module.ts
+++ b/packages/ecs/src/ecs.module.ts
@@ -92,6 +92,7 @@ module(ECS_MODULE, [
       commandBuilder: 'ecsServerGroupCommandBuilder',
       // configurationService: 'ecsServerGroupConfigurationService',
       scalingActivitiesEnabled: false,
+      skipUpstreamStageCheck: true,
     },
     loadBalancer: {
       transformer: EcsLoadBalancerTransformer,


### PR DESCRIPTION
ECS deployments don't need a Bake or Find Image from Resource stage upstream, so don't show an error that one is required.