### PR TITLE
fix(core/application): Delete Application component loses state while refreshing application.

### DIFF
--- a/packages/core/src/application/config/DeleteApplicationSection.tsx
+++ b/packages/core/src/application/config/DeleteApplicationSection.tsx
@@ -8,10 +8,11 @@ import { ApplicationWriter } from '../service/ApplicationWriter';
 
 export interface IDeleteApplicationSection {
   application: Application;
+  serverGroupsExist: number;
 }
 
 export function DeleteApplicationSection(props: IDeleteApplicationSection) {
-  const { application } = props;
+  const { application, serverGroupsExist } = props;
   const deleteApplication = (): void => {
     const taskMonitor = {
       application,
@@ -44,7 +45,7 @@ export function DeleteApplicationSection(props: IDeleteApplicationSection) {
       </>
     );
   } else {
-    return Boolean(application.serverGroups.data.length) ? (
+    return Boolean(serverGroupsExist) ? (
       <>
         <p>You cannot delete this application because it has server groups.</p>
       </>

--- a/packages/core/src/application/config/applicationConfig.view.html
+++ b/packages/core/src/application/config/applicationConfig.view.html
@@ -55,7 +55,10 @@
       </custom-banner-config>
     </page-section>
     <page-section key="delete" label="Delete Application">
-      <delete-application-section application="config.application"></delete-application-section>
+      <delete-application-section
+        application="config.application"
+        server-groups-exist="config.application.serverGroups.data.length"
+      ></delete-application-section>
     </page-section>
   </page-navigator>
 </div>

--- a/packages/core/src/application/config/deleteApplicationSection.module.ts
+++ b/packages/core/src/application/config/deleteApplicationSection.module.ts
@@ -6,5 +6,8 @@ import { withErrorBoundary } from '../../presentation/SpinErrorBoundary';
 export const DELETE_APPLICATION_SECTION = 'spinnaker.core.application.config.delete.directive';
 module(DELETE_APPLICATION_SECTION, []).component(
   'deleteApplicationSection',
-  react2angular(withErrorBoundary(DeleteApplicationSection, 'deleteApplicationSection'), ['application']),
+  react2angular(withErrorBoundary(DeleteApplicationSection, 'deleteApplicationSection'), [
+    'application',
+    'serverGroupsExist',
+  ]),
 );


### PR DESCRIPTION
Whenever application has servergroups, then Application cannot be Deleted and Following message shown from deck "You cannot delete this application because it has server groups."
Issue is when we land on to config page directly deck able to show delete option without checking for server groups (happens in deck Ui too when we load config page directly as shown in below recordings).

## Delete Application section before fix:-

https://github.com/spinnaker/deck/assets/61963157/da8c7835-cf8b-4773-9c81-3a042a49eeb6

## Delete Application section after fix:-

https://github.com/spinnaker/deck/assets/61963157/5daa727c-f7b6-4dc1-a7c7-011af9cad618


