### PR TITLE
Publish packages to NPM

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.5.2](https://github.com/spinnaker/deck/compare/deck-app@2.5.1...deck-app@2.5.2) (2023-05-01)
+
+**Note:** Version bump only for package deck-app
+
+
+
+
+
 ## [2.5.1](https://github.com/spinnaker/deck/compare/deck-app@2.5.0...deck-app@2.5.1) (2023-04-03)
 
 **Note:** Version bump only for package deck-app

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deck-app",
   "private": true,
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,7 @@
     "@spinnaker/amazon": "^0.13.6",
     "@spinnaker/appengine": "^0.1.4",
     "@spinnaker/cloudfoundry": "^0.1.4",
-    "@spinnaker/cloudrun": "^0.0.2",
+    "@spinnaker/cloudrun": "^0.1.0",
     "@spinnaker/core": "^0.23.1",
     "@spinnaker/docker": "^0.0.138",
     "@spinnaker/ecs": "^0.0.357",

--- a/packages/cloudrun/CHANGELOG.md
+++ b/packages/cloudrun/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.1.0](https://github.com/spinnaker/deck/compare/@spinnaker/cloudrun@0.0.2...@spinnaker/cloudrun@0.1.0) (2023-05-01)
+
+
+### Features
+
+* **provider/google:** Added Cloud Run manifest functionality in Deck. ([#9971](https://github.com/spinnaker/deck/issues/9971)) ([f5e19c7](https://github.com/spinnaker/deck/commit/f5e19c77a0135963ca1f54beb5ef9abc48ba8968))
+
+
+
+
+
 ## [0.0.2](https://github.com/spinnaker/deck/compare/@spinnaker/cloudrun@0.0.1...@spinnaker/cloudrun@0.0.2) (2023-04-03)
 
 **Note:** Version bump only for package @spinnaker/cloudrun

--- a/packages/cloudrun/package.json
+++ b/packages/cloudrun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudrun",
   "license": "Apache-2.0",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/packages/pluginsdk-peerdeps/CHANGELOG.md
+++ b/packages/pluginsdk-peerdeps/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.12.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.11.0...@spinnaker/pluginsdk-peerdeps@0.12.0) (2023-05-01)
+
+
+### Features
+
+* **peerdep-sync:** Synchronize peerdependencies ([94ea186](https://github.com/spinnaker/deck/commit/94ea186dc3209192556746dcf3101db3442d2fce))
+
+
+
+
+
 # [0.11.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.10.0...@spinnaker/pluginsdk-peerdeps@0.11.0) (2023-04-03)
 
 

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -46,71 +46,27 @@
     "utf-8-validate": "5.0.3"
   },
   "peerDependenciesMeta": {
-    "@rollup/plugin-commonjs": {
-      "dev": true
-    },
-    "@rollup/plugin-json": {
-      "dev": true
-    },
-    "@rollup/plugin-node-resolve": {
-      "dev": true
-    },
-    "@rollup/plugin-replace": {
-      "dev": true
-    },
-    "@rollup/plugin-typescript": {
-      "dev": true
-    },
-    "@rollup/plugin-url": {
-      "dev": true
-    },
-    "@spinnaker/eslint-plugin": {
-      "dev": true
-    },
-    "@types/react": {
-      "dev": true
-    },
-    "bufferutil": {
-      "dev": true
-    },
-    "npm-run-all": {
-      "dev": true
-    },
-    "postcss": {
-      "dev": true
-    },
-    "prettier": {
-      "dev": true
-    },
-    "pretty-quick": {
-      "dev": true
-    },
-    "rollup": {
-      "dev": true
-    },
-    "rollup-plugin-external-globals": {
-      "dev": true
-    },
-    "rollup-plugin-less": {
-      "dev": true
-    },
-    "rollup-plugin-postcss": {
-      "dev": true
-    },
-    "rollup-plugin-terser": {
-      "dev": true
-    },
-    "rollup-plugin-visualizer": {
-      "dev": true
-    },
-    "shx": {
-      "dev": true
-    },
-    "typescript": {
-      "dev": true
-    },
-    "utf-8-validate": {
-      "dev": true
-    }
+    "@rollup/plugin-commonjs": { "dev": true },
+    "@rollup/plugin-json": { "dev": true },
+    "@rollup/plugin-node-resolve": { "dev": true },
+    "@rollup/plugin-replace": { "dev": true },
+    "@rollup/plugin-typescript": { "dev": true },
+    "@rollup/plugin-url": { "dev": true },
+    "@spinnaker/eslint-plugin": { "dev": true },
+    "@types/react": { "dev": true },
+    "bufferutil": { "dev": true },
+    "npm-run-all": { "dev": true },
+    "postcss": { "dev": true },
+    "prettier": { "dev": true },
+    "pretty-quick": { "dev": true },
+    "rollup": { "dev": true },
+    "rollup-plugin-external-globals": { "dev": true },
+    "rollup-plugin-less": { "dev": true },
+    "rollup-plugin-postcss": { "dev": true },
+    "rollup-plugin-terser": { "dev": true },
+    "rollup-plugin-visualizer": { "dev": true },
+    "shx": { "dev": true },
+    "typescript": { "dev": true },
+    "utf-8-validate": { "dev": true }
   }
 }

--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk-peerdeps",
   "description": "Provides package dependencies to plugin developers",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "scripts": {
     "temp": "./convert-peerdeps.js --from-peerdeps --input package.json --output package.temp.json",
@@ -46,27 +46,71 @@
     "utf-8-validate": "5.0.3"
   },
   "peerDependenciesMeta": {
-    "@rollup/plugin-commonjs": { "dev": true },
-    "@rollup/plugin-json": { "dev": true },
-    "@rollup/plugin-node-resolve": { "dev": true },
-    "@rollup/plugin-replace": { "dev": true },
-    "@rollup/plugin-typescript": { "dev": true },
-    "@rollup/plugin-url": { "dev": true },
-    "@spinnaker/eslint-plugin": { "dev": true },
-    "@types/react": { "dev": true },
-    "bufferutil": { "dev": true },
-    "npm-run-all": { "dev": true },
-    "postcss": { "dev": true },
-    "prettier": { "dev": true },
-    "pretty-quick": { "dev": true },
-    "rollup": { "dev": true },
-    "rollup-plugin-external-globals": { "dev": true },
-    "rollup-plugin-less": { "dev": true },
-    "rollup-plugin-postcss": { "dev": true },
-    "rollup-plugin-terser": { "dev": true },
-    "rollup-plugin-visualizer": { "dev": true },
-    "shx": { "dev": true },
-    "typescript": { "dev": true },
-    "utf-8-validate": { "dev": true }
+    "@rollup/plugin-commonjs": {
+      "dev": true
+    },
+    "@rollup/plugin-json": {
+      "dev": true
+    },
+    "@rollup/plugin-node-resolve": {
+      "dev": true
+    },
+    "@rollup/plugin-replace": {
+      "dev": true
+    },
+    "@rollup/plugin-typescript": {
+      "dev": true
+    },
+    "@rollup/plugin-url": {
+      "dev": true
+    },
+    "@spinnaker/eslint-plugin": {
+      "dev": true
+    },
+    "@types/react": {
+      "dev": true
+    },
+    "bufferutil": {
+      "dev": true
+    },
+    "npm-run-all": {
+      "dev": true
+    },
+    "postcss": {
+      "dev": true
+    },
+    "prettier": {
+      "dev": true
+    },
+    "pretty-quick": {
+      "dev": true
+    },
+    "rollup": {
+      "dev": true
+    },
+    "rollup-plugin-external-globals": {
+      "dev": true
+    },
+    "rollup-plugin-less": {
+      "dev": true
+    },
+    "rollup-plugin-postcss": {
+      "dev": true
+    },
+    "rollup-plugin-terser": {
+      "dev": true
+    },
+    "rollup-plugin-visualizer": {
+      "dev": true
+    },
+    "shx": {
+      "dev": true
+    },
+    "typescript": {
+      "dev": true
+    },
+    "utf-8-validate": {
+      "dev": true
+    }
   }
 }


### PR DESCRIPTION
### This PR bumps the version(s) of all Deck package(s) that have unpublished changes.

# pluginsdk-peerdeps [0.12.0](https://github.com/spinnaker/deck/compare/@spinnaker/pluginsdk-peerdeps@0.11.0...@spinnaker/pluginsdk-peerdeps@0.12.0) (2023-05-01)


### Features

* **peerdep-sync:** Synchronize peerdependencies ([94ea186](https://github.com/spinnaker/deck/commit/94ea186dc3209192556746dcf3101db3442d2fce))

---

This PR bumps each package to the next semver version (patch/minor/major) based on the commit messages of unpublished changes using [Conventional Commits](https://conventionalcommits.org).

  - fix: patch release
  - feat: minor release
  - BREAKING CHANGE: major release

It also updates dependency versions in other packages in the monorepo which depend on the bumped package(s).

After this PR is merged, Github Actions will publish any bumped packages to the NPM registry.

_Auto-generated by `.github/workflows/package-bump-pr.yml`_