### PR TITLE
feat(artifacts): Add support for artifact store views and calls

### DIFF
--- a/packages/core/src/artifact/ArtifactIconService.ts
+++ b/packages/core/src/artifact/ArtifactIconService.ts
@@ -44,6 +44,7 @@ ArtifactIconService.registerType(ArtifactTypePatterns.CUSTOM_OBJECT, unknownArti
 ArtifactIconService.registerType(ArtifactTypePatterns.DOCKER_IMAGE, dockerIcon);
 ArtifactIconService.registerType(ArtifactTypePatterns.KUBERNETES, kubernetesIcon);
 ArtifactIconService.registerType(ArtifactTypePatterns.EMBEDDED_BASE64, embeddedBase64Icon);
+ArtifactIconService.registerType(ArtifactTypePatterns.REMOTE_BASE64, embeddedBase64Icon);
 ArtifactIconService.registerType(ArtifactTypePatterns.GCS_OBJECT, gcsObjectIcon);
 ArtifactIconService.registerType(ArtifactTypePatterns.GITHUB_FILE, gitHubFileIcon);
 ArtifactIconService.registerType(ArtifactTypePatterns.GIT_REPO, gitRepoIcon);

--- a/packages/core/src/artifact/ArtifactTypes.ts
+++ b/packages/core/src/artifact/ArtifactTypes.ts
@@ -7,6 +7,7 @@ export const ArtifactTypePatterns: IArtifactTypePatterns = {
   CUSTOM_OBJECT: /custom\/object/,
   DOCKER_IMAGE: /docker\/image/,
   EMBEDDED_BASE64: /embedded\/base64/,
+  REMOTE_BASE64: /remote\/base64/,
   GCS_OBJECT: /gcs\/object/,
   GITHUB_FILE: /github\/file/,
   GIT_REPO: /git\/repo/,

--- a/packages/core/src/domain/IArtifact.ts
+++ b/packages/core/src/domain/IArtifact.ts
@@ -12,3 +12,6 @@ export interface IArtifact {
   kind?: string; // TODO delete
   customKind?: boolean; // TODO delete
 }
+
+export const ARTIFACT_TYPE_EMBEDDED = 'embedded/base64';
+export const ARTIFACT_TYPE_REMOTE = 'remote/base64';

--- a/packages/core/src/pipeline/config/stages/bakeManifest/BakeManifestDetailsTab.tsx
+++ b/packages/core/src/pipeline/config/stages/bakeManifest/BakeManifestDetailsTab.tsx
@@ -3,10 +3,12 @@ import React from 'react';
 import type { IExecutionDetailsSectionProps } from '../common';
 import { ExecutionDetailsSection } from '../common';
 import { StageFailureMessage } from '../../../details';
-import type { IArtifact } from '../../../../domain';
+import { ARTIFACT_TYPE_EMBEDDED } from '../../../../domain';
 import { ManifestYaml } from '../../../../manifest';
 import { Overridable } from '../../../../overrideRegistry';
 import { decodeUnicodeBase64 } from '../../../../utils';
+import { getBakedArtifacts } from './utils/getBakedArtifacts';
+import { getContentReference } from './utils/getContentReference';
 
 @Overridable('bakeManifest.bakeManifestDetailsTab')
 export class BakeManifestDetailsTab extends React.Component<IExecutionDetailsSectionProps> {
@@ -14,20 +16,30 @@ export class BakeManifestDetailsTab extends React.Component<IExecutionDetailsSec
 
   public render() {
     const { current, name, stage } = this.props;
-    const bakedArtifacts: IArtifact[] = (stage.context.artifacts || []).filter(
-      (a: IArtifact) => a.type === 'embedded/base64',
-    );
+    const bakedArtifacts = getBakedArtifacts(stage.context);
+
     return (
       <ExecutionDetailsSection name={name} current={current}>
         <StageFailureMessage stage={stage} message={stage.failureMessage} />
-        {bakedArtifacts.map((artifact, i) => (
-          <ManifestYaml
-            key={i}
-            linkName={bakedArtifacts.length > 1 ? `Baked Manifest ${i} YAML` : 'Baked Manifest YAML'}
-            manifestText={decodeUnicodeBase64(artifact.reference)}
-            modalTitle="Baked Manifest"
-          />
-        ))}
+        {bakedArtifacts.map((artifact, i) => {
+          const linkName = bakedArtifacts.length > 1 ? `Baked Manifest ${i} YAML` : 'Baked Manifest YAML';
+
+          return artifact.type === ARTIFACT_TYPE_EMBEDDED ? (
+            <ManifestYaml
+              key={i}
+              linkName={linkName}
+              modalTitle="Baked Manifest"
+              manifestText={decodeUnicodeBase64(artifact.reference)}
+            />
+          ) : (
+            <ManifestYaml
+              key={i}
+              linkName={linkName}
+              modalTitle="Baked Manifest"
+              manifestUri={getContentReference(artifact.reference)}
+            />
+          );
+        })}
       </ExecutionDetailsSection>
     );
   }

--- a/packages/core/src/pipeline/config/stages/bakeManifest/utils/getBakedArtifacts.ts
+++ b/packages/core/src/pipeline/config/stages/bakeManifest/utils/getBakedArtifacts.ts
@@ -1,0 +1,13 @@
+import type { IArtifact, IExecutionContext } from '../../../../../domain';
+import { ARTIFACT_TYPE_EMBEDDED, ARTIFACT_TYPE_REMOTE } from '../../../../../domain';
+
+// IArtifact type is wrong and does not represent the real value
+export const getBakedArtifacts = (context: IExecutionContext): Array<IArtifact & { reference: string }> => {
+  if ('artifacts' in context) {
+    return context.artifacts.filter(
+      (a: IArtifact) => (a.type === ARTIFACT_TYPE_EMBEDDED || a.type === ARTIFACT_TYPE_REMOTE) && a.reference,
+    );
+  } else {
+    return [];
+  }
+};

--- a/packages/core/src/pipeline/config/stages/bakeManifest/utils/getContentReference.ts
+++ b/packages/core/src/pipeline/config/stages/bakeManifest/utils/getContentReference.ts
@@ -1,0 +1,3 @@
+export const getContentReference = (uri: string): string => {
+  return uri.replace(/^ref?:\/\//, '');
+};

--- a/packages/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
+++ b/packages/core/src/pipeline/config/triggers/artifacts/ArtifactService.ts
@@ -11,4 +11,8 @@ export class ArtifactService {
       .query({ type: type, artifactName: artifactName })
       .get();
   }
+
+  public static getArtifactByContentReference(contentRef: string): PromiseLike<{ reference: string }> {
+    return REST(`/artifacts/content-address/${contentRef}`).get();
+  }
 }

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -23,3 +23,5 @@ export * from './manualExecution/TriggerTemplate';
 export * from './service/ExecutionsTransformer';
 export * from './service/execution.service';
 export * from './status/ArtifactList';
+export * from './config/stages/bakeManifest/utils/getBakedArtifacts';
+export * from './config/stages/bakeManifest/utils/getContentReference';


### PR DESCRIPTION
/artifacts/content-address/{reference} is a new API that allows for requests to be made to get full artifacts.

Also adds support for new artifact type of remote/base64