### PR TITLE
fix(ecs): VPC Subnet dropdown fix in ecs server group creation.

### DIFF
--- a/packages/ecs/src/serverGroup/configure/wizard/networking/Networking.tsx
+++ b/packages/ecs/src/serverGroup/configure/wizard/networking/Networking.tsx
@@ -80,8 +80,15 @@ export class EcsNetworking extends React.Component<IEcsNetworkingProps, IEcsNetw
 
   private updateNetworkMode = (newNetworkMode: Option<string>) => {
     const updatedNetworkMode = newNetworkMode.value;
+    const cmd = this.props.command;
     this.props.notifyAngular('networkMode', updatedNetworkMode);
-    this.setState({ networkMode: updatedNetworkMode });
+    this.setState({
+      networkMode: updatedNetworkMode,
+      subnetTypesAvailable:
+        cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.subnetTypes
+          ? cmd.backingData.filtered.subnetTypes
+          : [],
+    });
   };
 
   private updateSecurityGroups = (newSecurityGroups: Option<string>) => {


### PR DESCRIPTION
In the initial state, when a new application was created and when the user is trying to create a Server group for ECS Instance, the credentials related to the aws account and the state of the subnet in the code were not updating properly and returning as undefined. As a result during the filtering of the subnet types, we are getting empty array [] as the output, which is causing the issue for the VPC subnets drop down while creating the server group.
![Screenshot from 2023-05-09 16-31-57](https://github.com/spinnaker/deck/assets/61963157/35233224-1585-492d-a8bd-2e4aade3ff06)

### Below recording showing behaviour before fix :-


https://github.com/spinnaker/deck/assets/61963157/6bff6865-b9f7-434f-b272-920fd210fe7b

### Below recording showing behaviour after fix :-


https://github.com/spinnaker/deck/assets/61963157/eaf3a877-a8c0-4cde-b1b6-2362175a558e

