### PR TITLE
fix(core/pipeline): Pipeline builder-pipeline action dropdown closing not properly

### DIFF
--- a/packages/core/src/pipeline/config/actions/PipelineConfigActions.tsx
+++ b/packages/core/src/pipeline/config/actions/PipelineConfigActions.tsx
@@ -18,6 +18,7 @@ export interface IPipelineConfigActionsProps {
 }
 
 export function PipelineConfigActions(props: IPipelineConfigActionsProps) {
+  const closeDropdown = () => document.body.click();
   const {
     pipeline,
     renamePipeline,
@@ -36,7 +37,7 @@ export function PipelineConfigActions(props: IPipelineConfigActionsProps) {
       <Dropdown.Toggle className="btn btn-sm dropdown-toggle">
         {pipeline.strategy === true ? 'Strategy' : 'Pipeline'} Actions
       </Dropdown.Toggle>
-      <Dropdown.Menu className="dropdown-menu">
+      <Dropdown.Menu className="dropdown-menu" onClick={closeDropdown}>
         {!pipeline.locked && <PipelineConfigAction name="Rename" action={renamePipeline} />}
         {!pipeline.locked && <PipelineConfigAction name="Delete" action={deletePipeline} />}
         {!pipeline.locked && pipeline.disabled && <PipelineConfigAction name="Enable" action={enablePipeline} />}


### PR DESCRIPTION
Click on any option dropdown from pipeline action not closing properly Pipeline builder screen . Closing outside the popup only close the dropdown.

### Before implementation of Fix:-

https://github.com/spinnaker/deck/assets/61963157/831ead5b-6648-44eb-a939-4b1bd4731dcd


### After implementation of fix:- 


https://github.com/spinnaker/deck/assets/61963157/3670565a-83a8-4985-8eb1-1c5c4605dfac


