### PR TITLE
fix(amazon): Allow scaling bounds to use floats between input steps

### DIFF
--- a/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/upsert/step/StepPolicyAction.tsx
@@ -106,6 +106,7 @@ export const StepPolicyAction = ({
                 <NumberInput
                   value={step.metricIntervalLowerBound}
                   max={step.metricIntervalUpperBound}
+                  step={0.1}
                   onChange={(e) =>
                     updateStep({ ...step, metricIntervalLowerBound: Number.parseFloat(e.target.value) }, index)
                   }
@@ -121,6 +122,7 @@ export const StepPolicyAction = ({
                 <NumberInput
                   value={step.metricIntervalUpperBound}
                   min={step.metricIntervalLowerBound}
+                  step={0.1}
                   onChange={(e) =>
                     updateStep({ ...step, metricIntervalUpperBound: Number.parseFloat(e.target.value) }, index)
                   }

--- a/packages/amazon/src/serverGroup/serverGroup.transformer.spec.ts
+++ b/packages/amazon/src/serverGroup/serverGroup.transformer.spec.ts
@@ -169,6 +169,17 @@ describe('awsServerGroupTransformer', () => {
           [0, 10, -5],
         );
       });
+
+      it('verify float adjustments work within the range', function () {
+        this.test(
+          [
+            { id: 1, scalingAdjustment: 10, metricIntervalLowerBound: 3.5, metricIntervalUpperBound: 5.5 },
+            { id: 2, scalingAdjustment: 0, metricIntervalLowerBound: 5.5 },
+            { id: 3, scalingAdjustment: -5, metricIntervalLowerBound: 1.2, metricIntervalUpperBound: 3.5 },
+          ],
+          [-5, 10, 0],
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Follow up to https://github.com/spinnaker/deck/pull/10026

It is necessary to add the standard HTML `step` prop in `NumberInput` to allow floats as inputs.