### PR TITLE
chore(secrets): adding GHA to sync NPM_AUTH_TOKEN to spinnaker/spinna…

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -22,11 +22,11 @@ jobs:
         uses: jpoehnelt/secrets-sync-action@v1.9.0
         with:
           SECRETS: |
-            ^SECRET_TO_SYNC$
+            ^NPM_AUTH_TOKEN$
           REPOSITORIES: |
-            ^link108/sync-secrets-to$
+            ^spinnaker/spinnaker$
           DRY_RUN: ${{ github.event.inputs.dry_run }}
           GITHUB_TOKEN: ${{ secrets.SYNC_TOKEN }}
         env:
-          SECRET_TO_SYNC: ${{ secrets.NPM_AUTH_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -1,0 +1,32 @@
+name: Sync Secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry Run'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+jobs:
+  sync-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Sync Secrets
+        uses: jpoehnelt/secrets-sync-action@v1.9.0
+        with:
+          SECRETS: |
+            ^SECRET_TO_SYNC$
+          REPOSITORIES: |
+            ^link108/sync-secrets-to$
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          GITHUB_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        env:
+          SECRET_TO_SYNC: ${{ secrets.NPM_AUTH_TOKEN }}
+


### PR DESCRIPTION
After this PR is merged, I'll add a personal access token, scoped to spinnaker/deck and spinnaker/spinnaker with the secrets read/write permissions enabled. I'm just going to use a personal token vs an org token, since we don't have that setup at the moment. 