### PR TITLE
fix(aws): Fix IPv6 addresses being incorrectly associated when cloning server groups that have launch templates enabled (#6979)

### DIFF
--- a/packages/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/packages/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -437,7 +437,8 @@ angular
                 command.viewState.useSimpleInstanceTypeSelector = isSimpleModeEnabled(command);
               }
 
-              const ipv6AddressCount = _.get(launchTemplateData, 'networkInterfaces[0]');
+              const networkInterfaces = _.get(launchTemplateData, 'networkInterfaces[0]');
+              const ipv6AddressCount = (networkInterfaces as INetworkInterface)?.ipv6AddressCount ?? 0;
 
               const asgSettings = AWSProviderSettings.serverGroups;
               const isTestEnv = serverGroup.accountDetails && serverGroup.accountDetails.environment === 'test';


### PR DESCRIPTION
This is a fix for [#6979](https://github.com/spinnaker/spinnaker/issues/6979).

<img width="606" alt="ipv6" src="https://github.com/user-attachments/assets/320077fc-6d93-4d82-8513-9f6553d52658">

The IPv6 checkbox was previously checked when it should not have been.

This line:

```
associateIPv6Address: shouldAutoEnableIPv6 || Boolean(ipv6AddressCount),
```

Was casting the entire object below to Boolean, which ALWAYS resulted in a value of `true`:

```json
[
  {
    "deviceIndex": 0,
    "groups": [
      "sg-0a1a8a45acf3192b8"
    ],
    "ipv4Prefixes": [],
    "ipv6AddressCount": 0,
    "ipv6Addresses": [],
    "ipv6Prefixes": [],
    "privateIpAddresses": []
  }
]
```

The change casts the value of `ipv6AddressCount` within the object to Boolean instead of the object itself.