### PR TITLE
Publish packages to NPM

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.5.0](https://github.com/spinnaker/deck/compare/deck-app@2.4.3...deck-app@2.5.0) (2023-03-15)
+
+
+### Features
+
+* **provider/cloudrun:** Added cloudrun functionality to deck ([#9931](https://github.com/spinnaker/deck/issues/9931)) ([3611e95](https://github.com/spinnaker/deck/commit/3611e9520b2294454a8b5dddc85cb3190722ffc7))
+
+
+
+
+
 ## [2.4.3](https://github.com/spinnaker/deck/compare/deck-app@2.4.2...deck-app@2.4.3) (2023-02-20)
 
 **Note:** Version bump only for package deck-app

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deck-app",
   "private": true,
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/pluginsdk-peerdeps/CHANGELOG.md
+++ b/packages/pluginsdk-peerdeps/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.10.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.9.0...@spinnaker/pluginsdk-peerdeps@0.10.0) (2023-03-15)
+
+
+### Features
+
+* **peerdep-sync:** Synchronize peerdependencies ([1eca783](https://github.com/spinnaker/deck/commit/1eca783ac57b894efc37c58a60122f2b5ce07b05))
+
+
+
+
+
 # [0.9.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.8.0...@spinnaker/pluginsdk-peerdeps@0.9.0) (2023-02-20)
 
 

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk-peerdeps",
   "description": "Provides package dependencies to plugin developers",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "scripts": {
     "temp": "./convert-peerdeps.js --from-peerdeps --input package.json --output package.temp.json",
@@ -46,27 +46,71 @@
     "utf-8-validate": "5.0.3"
   },
   "peerDependenciesMeta": {
-    "@rollup/plugin-commonjs": { "dev": true },
-    "@rollup/plugin-json": { "dev": true },
-    "@rollup/plugin-node-resolve": { "dev": true },
-    "@rollup/plugin-replace": { "dev": true },
-    "@rollup/plugin-typescript": { "dev": true },
-    "@rollup/plugin-url": { "dev": true },
-    "@spinnaker/eslint-plugin": { "dev": true },
-    "@types/react": { "dev": true },
-    "bufferutil": { "dev": true },
-    "npm-run-all": { "dev": true },
-    "postcss": { "dev": true },
-    "prettier": { "dev": true },
-    "pretty-quick": { "dev": true },
-    "rollup": { "dev": true },
-    "rollup-plugin-external-globals": { "dev": true },
-    "rollup-plugin-less": { "dev": true },
-    "rollup-plugin-postcss": { "dev": true },
-    "rollup-plugin-terser": { "dev": true },
-    "rollup-plugin-visualizer": { "dev": true },
-    "shx": { "dev": true },
-    "typescript": { "dev": true },
-    "utf-8-validate": { "dev": true }
+    "@rollup/plugin-commonjs": {
+      "dev": true
+    },
+    "@rollup/plugin-json": {
+      "dev": true
+    },
+    "@rollup/plugin-node-resolve": {
+      "dev": true
+    },
+    "@rollup/plugin-replace": {
+      "dev": true
+    },
+    "@rollup/plugin-typescript": {
+      "dev": true
+    },
+    "@rollup/plugin-url": {
+      "dev": true
+    },
+    "@spinnaker/eslint-plugin": {
+      "dev": true
+    },
+    "@types/react": {
+      "dev": true
+    },
+    "bufferutil": {
+      "dev": true
+    },
+    "npm-run-all": {
+      "dev": true
+    },
+    "postcss": {
+      "dev": true
+    },
+    "prettier": {
+      "dev": true
+    },
+    "pretty-quick": {
+      "dev": true
+    },
+    "rollup": {
+      "dev": true
+    },
+    "rollup-plugin-external-globals": {
+      "dev": true
+    },
+    "rollup-plugin-less": {
+      "dev": true
+    },
+    "rollup-plugin-postcss": {
+      "dev": true
+    },
+    "rollup-plugin-terser": {
+      "dev": true
+    },
+    "rollup-plugin-visualizer": {
+      "dev": true
+    },
+    "shx": {
+      "dev": true
+    },
+    "typescript": {
+      "dev": true
+    },
+    "utf-8-validate": {
+      "dev": true
+    }
   }
 }

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -46,71 +46,27 @@
     "utf-8-validate": "5.0.3"
   },
   "peerDependenciesMeta": {
-    "@rollup/plugin-commonjs": {
-      "dev": true
-    },
-    "@rollup/plugin-json": {
-      "dev": true
-    },
-    "@rollup/plugin-node-resolve": {
-      "dev": true
-    },
-    "@rollup/plugin-replace": {
-      "dev": true
-    },
-    "@rollup/plugin-typescript": {
-      "dev": true
-    },
-    "@rollup/plugin-url": {
-      "dev": true
-    },
-    "@spinnaker/eslint-plugin": {
-      "dev": true
-    },
-    "@types/react": {
-      "dev": true
-    },
-    "bufferutil": {
-      "dev": true
-    },
-    "npm-run-all": {
-      "dev": true
-    },
-    "postcss": {
-      "dev": true
-    },
-    "prettier": {
-      "dev": true
-    },
-    "pretty-quick": {
-      "dev": true
-    },
-    "rollup": {
-      "dev": true
-    },
-    "rollup-plugin-external-globals": {
-      "dev": true
-    },
-    "rollup-plugin-less": {
-      "dev": true
-    },
-    "rollup-plugin-postcss": {
-      "dev": true
-    },
-    "rollup-plugin-terser": {
-      "dev": true
-    },
-    "rollup-plugin-visualizer": {
-      "dev": true
-    },
-    "shx": {
-      "dev": true
-    },
-    "typescript": {
-      "dev": true
-    },
-    "utf-8-validate": {
-      "dev": true
-    }
+    "@rollup/plugin-commonjs": { "dev": true },
+    "@rollup/plugin-json": { "dev": true },
+    "@rollup/plugin-node-resolve": { "dev": true },
+    "@rollup/plugin-replace": { "dev": true },
+    "@rollup/plugin-typescript": { "dev": true },
+    "@rollup/plugin-url": { "dev": true },
+    "@spinnaker/eslint-plugin": { "dev": true },
+    "@types/react": { "dev": true },
+    "bufferutil": { "dev": true },
+    "npm-run-all": { "dev": true },
+    "postcss": { "dev": true },
+    "prettier": { "dev": true },
+    "pretty-quick": { "dev": true },
+    "rollup": { "dev": true },
+    "rollup-plugin-external-globals": { "dev": true },
+    "rollup-plugin-less": { "dev": true },
+    "rollup-plugin-postcss": { "dev": true },
+    "rollup-plugin-terser": { "dev": true },
+    "rollup-plugin-visualizer": { "dev": true },
+    "shx": { "dev": true },
+    "typescript": { "dev": true },
+    "utf-8-validate": { "dev": true }
   }
 }


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.

# pluginsdk-peerdeps [0.10.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.9.0...@spinnaker/pluginsdk-peerdeps@0.10.0) (2023-03-15)


### Features

* **peerdep-sync:** Synchronize peerdependencies ([1eca783](https://github.com/spinnaker/deck/commit/1eca783ac57b894efc37c58a60122f2b5ce07b05))

---

This PR bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_