### PR TITLE
fix(aws): Fix userData getting lost when cloning an AWS server group that uses launch templates (#6771)

### DIFF
--- a/packages/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/packages/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -405,6 +405,9 @@ angular
                 spotMaxPrice = launchTemplateData.instanceMarketOptions?.spotOptions?.maxPrice;
                 command.instanceType = launchTemplateData.instanceType;
                 command.viewState.useSimpleInstanceTypeSelector = true;
+                if (launchTemplateData.userData) {
+                  command.base64UserData = launchTemplateData.userData;
+                }
               }
 
               if (serverGroup.mixedInstancesPolicy) {


### PR DESCRIPTION
Fixes issue [6771](https://github.com/spinnaker/spinnaker/issues/6771).

<img width="892" alt="deck-fix" src="https://github.com/user-attachments/assets/4e180704-b920-4f82-b47d-ff462013cc63">
