### PR TITLE
feat(gce): support resourceManagerTags in instance template

### DIFF
--- a/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -285,6 +285,12 @@ angular
         }
       }
 
+      function populateResourceManagerTags(instanceTemplateResourceManagerTags, command) {
+        if (instanceTemplateResourceManagerTags) {
+          Object.assign(command.resourceManagerTags, instanceTemplateResourceManagerTags);
+        }
+      }
+
       function populateLabels(instanceTemplateLabels, command) {
         if (instanceTemplateLabels) {
           Object.assign(command.labels, instanceTemplateLabels);
@@ -363,6 +369,7 @@ angular
           instanceMetadata: {},
           tags: [],
           labels: {},
+          resourceManagerTags: [],
           enableSecureBoot: false,
           enableVtpm: false,
           enableIntegrityMonitoring: false,
@@ -441,6 +448,7 @@ angular
           instanceMetadata: {},
           tags: [],
           labels: {},
+          resourceManagerTags: [],
           availabilityZones: [],
           enableSecureBoot: serverGroup.enableSecureBoot,
           enableVtpm: serverGroup.enableVtpm,
@@ -573,6 +581,9 @@ angular
               const instanceTemplateTags = { items: extendedCommand.tags };
               extendedCommand.tags = [];
               populateTags(instanceTemplateTags, extendedCommand);
+
+              const resourceManagerTags = extendedCommand.resourceManagerTags
+              populateResourceManagerTags(resourceManagerTags, extendedCommand)
 
               return extendedCommand;
             });

--- a/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -369,7 +369,7 @@ angular
           instanceMetadata: {},
           tags: [],
           labels: {},
-          resourceManagerTags: [],
+          resourceManagerTags: {},
           enableSecureBoot: false,
           enableVtpm: false,
           enableIntegrityMonitoring: false,
@@ -448,7 +448,7 @@ angular
           instanceMetadata: {},
           tags: [],
           labels: {},
-          resourceManagerTags: [],
+          resourceManagerTags: {},
           availabilityZones: [],
           enableSecureBoot: serverGroup.enableSecureBoot,
           enableVtpm: serverGroup.enableVtpm,
@@ -582,8 +582,8 @@ angular
               extendedCommand.tags = [];
               populateTags(instanceTemplateTags, extendedCommand);
 
-              const resourceManagerTags = extendedCommand.resourceManagerTags
-              populateResourceManagerTags(resourceManagerTags, extendedCommand)
+              const resourceManagerTags = extendedCommand.resourceManagerTags;
+              populateResourceManagerTags(resourceManagerTags, extendedCommand);
 
               return extendedCommand;
             });

--- a/packages/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.directive.html
+++ b/packages/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.directive.html
@@ -89,6 +89,13 @@
 </div>
 <div class="form-group">
   <div class="sm-label-left">
+    <b>Resource Manager Tags</b>
+    <help-field key="gce.serverGroup.resourceManagerTags"></help-field>
+  </div>
+  <map-editor model="vm.command.resourceManagerTags" add-button-label="Add New Tag" allow-empty="true"></map-editor>
+</div>
+<div class="form-group">
+  <div class="sm-label-left">
     Shielded VMs
     <help-field key="gce.serverGroup.shieldedVmConfig"></help-field>
   </div>

--- a/packages/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.directive.html
+++ b/packages/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.directive.html
@@ -92,7 +92,7 @@
     <b>Resource Manager Tags</b>
     <help-field key="gce.serverGroup.resourceManagerTags"></help-field>
   </div>
-  <map-editor model="vm.command.resourceManagerTags" add-button-label="Add New Tag" allow-empty="true"></map-editor>
+  <map-editor model="vm.command.resourceManagerTags" add-button-label="Add New Tag" allow-empty="false"></map-editor>
 </div>
 <div class="form-group">
   <div class="sm-label-left">

