### PR TITLE
Publish packages to NPM

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.4.2](https://github.com/spinnaker/deck/compare/deck-app@2.4.1...deck-app@2.4.2) (2023-02-07)
+
+**Note:** Version bump only for package deck-app
+
+
+
+
+
 ## [2.4.1](https://github.com/spinnaker/deck/compare/deck-app@2.4.0...deck-app@2.4.1) (2023-02-02)
 
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deck-app",
   "private": true,
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,7 @@
     "@spinnaker/cloudfoundry": "^0.1.3",
     "@spinnaker/core": "^0.23.0",
     "@spinnaker/docker": "^0.0.137",
-    "@spinnaker/ecs": "^0.0.355",
+    "@spinnaker/ecs": "^0.0.356",
     "@spinnaker/google": "^0.2.3",
     "@spinnaker/kayenta": "2.0.0",
     "@spinnaker/kubernetes": "^0.4.0",

--- a/packages/ecs/CHANGELOG.md
+++ b/packages/ecs/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.356](https://github.com/spinnaker/deck/compare/@spinnaker/ecs@0.0.355...@spinnaker/ecs@0.0.356) (2023-02-07)
+
+
+### Bug Fixes
+
+* **ecs:** skip checking for upstream stages for ECS deploy ([#9945](https://github.com/spinnaker/deck/issues/9945)) ([898a595](https://github.com/spinnaker/deck/commit/898a59504ea58a456baf19e0a21a4cace683feb7))
+
+
+
+
+
 ## [0.0.355](https://github.com/spinnaker/deck/compare/@spinnaker/ecs@0.0.354...@spinnaker/ecs@0.0.355) (2023-02-02)
 
 **Note:** Version bump only for package @spinnaker/ecs

--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.355",
+  "version": "0.0.356",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/packages/pluginsdk-peerdeps/CHANGELOG.md
+++ b/packages/pluginsdk-peerdeps/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.8.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.7.0...@spinnaker/pluginsdk-peerdeps@0.8.0) (2023-02-07)
+
+
+### Features
+
+* **peerdep-sync:** Synchronize peerdependencies ([51ba791](https://github.com/spinnaker/deck/commit/51ba7916af758d8197aac5ae827b55e2d9b7bd00))
+
+
+
+
+
 # [0.7.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.6.0...@spinnaker/pluginsdk-peerdeps@0.7.0) (2023-02-02)
 
 

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -46,71 +46,27 @@
     "utf-8-validate": "5.0.3"
   },
   "peerDependenciesMeta": {
-    "@rollup/plugin-commonjs": {
-      "dev": true
-    },
-    "@rollup/plugin-json": {
-      "dev": true
-    },
-    "@rollup/plugin-node-resolve": {
-      "dev": true
-    },
-    "@rollup/plugin-replace": {
-      "dev": true
-    },
-    "@rollup/plugin-typescript": {
-      "dev": true
-    },
-    "@rollup/plugin-url": {
-      "dev": true
-    },
-    "@spinnaker/eslint-plugin": {
-      "dev": true
-    },
-    "@types/react": {
-      "dev": true
-    },
-    "bufferutil": {
-      "dev": true
-    },
-    "npm-run-all": {
-      "dev": true
-    },
-    "postcss": {
-      "dev": true
-    },
-    "prettier": {
-      "dev": true
-    },
-    "pretty-quick": {
-      "dev": true
-    },
-    "rollup": {
-      "dev": true
-    },
-    "rollup-plugin-external-globals": {
-      "dev": true
-    },
-    "rollup-plugin-less": {
-      "dev": true
-    },
-    "rollup-plugin-postcss": {
-      "dev": true
-    },
-    "rollup-plugin-terser": {
-      "dev": true
-    },
-    "rollup-plugin-visualizer": {
-      "dev": true
-    },
-    "shx": {
-      "dev": true
-    },
-    "typescript": {
-      "dev": true
-    },
-    "utf-8-validate": {
-      "dev": true
-    }
+    "@rollup/plugin-commonjs": { "dev": true },
+    "@rollup/plugin-json": { "dev": true },
+    "@rollup/plugin-node-resolve": { "dev": true },
+    "@rollup/plugin-replace": { "dev": true },
+    "@rollup/plugin-typescript": { "dev": true },
+    "@rollup/plugin-url": { "dev": true },
+    "@spinnaker/eslint-plugin": { "dev": true },
+    "@types/react": { "dev": true },
+    "bufferutil": { "dev": true },
+    "npm-run-all": { "dev": true },
+    "postcss": { "dev": true },
+    "prettier": { "dev": true },
+    "pretty-quick": { "dev": true },
+    "rollup": { "dev": true },
+    "rollup-plugin-external-globals": { "dev": true },
+    "rollup-plugin-less": { "dev": true },
+    "rollup-plugin-postcss": { "dev": true },
+    "rollup-plugin-terser": { "dev": true },
+    "rollup-plugin-visualizer": { "dev": true },
+    "shx": { "dev": true },
+    "typescript": { "dev": true },
+    "utf-8-validate": { "dev": true }
   }
 }

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk-peerdeps",
   "description": "Provides package dependencies to plugin developers",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "scripts": {
     "temp": "./convert-peerdeps.js --from-peerdeps --input package.json --output package.temp.json",
@@ -46,27 +46,71 @@
     "utf-8-validate": "5.0.3"
   },
   "peerDependenciesMeta": {
-    "@rollup/plugin-commonjs": { "dev": true },
-    "@rollup/plugin-json": { "dev": true },
-    "@rollup/plugin-node-resolve": { "dev": true },
-    "@rollup/plugin-replace": { "dev": true },
-    "@rollup/plugin-typescript": { "dev": true },
-    "@rollup/plugin-url": { "dev": true },
-    "@spinnaker/eslint-plugin": { "dev": true },
-    "@types/react": { "dev": true },
-    "bufferutil": { "dev": true },
-    "npm-run-all": { "dev": true },
-    "postcss": { "dev": true },
-    "prettier": { "dev": true },
-    "pretty-quick": { "dev": true },
-    "rollup": { "dev": true },
-    "rollup-plugin-external-globals": { "dev": true },
-    "rollup-plugin-less": { "dev": true },
-    "rollup-plugin-postcss": { "dev": true },
-    "rollup-plugin-terser": { "dev": true },
-    "rollup-plugin-visualizer": { "dev": true },
-    "shx": { "dev": true },
-    "typescript": { "dev": true },
-    "utf-8-validate": { "dev": true }
+    "@rollup/plugin-commonjs": {
+      "dev": true
+    },
+    "@rollup/plugin-json": {
+      "dev": true
+    },
+    "@rollup/plugin-node-resolve": {
+      "dev": true
+    },
+    "@rollup/plugin-replace": {
+      "dev": true
+    },
+    "@rollup/plugin-typescript": {
+      "dev": true
+    },
+    "@rollup/plugin-url": {
+      "dev": true
+    },
+    "@spinnaker/eslint-plugin": {
+      "dev": true
+    },
+    "@types/react": {
+      "dev": true
+    },
+    "bufferutil": {
+      "dev": true
+    },
+    "npm-run-all": {
+      "dev": true
+    },
+    "postcss": {
+      "dev": true
+    },
+    "prettier": {
+      "dev": true
+    },
+    "pretty-quick": {
+      "dev": true
+    },
+    "rollup": {
+      "dev": true
+    },
+    "rollup-plugin-external-globals": {
+      "dev": true
+    },
+    "rollup-plugin-less": {
+      "dev": true
+    },
+    "rollup-plugin-postcss": {
+      "dev": true
+    },
+    "rollup-plugin-terser": {
+      "dev": true
+    },
+    "rollup-plugin-visualizer": {
+      "dev": true
+    },
+    "shx": {
+      "dev": true
+    },
+    "typescript": {
+      "dev": true
+    },
+    "utf-8-validate": {
+      "dev": true
+    }
   }
 }


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.

# pluginsdk-peerdeps [0.8.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.7.0...@spinnaker/pluginsdk-peerdeps@0.8.0) (2023-02-07)


### Features

* **peerdep-sync:** Synchronize peerdependencies ([51ba791](https://github.com/spinnaker/deck/commit/51ba7916af758d8197aac5ae827b55e2d9b7bd00))

---

This PR bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_