### PR TITLE
fix: UI crashes when running pipeline(s) with many stages.

### DIFF
--- a/packages/core/src/pipeline/config/graph/PipelineGraph.tsx
+++ b/packages/core/src/pipeline/config/graph/PipelineGraph.tsx
@@ -117,15 +117,22 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
     if (!node.children.length) {
       return node.phase;
     }
+    const checkedNodeIds = new Set<string | number>();
     const result: number[] = [];
-    this.collect(node.children, result);
+    this.collect(node.children, result, checkedNodeIds);
     return max(result);
   }
 
-  private collect(nodes: IPipelineGraphNode[], result: number[]) {
+  private collect(nodes: IPipelineGraphNode[], result: number[], checkedNodeIds: Set<string | number>) {
     nodes.forEach((node) => {
+      if (checkedNodeIds.has(node.id)) {
+        return;
+      } else {
+        checkedNodeIds.add(node.id);
+      }
+
       if (node.children.length) {
-        this.collect(node.children, result);
+        this.collect(node.children, result, checkedNodeIds);
       } else {
         result.push(node.phase);
       }


### PR DESCRIPTION
This change prevents iterating over child nodes as it has already been checked and as a result greatly reduces the number of interactions and increases speed.