### PR TITLE
fix(pipelineGraph): Handling exception when requisiteStageRefIds is not defined

### DIFF
--- a/packages/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/packages/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -142,6 +142,9 @@ export class PipelineConfigService {
   private static groupStagesByRequisiteStageRefIds(pipeline: IPipeline) {
     return pipeline.stages.reduce((acc, obj) => {
       const parent = obj['refId'];
+      if (obj['requisiteStageRefIds'] === undefined) {
+        obj['requisiteStageRefIds'] = [];
+      }
       obj.requisiteStageRefIds.forEach((child) => {
         const values = acc.get(child);
         if (values && values.length) {


### PR DESCRIPTION
Deck prior to 1.27.x was rendering the pipelines when the first stages didnt have defined the requisiteStageRefIds. 

Although this was not ideal it allowed users to template their first stages without the key. After the pipelineGraph updates this is causing an exception and breaking the rendering of the pipelines causing issues to users upgrading.

With this fix it is checked if the key is not defined and defaulting it to a empty array.

![Screenshot 2024-04-25 at 09 06 19](https://github.com/spinnaker/deck/assets/28927773/66c74964-c826-47af-8352-6e4a692e23f0)
