### PR TITLE
fix(deck/cloudformation): Invalid default name for CloudFormation changeSet

### DIFF
--- a/packages/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
+++ b/packages/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
@@ -13,7 +13,7 @@ export interface ICloudFormationChangeSetInfoProps {
 export const CloudFormationChangeSetInfo = (props: ICloudFormationChangeSetInfoProps) => {
   const { stage, stageconfig } = props;
   const [changeSetName, setChangeSetName] = useState(
-    (stage as any).changeSetName ? (stage as any).changeSetName : "ChangeSet-${ execution['id']}",
+    (stage as any).changeSetName ? (stage as any).changeSetName : "ChangeSet-${execution['id']}",
   );
   const [executeChangeSet, setExecuteChangeSet] = useState((stage as any).executeChangeSet);
   const [actionOnReplacement, setActionOnReplacement] = useState((stage as any).actionOnReplacement);


### PR DESCRIPTION
https://github.com/spinnaker/spinnaker/issues/6889

### Issue Summary:

When you use the "Deploy (CloudFormation Stack)", the default name for the CloudFormation ChangeSet is invalid, this prevents the stage from succeeding.

### Cloud Provider(s):
n/a

### Environment:
n/a

### Feature Area:
Amazon -> "Deploy (CloudFormation Stack)"

### Description:
The default CloudFormation changeSet name has a space in it and is invalid. The code is on [this](https://github.com/spinnaker/deck/blob/8c112bbe6c1a5298eb7c69b6f09927413c8affbb/packages/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx#L16) line:

```
    (stage as any).changeSetName ? (stage as any).changeSetName : "ChangeSet-${ execution['id']}",
```

Notice there is a space before "execution" in the `ChangeSetName`: `ChangeSet-${ execution['id']]"`

This is an invalid name and the pipeline fails.  Without the space it works, it should be changed to:
```
    (stage as any).changeSetName ? (stage as any).changeSetName : "ChangeSet-${execution['id']}",
```

### Steps to Reproduce:
1. Configure an existing or new pipeline
2. Select a region for the stack
3. Add stage -> "Deploy (CloudFormation Stack)"
4. Pick an account
5. Create a Stack name such as "test"
6. Tick the box "Create CloudFormation ChangeSet"
7. Under "Source" select "Text" and enter sample CloudFormation code (such as below, or any other).
```
AWSTemplateFormatVersion: '2010-09-09'
Description: Creates s3 bucket to test cloudformation.
Outputs:
  WebsiteURL:
    Description: URL for website hosted on S3
    Value:
      'Fn::GetAtt':
        - S3Bucket
        - WebsiteURL
Resources:
  S3Bucket:
    Properties:
      BucketName: test1341243141
      PublicAccessBlockConfiguration:
        BlockPublicAcls: false
        BlockPublicPolicy: false
        IgnorePublicAcls: false
        RestrictPublicBuckets: false
    Type: 'AWS::S3::Bucket'
```

Run the pipeline and get the following error:

> Exception ( Monitor Cloud Formation )
> 
> 1 validation error detected: Value null at 'changeSetName' failed to satisfy constraint: Member must not be null (Service: > AmazonCloudFormation; Status Code: 400; Error Code: ValidationError; Request ID: 4d249ee8-52bb-416d-9c95-1b0367ac3b2e; Proxy: null)

### Additional Details:
n/a

