### PR TITLE
feat(evaluateVariables stage) Made fetch exec history on evaluateVariables stage configurable

### DIFF
--- a/packages/app/src/settings.js
+++ b/packages/app/src/settings.js
@@ -148,6 +148,7 @@ window.spinnakerSettings = {
     defaultManifest: 'spinnaker.yml',
     manifestBasePath: '.spinnaker',
   },
+  maxFetchHistoryOnEvaluateVariables: 100,
   maxPipelineAgeDays: 14,
   newApplicationDefaults: {
     chaosMonkey: false,

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -127,6 +127,7 @@ export interface ISpinnakerSettings {
     manifestBasePath: string;
     urls?: Partial<IManagedDeliveryURLs>;
   };
+  maxFetchHistoryOnEvaluateVariables?: number;
   maxPipelineAgeDays: number;
   newApplicationDefaults: INewApplicationDefaults;
   notifications: INotificationSettings;
@@ -175,6 +176,7 @@ SETTINGS.managedDelivery = SETTINGS.managedDelivery || {
   defaultManifest: 'spinnaker.yml',
   manifestBasePath: '.spinnaker',
 };
+SETTINGS.maxFetchHistoryOnEvaluateVariables = SETTINGS.maxFetchHistoryOnEvaluateVariables ?? 100;
 
 // A helper to make resetting settings to steady state after running tests easier
 const originalSettings: ISpinnakerSettings = cloneDeep(SETTINGS);

--- a/packages/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
+++ b/packages/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
@@ -26,7 +26,7 @@ export function ExecutionAndStagePicker(props: IExecutionAndStagePickerProps) {
   const fetchExecutions = useData(
     () =>
       executionService.getExecutionsForConfigIds([pipeline.id], {
-        limit: SETTINGS.maxFetchHistoryOnEvaluateVariables
+        limit: SETTINGS.maxFetchHistoryOnEvaluateVariables,
       }),
     [],
     [],

--- a/packages/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
+++ b/packages/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
@@ -2,6 +2,7 @@ import { isEqual, keyBy } from 'lodash';
 import React from 'react';
 import type { Option } from 'react-select';
 
+import { SETTINGS } from '../../../../config';
 import type { IExecution, IPipeline, IStage } from '../../../../domain';
 import type { IStageForSpelPreview } from '../../../../presentation';
 import { FormField, ReactSelectInput, useData } from '../../../../presentation';
@@ -23,7 +24,10 @@ export function ExecutionAndStagePicker(props: IExecutionAndStagePickerProps) {
   const [showStageSelector, setShowStageSelector] = React.useState(false);
 
   const fetchExecutions = useData(
-    () => executionService.getExecutionsForConfigIds([pipeline.id], { limit: 100 }),
+    () =>
+      executionService.getExecutionsForConfigIds([pipeline.id], {
+        limit: SETTINGS.maxFetchHistoryOnEvaluateVariables
+      }),
     [],
     [],
   );


### PR DESCRIPTION
Evaluate Variables stage on pipeline config view loads previous 100 pipeline execution history to show the evaluated variable values on previous execution.

The size of execution context is too huge if the pipeline is lengthy and it has a lot of artifacts and have a lot of previous executions. One of our pipeline is not accessible evaluate variables stage in the pipeline config as it timed out on `executionService.getExecutionsForConfigIds()` executions always due to size of the response (~400MB) and slowness of the VPN network.

![phoenix-mcd_·_pipeline_config](https://github.com/user-attachments/assets/b1ccd108-6d03-4f96-a495-7a7e2547531b)

Spinning circle UI is keep going and then timed out usually due to slowness of the network and size of the http get response.



This change can make the number of fetching history configurable on `settings-local.js`
```
window.spinnakerSettings.maxFetchHistoryOnEvaluateVariables = 5;
```

Default value of it is `100` if it is not defined on `settings-local.js`.

With this change we can adjust fetch history size for evaluate variable stage config UI, and prevent UI delays and errors.


