### PR TITLE
fix(runJobs): Persist External Log links after the deletion of the pods

### DIFF
--- a/packages/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/packages/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -52,7 +52,7 @@ export class JobStageExecutionLogs extends React.Component<IJobStageExecutionLog
     const { manifest } = this.state;
     const { externalLink, podNamesProviders, location, account } = this.props;
     // prefer links to external logging platforms
-    if (!isEmpty(manifest) && externalLink) {
+    if (externalLink) {
       return (
         <a target="_blank" href={this.renderExternalLink(externalLink, manifest)}>
           Console Output (External)

--- a/packages/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/packages/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -1,4 +1,4 @@
-import { isEmpty, template } from 'lodash';
+import { template } from 'lodash';
 import React from 'react';
 import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';


### PR DESCRIPTION
After the deletion of the runjob (for any reason) Deck instead of persisting the External system link for the logs it falls back to the default Console Output.

Since the user is linking the logs of a Runjob to an external system it makes sense that the link for the previous executions should persist in Deck. 

Fixes this old issue: https://github.com/spinnaker/spinnaker/issues/5717