### PR TITLE
feat(icons): allow plugins to provide custom icon components

### DIFF
--- a/packages/presentation/src/icons/Icon.tsx
+++ b/packages/presentation/src/icons/Icon.tsx
@@ -1,3 +1,4 @@
+import type { SVGComponent } from '*.svg';
 import React, { memo } from 'react';
 
 import { iconsByName } from './iconsByName';
@@ -6,7 +7,7 @@ export type IconNames = keyof typeof iconsByName;
 
 export type IIconProps = {
   name?: IconNames;
-  reactComponent?: ReactComponent;
+  reactComponent?: SVGComponent;
   appearance?: 'light' | 'neutral' | 'dark';
   size?: 'extraSmall' | 'small' | 'medium' | 'large' | 'extraLarge' | string;
   color?: string;
@@ -24,20 +25,12 @@ const pxDimensionsBySize: { [size: string]: string } = {
   extraLarge: '40px',
 };
 
-const throwInvalidIconError = (name: string) => {
+const throwInvalidIconError = (name: string | undefined) => {
   throw new Error(`No icon with the name ${name} exists`);
 };
 
 export const Icon = memo(({ name, reactComponent, appearance, size, color, className }: IIconProps) => {
-  let Component;
-  if (reactComponent) {
-    Component = reactComponent;
-  } else {
-    Component = iconsByName[name];
-    if (!Component) {
-      throwInvalidIconError(name);
-    }
-  }
+  const Component = name ? iconsByName[name] : reactComponent || throwInvalidIconError(name);
 
   const width = size ? pxDimensionsBySize[size] || size : pxDimensionsBySize[DEFAULT_SIZE];
   const fill = color ? `var(--color-${color})` : `var(--color-icon-${appearance || DEFAULT_APPEARANCE})`;

--- a/packages/presentation/src/icons/Icon.tsx
+++ b/packages/presentation/src/icons/Icon.tsx
@@ -25,12 +25,24 @@ const pxDimensionsBySize: { [size: string]: string } = {
   extraLarge: '40px',
 };
 
-const throwInvalidIconError = (name: string | undefined) => {
+const throwInvalidIconError = (name: string) => {
   throw new Error(`No icon with the name ${name} exists`);
 };
 
+const throwInvalidIconComponentError = () => {
+  throw new Error('No name or reactComponent provided in Icon props');
+};
+
 export const Icon = memo(({ name, reactComponent, appearance, size, color, className }: IIconProps) => {
-  const Component = name ? iconsByName[name] : reactComponent || throwInvalidIconError(name);
+  let Component;
+  if (name) {
+    Component = iconsByName[name];
+    if (!Component) {
+      throwInvalidIconError(name);
+    }
+  } else {
+    Component = reactComponent || throwInvalidIconComponentError();
+  }
 
   const width = size ? pxDimensionsBySize[size] || size : pxDimensionsBySize[DEFAULT_SIZE];
   const fill = color ? `var(--color-${color})` : `var(--color-icon-${appearance || DEFAULT_APPEARANCE})`;

--- a/packages/presentation/src/icons/Icon.tsx
+++ b/packages/presentation/src/icons/Icon.tsx
@@ -5,7 +5,8 @@ import { iconsByName } from './iconsByName';
 export type IconNames = keyof typeof iconsByName;
 
 export type IIconProps = {
-  name: IconNames;
+  name?: IconNames;
+  reactComponent?: ReactComponent;
   appearance?: 'light' | 'neutral' | 'dark';
   size?: 'extraSmall' | 'small' | 'medium' | 'large' | 'extraLarge' | string;
   color?: string;
@@ -27,11 +28,15 @@ const throwInvalidIconError = (name: string) => {
   throw new Error(`No icon with the name ${name} exists`);
 };
 
-export const Icon = memo(({ name, appearance, size, color, className }: IIconProps) => {
-  const Component = iconsByName[name];
-
-  if (!Component) {
-    throwInvalidIconError(name);
+export const Icon = memo(({ name, reactComponent, appearance, size, color, className }: IIconProps) => {
+  let Component;
+  if (reactComponent) {
+    Component = reactComponent;
+  } else {
+    Component = iconsByName[name];
+    if (!Component) {
+      throwInvalidIconError(name);
+    }
   }
 
   const width = size ? pxDimensionsBySize[size] || size : pxDimensionsBySize[DEFAULT_SIZE];

--- a/packages/presentation/src/types/svg.d.ts
+++ b/packages/presentation/src/types/svg.d.ts
@@ -1,6 +1,7 @@
 declare module '*.svg' {
   import type { ComponentType, SVGProps } from 'react';
-  export const ReactComponent: ComponentType<SVGProps<HTMLOrSVGElement>>;
+  export type SVGComponent = ComponentType<SVGProps<HTMLOrSVGElement>>;
+  export const ReactComponent: SVGComponent;
   const URL: string;
   export default URL;
 }


### PR DESCRIPTION
Enables plugins to use the Icon component with a custom icon.

Currently the Icon component is limited to only icons defined in iconsByName.