### PR TITLE
Make Wait Stage restartable

### DIFF
--- a/packages/core/src/pipeline/config/stages/wait/waitStage.ts
+++ b/packages/core/src/pipeline/config/stages/wait/waitStage.ts
@@ -8,6 +8,7 @@ Registry.pipeline.registerStage({
   label: 'Wait',
   description: 'Waits a specified period of time',
   key: 'wait',
+  restartable: true,
   component: WaitStageConfig,
   executionDetailsSections: [WaitExecutionDetails, ExecutionDetailsTasks],
   executionLabelComponent: WaitExecutionLabel,


### PR DESCRIPTION
I think, It is necessary to make Wait stage restartable, because if you cancel release pipeline, while Wait Stage is running, you won't be able to restart pipeline where it stopped, you will be forced to restart pipeline from the very beginning.

Before:
<img width="349" alt="image" src="https://github.com/spinnaker/deck/assets/70900359/304ffdec-9808-44a0-b554-5bdd218f3e45">

After:
<img width="349" alt="image" src="https://github.com/spinnaker/deck/assets/70900359/d661f53e-bbb6-4f9a-96b3-52edd50f3d2a">