### PR TITLE
fix(functions): Updating Lambda functions available Runtimes to match the Lambda plugin runtimes

### DIFF
--- a/packages/amazon/src/function/configure/FunctionBasicInformation.tsx
+++ b/packages/amazon/src/function/configure/FunctionBasicInformation.tsx
@@ -20,20 +20,26 @@ import type { IAmazonFunction } from '../../domain';
 import type { IAmazonFunctionUpsertCommand } from '../../index';
 
 const availableRuntimes = [
-  'nodejs10.x',
   'nodejs12.x',
+  'nodejs14.x',
+  'nodejs16.x',
+  'nodejs18.x',
   'java8',
+  'java8.al2',
   'java11',
-  'python2.7',
-  'python3.6',
+  'java17',
   'python3.7',
   'python3.8',
-  'dotnetcore2.1',
+  'python3.9',
+  'python3.10',
   'dotnetcore3.1',
+  'dotnet7',
+  'dotnet6',
+  'dotnet5.0',
   'go1.x',
-  'ruby2.5',
   'ruby2.7',
   'provided',
+  'provided.al2',
 ];
 
 export interface IFunctionProps {


### PR DESCRIPTION
Updating Functions available runtimes to match the OSS Lambda plugin ones
![lambdaRuntimes](https://github.com/spinnaker/deck/assets/28927773/688b9774-545d-4e87-907e-ad66f6077f34)
