### PR TITLE
fix(lambda): Invoke stage excludedArtifactTypes not including the embedded-artifact type

### DIFF
--- a/packages/amazon/src/pipeline/stages/invokeLambda/components/InvokeLambdaOperation.tsx
+++ b/packages/amazon/src/pipeline/stages/invokeLambda/components/InvokeLambdaOperation.tsx
@@ -19,6 +19,7 @@ export function InvokeLambdaOperation(props: IFormikStageConfigInjectedProps) {
     ArtifactTypePatterns.BITBUCKET_FILE,
     ArtifactTypePatterns.CUSTOM_OBJECT,
     ArtifactTypePatterns.EMBEDDED_BASE64,
+    ArtifactTypePatterns.REMOTE_BASE64,
     ArtifactTypePatterns.GCS_OBJECT,
     ArtifactTypePatterns.GITHUB_FILE,
     ArtifactTypePatterns.GITLAB_FILE,


### PR DESCRIPTION
Lambda Invoke Stage after the implementation of the remote/base64 as an artifact type is not including the embedded-artifact account in the expected artifacts since the REMOTE_BASE64 artifact type was not added in the except list.

Before the change:
![image](https://github.com/spinnaker/deck/assets/28927773/c17644cf-a11a-4f80-a2d6-71fc800182d8)

After the change:
![image](https://github.com/spinnaker/deck/assets/28927773/54889936-1367-4132-b961-010ef0e2f3af)
