### PR TITLE
feat: Split deployment failure messages.

### DIFF
--- a/packages/core/src/domain/IOrchestratedItem.ts
+++ b/packages/core/src/domain/IOrchestratedItem.ts
@@ -16,6 +16,7 @@ export interface IOrchestratedItem extends ITimedItem {
   getValueFor: (k: string) => any;
   originalStatus: string;
   status: string;
+  failureMessages: string[];
   failureMessage: string;
   isBuffered: boolean;
   isCompleted: boolean;

--- a/packages/core/src/presentation/CollapsibleElement.tsx
+++ b/packages/core/src/presentation/CollapsibleElement.tsx
@@ -12,9 +12,11 @@ export const CollapsibleElement: React.FC<{ maxHeight: number }> = ({ children, 
     setIsOverflowing(contentRef.current.offsetHeight < contentRef.current.scrollHeight);
   }, []);
 
-  React.useEffect(() => {
-    checkIsOverflowing();
-  }, [children, checkIsOverflowing]);
+  React.useLayoutEffect(() => {
+    setTimeout(() => {
+      checkIsOverflowing();
+    });
+  }, [checkIsOverflowing]);
 
   React.useEffect(() => {
     window.addEventListener('resize', checkIsOverflowing);

--- a/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/DeployStatus.less
+++ b/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/DeployStatus.less
@@ -1,0 +1,11 @@
+.deploy-status .collapsible-element {
+  margin-bottom: 20px;
+
+  .alert {
+    margin-bottom: 0;
+  }
+
+  .content {
+    padding: 0;
+  }
+}

--- a/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/DeployStatus.tsx
+++ b/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/DeployStatus.tsx
@@ -2,11 +2,13 @@ import { get } from 'lodash';
 import React from 'react';
 
 import type { IExecutionDetailsSectionProps, IManifest } from '@spinnaker/core';
-import { ExecutionDetailsSection, StageFailureMessage } from '@spinnaker/core';
+import { CollapsibleElement, ExecutionDetailsSection, StageFailureMessage } from '@spinnaker/core';
 
 import { ManifestStatus } from './ManifestStatus';
 import type { IStageManifest } from '../../../../manifest/manifest.service';
 import { KubernetesManifestService } from '../../../../manifest/manifest.service';
+
+import './DeployStatus.less';
 
 export interface IManifestSubscription {
   id: string;
@@ -87,22 +89,28 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
     const { name: sectionName, current: currentSection, stage } = this.props;
     const manifests: IManifest[] = this.state.subscriptions.filter((sub) => !!sub.manifest).map((sub) => sub.manifest);
     return (
-      <ExecutionDetailsSection name={sectionName} current={currentSection}>
-        <StageFailureMessage stage={stage} message={stage.failureMessage} />
-        {manifests && (
-          <div className="row">
-            <div className="col-md-12">
-              <div className="well alert alert-info">
-                {manifests.map((manifest) => {
-                  const uid =
-                    manifest.manifest.metadata.uid || KubernetesManifestService.manifestIdentifier(manifest.manifest);
-                  return <ManifestStatus key={uid} manifest={manifest} account={stage.context.account} />;
-                })}
+      <div className="deploy-status">
+        <ExecutionDetailsSection name={sectionName} current={currentSection}>
+          {stage.failureMessages.map((failureMessage) => (
+            <CollapsibleElement key={failureMessage} maxHeight={150}>
+              <StageFailureMessage stage={stage} message={failureMessage} />
+            </CollapsibleElement>
+          ))}
+          {!!manifests?.length && (
+            <div className="row">
+              <div className="col-md-12">
+                <div className="well alert alert-info">
+                  {manifests.map((manifest) => {
+                    const uid =
+                      manifest.manifest.metadata.uid || KubernetesManifestService.manifestIdentifier(manifest.manifest);
+                    return <ManifestStatus key={uid} manifest={manifest} account={stage.context.account} />;
+                  })}
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </ExecutionDetailsSection>
+          )}
+        </ExecutionDetailsSection>
+      </div>
     );
   }
 }


### PR DESCRIPTION
In the context of the deploy manifest stage, numerous failure messages are currently consolidated into a single message, rendering the information less user-friendly. This is primarily attributed to the necessity of scrolling through the lengthy message and attentively discerning where one exception concludes and another commences. The proposed resolution in this pull request involves segregating failure messages into distinct blocks. For a more comprehensive understanding of this enhancement, kindly refer to the attached video demonstration.

https://github.com/spinnaker/deck/assets/106548537/b8886a99-bcda-4044-a869-2267b211539f