--- a/packages/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettingsSelector.directive.spec.js
+++ b/packages/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettingsSelector.directive.spec.js
@@ -18,7 +18,7 @@ describe('Directive: GCE Group Advanced Settings Selector', function () {
       );
       this.gceTagManager = gceTagManager;
       this.scope = $rootScope.$new();
-      this.scope.command = { instanceMetadata: [], tags: [], labels: [], authScopes: [] };
+      this.scope.command = { instanceMetadata: [], tags: [], labels: [], authScopes: [], resourceManagerTags: [] };
       this.elem = angular.element(
         '<gce-server-group-advanced-settings-selector command="command"></gce-server-group-advanced-settings-selector>',
       );
@@ -55,19 +55,4 @@ describe('Directive: GCE Group Advanced Settings Selector', function () {
     expect(this.scope.command.tags[0].value).toEqual('myTag2');
     expect(this.gceTagManager.updateSelectedTags).toHaveBeenCalled();
   });
-
-  it('should correctly add ResourceManagerTags to the command', function () {
-    expect(this.scope.command.resourceManagerTags.length).toEqual(0);
-
-    this.elem.find('table.resourceManagerTags button').trigger('click');
-    this.scope.$apply();
-    expect(this.scope.command.tags.length).toEqual(1);
-
-    this.elem.find('table.resourceManagerTags input').val('myTag').trigger('input');
-    this.scope.$apply();
-
-    expect(this.scope.command.tags.length).toEqual(1);
-    expect(this.scope.command.tags[0].value).toEqual('myTag');
-  });
-
 });

--- a/packages/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettingsSelector.directive.spec.js
+++ b/packages/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettingsSelector.directive.spec.js
@@ -55,4 +55,19 @@ describe('Directive: GCE Group Advanced Settings Selector', function () {
     expect(this.scope.command.tags[0].value).toEqual('myTag2');
     expect(this.gceTagManager.updateSelectedTags).toHaveBeenCalled();
   });
+
+  it('should correctly add ResourceManagerTags to the command', function () {
+    expect(this.scope.command.resourceManagerTags.length).toEqual(0);
+
+    this.elem.find('table.resourceManagerTags button').trigger('click');
+    this.scope.$apply();
+    expect(this.scope.command.tags.length).toEqual(1);
+
+    this.elem.find('table.resourceManagerTags input').val('myTag').trigger('input');
+    this.scope.$apply();
+
+    expect(this.scope.command.tags.length).toEqual(1);
+    expect(this.scope.command.tags[0].value).toEqual('myTag');
+  });
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5828,15 +5828,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001248:
-  version "1.0.30001251"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
-
-caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
-  version "1.0.30001373"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz#2dc3bc3bfcb5d5a929bec11300883040d7b4b4be"
-  integrity sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001248, caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
+  version "1.0.30001662"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz"
+  integrity sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Add support for `resourceManagerTags` in GCE. For more details, refer to: https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert.

Enable [Resource Manager Tags](https://cloud.google.com/resource-manager/docs/tags/tags-overview) in the configuration of Deploy stages for the Google provider in GCE.

When setting up a GCE deployment, the resource-manager-tags input option can be found under the Advanced settings.
<img width="1271" alt="Captura de pantalla 2024-09-23 a la(s) 9 50 19 p m" src="https://github.com/user-attachments/assets/660f2512-44ff-4261-808d-9ff3c57c53e0">
<img width="922" alt="Captura de pantalla 2024-09-23 a la(s) 9 50 47 p m" src="https://github.com/user-attachments/assets/f7279b49-7517-4ee1-8bb0-ee0af57fc144">


Resource manager tags must have the following structure: `tagKeys/xxxxxxxx` and `tagValues/xxxxxxx` and resource tags needs to be created before add them to the GCE cluster.

The resourceManagerTags are added in the cluster info:
<img width="659" alt="Captura de pantalla 2024-09-23 a la(s) 9 53 09 p m" src="https://github.com/user-attachments/assets/f2438ed8-debc-4c8d-894a-62da6d60500c">

Once the deployment is successful, the resourceManagerTags will be attached to both the InstanceTemplate and the Instance in GCE:
<img width="936" alt="Captura de pantalla 2024-09-23 a la(s) 9 57 08 p m" src="https://github.com/user-attachments/assets/e3e620b6-a4db-433c-ae4b-3160e8c83fdc">
<img width="1048" alt="Captura de pantalla 2024-09-23 a la(s) 9 57 39 p m" src="https://github.com/user-attachments/assets/5b474433-a68e-4eaa-befe-b578e07472a2">

Clouddriver PR: https://github.com/spinnaker/clouddriver/pull/6282
Kork PR: https://github.com/spinnaker/kork/pull/1203
Issue related: https://github.com/spinnaker/spinnaker/issues/6931