### PR TITLE
fix(pipeline): Handle render/validation when stageTimeoutMs is a Spel expression

### DIFF
--- a/packages/core/src/pipeline/config/validation/PipelineConfigValidator.ts
+++ b/packages/core/src/pipeline/config/validation/PipelineConfigValidator.ts
@@ -54,6 +54,10 @@ export interface ICustomValidator extends IStageOrTriggerValidator, IValidatorCo
   [k: string]: any;
 }
 
+function isNumberOrSpel(valInput: any) {
+  return (isNumber(valInput) && valInput > 0) || (typeof valInput === 'string' && valInput.includes('${'));
+}
+
 export class PipelineConfigValidator {
   private static validators: Map<string, IStageOrTriggerValidator> = new Map();
   private static validationStream: Subject<IPipelineValidationResults> = new Subject();
@@ -151,7 +155,7 @@ export class PipelineConfigValidator {
         );
       }
 
-      if (stage.stageTimeoutMs !== undefined && !(isNumber(stage.stageTimeoutMs) && stage.stageTimeoutMs > 0)) {
+      if (stage.stageTimeoutMs !== undefined && !isNumberOrSpel(stage.stageTimeoutMs)) {
         stageValidations.set(stage, [
           ...(stageValidations.get(stage) || []),
           'Stage is configured to fail after a specific amount of time, but no time is set.',


### PR DESCRIPTION
Deck is throwing an exception when stageTimeoutMs is templated with a Spel Expression although Orca can handle the evaluation during runtime. 

This PR fixes the exception in Deck and also modifies the validator to accept a Spel expression. 

Before the change: 
![image](https://github.com/spinnaker/deck/assets/28927773/def10c14-88d5-491f-919f-5160dcbf6e0a)


After the change: 
![image](https://github.com/spinnaker/deck/assets/28927773/5b503788-0dfc-49da-9454-c91c1a9f7b28)


Recording with a pipeline that uses input with Spel to determine the stageTimeoutMs:


https://github.com/spinnaker/deck/assets/28927773/8f550f45-e2b4-4abf-8ee6-ff6a9fe8c182

