### PR TITLE
feat: Expose spinnaker/kayenta to the plugin framework to allow us to create kayenta plugins in Deck

### DIFF
--- a/packages/core/src/plugins/sharedLibraries.ts
+++ b/packages/core/src/plugins/sharedLibraries.ts
@@ -8,7 +8,6 @@ import * as reactDOM from 'react-dom';
 import * as rxjs from 'rxjs';
 
 import * as spinnakerCore from '../index';
-
 export const sharedLibraries = {
   // This is the global (window) variable that the shared libs will be exposed on
   globalVariablePrefix: 'spinnaker.plugins.sharedLibraries',
@@ -30,7 +29,9 @@ export const sharedLibraries = {
     if (destinationObject) {
       // Temporarily expose @spinnaker/core.
       // This should be removed at some point and replaced with a much smaller spinnaker/ui module which doesn't yet exist
+      exposeSharedLibrary('ajv', require('ajv'));
       exposeSharedLibrary('@spinnaker/core', spinnakerCore);
+      exposeSharedLibrary('@spinnaker/kayenta', require('@spinnaker/kayenta'));
       exposeSharedLibrary('@uirouter/core', uiRouterCore);
       exposeSharedLibrary('@uirouter/react', uiRouterReact);
       exposeSharedLibrary('@uirouter/rx', uiRouterRx);
@@ -38,6 +39,9 @@ export const sharedLibraries = {
       exposeSharedLibrary('prop-types', propTypes);
       exposeSharedLibrary('react', react);
       exposeSharedLibrary('react-dom', reactDOM);
+      exposeSharedLibrary('react-redux', require('react-redux'));
+      exposeSharedLibrary('redux-actions', require('redux-actions'));
+      exposeSharedLibrary('reselect', require('reselect'));
       exposeSharedLibrary('rxjs', rxjs);
       exposeSharedLibrary('rxjs/Observable', { Observable: rxjs.Observable });
     }

--- a/packages/scripts/config/rollup.config.base.plugin.js
+++ b/packages/scripts/config/rollup.config.base.plugin.js
@@ -15,7 +15,9 @@ module.exports = {
 function spinnakerSharedLibraries() {
   // Updates here should also be added in core/src/plugins/sharedLibraries.ts
   const libraries = [
+    'ajv',
     '@spinnaker/core',
+    '@spinnaker/kayenta',
     '@uirouter/core',
     '@uirouter/react',
     '@uirouter/rx',
@@ -23,6 +25,9 @@ function spinnakerSharedLibraries() {
     'prop-types',
     'react',
     'react-dom',
+    'react-redux',
+    'redux-actions',
+    'reselect',
     'rxjs',
     'rxjs/Observable',
   ];


### PR DESCRIPTION
Currently it is not possible to write Deck Kayenta plugins because the kayenta module is not exposed to the plugin system. With this PR we intend to implement this feature