### PR TITLE
fix(6755): Resolved issue regarding warning reporting when cloning a server group in AWS

### DIFF
--- a/packages/core/src/serverGroup/configure/common/v2instanceArchetypeSelector.component.ts
+++ b/packages/core/src/serverGroup/configure/common/v2instanceArchetypeSelector.component.ts
@@ -22,6 +22,16 @@ class V2InstanceArchetypeSelectorController implements IComponentController {
     const { $scope } = this;
     this.instanceTypeService.getCategories(this.command.selectedProvider).then((categories) => {
       $scope.instanceProfiles = categories;
+      // Resetting the 'unavailable' properties to avoid caching initially.
+      categories.forEach((profile) => {
+        if (profile.type === this.command.viewState.instanceProfile) {
+          profile.families.forEach((family) => {
+            family.instanceTypes.forEach((instanceType) => {
+              instanceType.unavailable = false;
+            });
+          });
+        }
+      });
       if ($scope.instanceProfiles.length % 3 === 0) {
         $scope.columns = 3;
       }


### PR DESCRIPTION


As part of resolving issue [6755](https://github.com/spinnaker/spinnaker/issues/6755). Adding changes to reset the instance object properties(i.e, unavailable) whenever server group dialog opens. By doing this will resolved the issues occurs due to incorrect value stored in instance object(i.e, unavailable) while following the same steps given in above issue again and again without refreshing the browser.