### PR TITLE
fix(lambda): available Runtimes shared between Deploy stage and Functions tab

### DIFF
--- a/packages/amazon/src/function/configure/FunctionBasicInformation.tsx
+++ b/packages/amazon/src/function/configure/FunctionBasicInformation.tsx
@@ -19,7 +19,7 @@ import { s3BucketNameValidator } from '../../aws.validators';
 import type { IAmazonFunction } from '../../domain';
 import type { IAmazonFunctionUpsertCommand } from '../../index';
 
-import {availableRuntimes} from "../../pipeline/stages/deployLambda/components/function.constants";
+import { availableRuntimes } from '../../pipeline/stages/deployLambda/components/function.constants';
 
 export interface IFunctionProps {
   app: Application;

--- a/packages/amazon/src/function/configure/FunctionBasicInformation.tsx
+++ b/packages/amazon/src/function/configure/FunctionBasicInformation.tsx
@@ -19,22 +19,7 @@ import { s3BucketNameValidator } from '../../aws.validators';
 import type { IAmazonFunction } from '../../domain';
 import type { IAmazonFunctionUpsertCommand } from '../../index';
 
-const availableRuntimes = [
-  'nodejs10.x',
-  'nodejs12.x',
-  'java8',
-  'java11',
-  'python2.7',
-  'python3.6',
-  'python3.7',
-  'python3.8',
-  'dotnetcore2.1',
-  'dotnetcore3.1',
-  'go1.x',
-  'ruby2.5',
-  'ruby2.7',
-  'provided',
-];
+import {availableRuntimes} from "../../pipeline/stages/deployLambda/components/function.constants";
 
 export interface IFunctionProps {
   app: Application;


### PR DESCRIPTION
Having the Lambda available Runtimes defined in 2 places creates a drift between what is available in the deploy stage vs what it is available for manual creation of a Lambda function through the Functions tab. 

![Image 2023-10-23 at 17 50 55](https://github.com/spinnaker/deck/assets/28927773/28c66fb6-4525-4647-80bd-1cd21e194217)
