### PR TITLE
chore(ff): Set default for dynamicRollbackTimeoutEnabled to true.

### DIFF
--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -18,7 +18,7 @@ var mineCanaryEnabled = '{%features.mineCanary%}' === 'true';
 var pipelineTemplatesEnabled = '{%features.pipelineTemplates%}' === 'true';
 var reduxLoggerEnabled = '{%canary.reduxLogger%}' === 'true';
 var showAllConfigsEnabled = '{%canary.showAllCanaryConfigs%}' === 'true';
-var dynamicRollbackTimeoutEnabled = '{%feature.dynamicRollbackTimeout%}' === 'true';
+var dynamicRollbackTimeoutEnabled = '{%feature.dynamicRollbackTimeout%}' !== 'false';
 var slack = {
   botName: '{%notifications.slack.botName%}',
   enabled: '{%notifications.slack.enabled%}' === 'true',


### PR DESCRIPTION
Defaulting the feature flag to true.

The feature flag enables the timeout value to be configurable from the UI. If the value is not set in the UI the hardcoded value is used.

The implementation was tested on a previous pr.
