### PR TITLE
feat(ecs): Add support for ECS deployment circuit breaker

### DIFF
--- a/packages/ecs/src/ecs.help.ts
+++ b/packages/ecs/src/ecs.help.ts
@@ -36,6 +36,7 @@ const helpContents: { [key: string]: string } = {
   'ecs.placementStrategy':
     '<p>The strategy the container scheduler will be using.  See <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html" target="_blank">AWS documentation</a> for more details. </p><p>You should at least balance across availability zones</p><p>Custom placement strategies have not been implemented yet.</p>',
   'ecs.platformVersion': '<p>Defaults to the latest platform version.</p>',
+  'ecs.enableDeploymentCircuitBreaker': '<p>Enable circuit breaker for the ECS service.</p>',
   'ecs.capacity.copySourceScalingPoliciesAndActions':
     '<p>Copy Application Autoscaling policies and their associated alarms from the previous ECS service.</p>',
   'ecs.launchtype': '<p>Launch service tasks on your own EC2 instances or on Fargate.</p>',

--- a/packages/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/packages/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -151,6 +151,7 @@ angular
               copySourceScalingPoliciesAndActions: true,
               preferSourceCapacity: true,
               useSourceCapacity: true,
+              enableDeploymentCircuitBreaker: false,
               viewState: {
                 useAllImageSelection: false,
                 useSimpleCapacity: true,

--- a/packages/ecs/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
+++ b/packages/ecs/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
@@ -79,12 +79,12 @@
   </div>
 
   <div class="form-group">
-    <div class="col-md-12 checkbox">
-      <label>
-        <input type="checkbox" ng-model="$ctrl.command.enableDeploymentCircuitBreaker" />
-        <b>Enable Deployment Circuit Breaker for the ECS service.</b>
-      </label>
+    <div class="col-md-5 sm-label-right">
+      Enable Deployment Circuit Breaker
       <help-field key="ecs.enableDeploymentCircuitBreaker"></help-field>
+    </div>
+    <div class="col-md-3">
+      <input type="checkbox" ng-model="$ctrl.command.enableDeploymentCircuitBreaker" />
     </div>
   </div>
 

--- a/packages/ecs/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
+++ b/packages/ecs/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
@@ -79,6 +79,16 @@
   </div>
 
   <div class="form-group">
+    <div class="col-md-12 checkbox">
+      <label>
+        <input type="checkbox" ng-model="$ctrl.command.enableDeploymentCircuitBreaker" />
+        <b>Enable Deployment Circuit Breaker for the ECS service.</b>
+      </label>
+      <help-field key="ecs.enableDeploymentCircuitBreaker"></help-field>
+    </div>
+  </div>
+
+  <div class="form-group">
     <div class="col-md-5 sm-label-right">
       <b>Placement Strategy</b> <help-field key="ecs.placementStrategy"></help-field>
     </div>


### PR DESCRIPTION
This is my first contribution, and I tried to implement https://github.com/spinnaker/spinnaker/issues/6225

This change comes together with this PR from clouddriver: https://github.com/spinnaker/clouddriver/pull/6132

It implements a new checkbox to activate ECS Deployment Circuit Breaker for the ECS service; the default is false to not change any existing behavior.

The checkbox looks like this. I thought it should go under "Advanced settings".
![image](https://github.com/spinnaker/clouddriver/assets/5127047/83f65ee1-a259-44da-90b0-0329abf5b1f1)

If enabled, it adds the attribute `enabledDeploymentCircuitBreaker` to the server group:
![image](https://github.com/spinnaker/clouddriver/assets/5127047/553469a4-e93a-4b4d-8e1a-c92791c947eb)

Running the Deploy stage will create an ECS service with Deployment Circuit Breaker enabled:
![image](https://github.com/spinnaker/clouddriver/assets/5127047/33ab34af-b83e-4672-a6f7-6cb8bceb8d5d)

I'm open for your comments and your thoughts, also on the implementation - I mainly "mimicked" how other attributes/feature were implemented and tried my best "copy/pasting". 😏 
