### PR TITLE
chore(gcp): Adding STRONG_COOKIE_AFFINITY in gcp LB model

### DIFF
--- a/packages/google/src/loadBalancer/configure/common/sessionAffinityNameMaps.ts
+++ b/packages/google/src/loadBalancer/configure/common/sessionAffinityNameMaps.ts
@@ -12,6 +12,7 @@ export const sessionAffinityViewToModelMap: IStringMap = {
   'Client IP, port and protocol': 'CLIENT_IP_PORT_PROTO',
   'Header Field': 'HEADER_FIELD',
   'HTTP Cookie': 'HTTP_COOKIE',
+  'Strong Cookie': 'STRONG_COOKIE_AFFINITY',
 };
 
 export const sessionAffinityModelToViewMap = _.invert<IStringMap, IStringMap>(sessionAffinityViewToModelMap);


### PR DESCRIPTION
Although STRONG_COOKIE_AFFINITY is a beta feature for GCP LB adding it to the model as an option.

Related clouddriver PR https://github.com/spinnaker/clouddriver/pull/6259