### PR TITLE
Revert "fix(core): conditionally hide expression evaluation warning messages (#9771)"

### DIFF
--- a/packages/core/src/pipeline/details/StageFailureMessage.tsx
+++ b/packages/core/src/pipeline/details/StageFailureMessage.tsx
@@ -73,33 +73,19 @@ export class StageFailureMessage extends React.Component<IStageFailureMessagePro
   }
 
   public render() {
-    const { message, messages, stage } = this.props;
+    const { message, messages } = this.props;
     const { isFailed, failedTask, failedExecutionId, failedStageName, failedStageId } = this.state;
 
-    let stageMessages = message && !messages.length ? [message] : messages;
-    if (stageMessages.length > 0) {
+    if (isFailed || failedTask || message || messages.length) {
       const exceptionTitle = isFailed ? (messages.length ? 'Exceptions' : 'Exception') : 'Warning';
-
-      // expression evaluation warnings can get really long and hide actual failure messages, source
-      // filter out expression evaluation failure messages if either:
-      // - there was a stage failure (and failed expressions don't fail the stage)
-      // - expression evaluation was explicitly disabled for the stage(as Orca still processes expressions and populates
-      //   warnings when evaluation is disabled disabled)
-      const shouldFilterExpressionFailures =
-        (isFailed && !stage.context?.failOnFailedExpressions) || stage.context?.skipExpressionEvaluation;
-
-      if (shouldFilterExpressionFailures) {
-        stageMessages = stageMessages.filter((m) => !m.startsWith('Failed to evaluate'));
-
-        if (stageMessages.length === 0) {
-          // no messages to be displayed after filtering
-          return null;
-        }
-      }
-
-      const displayMessages = stageMessages.map((m, i) => (
-        <Markdown key={i} message={m || StageFailureMessages.NO_REASON_PROVIDED} className="break-word" />
-      ));
+      const displayMessages =
+        message || !messages.length ? (
+          <Markdown message={message || StageFailureMessages.NO_REASON_PROVIDED} className="break-word" />
+        ) : (
+          messages.map((m, i) => (
+            <Markdown key={i} message={m || StageFailureMessages.NO_REASON_PROVIDED} className="break-word" />
+          ))
+        );
 
       if (displayMessages) {
         return (


### PR DESCRIPTION
Revert "fix(core): conditionally hide expression evaluation warning messages (#9771)"

This reverts commit 7e3dd5053ccdb06ce067303062f90ae82b56bfc8.

This is the cause of https://github.com/spinnaker/spinnaker/issues/6869, which occurs when there are expression evaluation failures as well as actual task failures. 

Deck merges all failure messages found in a stage [into a single string](https://github.com/spinnaker/deck/blob/db06e88bada70fa4065f56fc33af7207943415c5/packages/core/src/orchestratedItem/orchestratedItem.transformer.ts#L143) which is then passed to this component. If there are any expression evaluation failures they are always first in the string, so the filter for `Failed to evaluate` is removing the entire thing rather than just the expression failures as intended.