### PR TITLE
feat(gce): add support for hyperdisk in GCE

### DIFF
--- a/packages/google/src/instance/gceInstanceTypeDisks.ts
+++ b/packages/google/src/instance/gceInstanceTypeDisks.ts
@@ -78,7 +78,7 @@ export const GCE_INSTANCE_TYPE_DISK_DEFAULTS = Object.freeze([
     supportsLocalSSD: false,
     disks: [
       {
-        type: 'hyperdisk-balanced',
+        type: 'pd-standard',
         sizeGb: 10,
       },
     ],

--- a/packages/google/src/instance/gceInstanceTypeDisks.ts
+++ b/packages/google/src/instance/gceInstanceTypeDisks.ts
@@ -78,7 +78,7 @@ export const GCE_INSTANCE_TYPE_DISK_DEFAULTS = Object.freeze([
     supportsLocalSSD: false,
     disks: [
       {
-        type: 'pd-standard',
+        type: 'hyperdisk-balanced',
         sizeGb: 10,
       },
     ],

--- a/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -104,7 +104,9 @@ angular
           }
         });
         const localSSDDisks = disks.filter((disk) => disk.type === 'local-ssd');
-        const persistentDisks = disks.filter((disk) => disk.type.startsWith('pd-'));
+        const persistentDisks = disks.filter(
+          (disk) => disk.type.startsWith('pd-') || disk.type.startsWith('hyperdisk-'),
+        );
 
         if (persistentDisks.length) {
           command.disks = persistentDisks.concat(localSSDDisks);

--- a/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -151,7 +151,9 @@ angular
       }
 
       function getPersistentDisks(command) {
-        return (command.disks || []).filter((disk) => disk.type.startsWith('pd-'));
+        return (command.disks || []).filter(
+          (disk) => disk.type.startsWith('pd-') || disk.type.startsWith('hyperdisk-'),
+        );
       }
 
       function calculatePersistentDiskOverriddenStorageDescription(command) {

--- a/packages/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/packages/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -61,7 +61,7 @@ angular
       gceTagManager,
       gceLoadBalancerSetTransformer,
     ) {
-      const persistentDiskTypes = ['pd-standard', 'pd-ssd'];
+      const persistentDiskTypes = ['pd-standard', 'pd-ssd', 'hyperdisk-balanced'];
       const authScopes = [
         'cloud-platform',
         'userinfo.email',

--- a/packages/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
+++ b/packages/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
@@ -84,7 +84,9 @@ class GceDiskConfigurerController implements IComponentController {
   }
 
   private sortDisks(disks: IGceDisk[]): IGceDisk[] {
-    const diskWithoutImage = disks.find((disk) => disk.type.startsWith('pd-') && disk.sourceImage === undefined);
+    const diskWithoutImage = disks.find(
+      (disk) => (disk.type.startsWith('pd-') || disk.type.startsWith('hyperdisk-')) && disk.sourceImage === undefined,
+    );
     return [diskWithoutImage].concat(without(disks, diskWithoutImage));
   }
 
@@ -93,7 +95,9 @@ class GceDiskConfigurerController implements IComponentController {
   }
 
   private getPersistentDisks(): IGceDisk[] {
-    return (this.command.disks || []).filter((disk: IGceDisk) => disk.type.startsWith('pd-'));
+    return (this.command.disks || []).filter(
+      (disk: IGceDisk) => disk.type.startsWith('pd-') || disk.type.startsWith('hyperdisk-'),
+    );
   }
 }
 

--- a/packages/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
+++ b/packages/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
@@ -22,16 +22,10 @@ class GceDiskConfigurerController implements IComponentController {
   constructor(public $scope: IScope) {}
 
   public $onInit(): void {
-    /* eslint-disable no-console */
-    console.log('init persistDisk component');
-    /* eslint-enable no-console */
     this.setLocalSSDCount();
     this.setPersistentDisks();
 
     if (this.getLocalSSDDisks().length && !this.command?.viewState?.instanceTypeDetails?.storage?.localSSDSupported) {
-      /* eslint-disable no-console */
-      console.log('updating disks on init ', this.sortDisks(this.getPersistentDisks()));
-      /* eslint-enable no-console */
       this.updateDisks({ disks: this.sortDisks(this.getPersistentDisks()) });
     }
 
@@ -59,13 +53,7 @@ class GceDiskConfigurerController implements IComponentController {
 
   public handlePersistentDiskChange(): void {
     let disks = this.persistentDisks.concat(this.getLocalSSDDisks());
-    /* eslint-disable no-console */
-    console.log('handle persist disk change, before sort', disks);
-    /* eslint-enable no-console */
     disks = this.sortDisks(disks);
-    /* eslint-disable no-console */
-    console.log('handle persist disk change, after sort', disks);
-    /* eslint-enable no-console */
     this.updateDisks({ disks });
   }
 
@@ -99,9 +87,6 @@ class GceDiskConfigurerController implements IComponentController {
     const diskWithoutImage = disks.find(
       (disk) => (disk.type.startsWith('pd-') || disk.type.startsWith('hyperdisk-')) && disk.sourceImage === undefined,
     );
-    /* eslint-disable no-console */
-    console.log('in sort,', disks, diskWithoutImage);
-    /* eslint-enable no-console */
     return [diskWithoutImage].concat(without(disks, diskWithoutImage));
   }
 
@@ -110,9 +95,6 @@ class GceDiskConfigurerController implements IComponentController {
   }
 
   private getPersistentDisks(): IGceDisk[] {
-    /* eslint-disable no-console */
-    console.log('getting persist disks ', this.command.disks);
-    /* eslint-enable no-console */
     return (this.command.disks || []).filter(
       (disk: IGceDisk) => disk.type.startsWith('pd-') || disk.type.startsWith('hyperdisk-'),
     );

--- a/packages/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
+++ b/packages/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
@@ -22,10 +22,16 @@ class GceDiskConfigurerController implements IComponentController {
   constructor(public $scope: IScope) {}
 
   public $onInit(): void {
+    /* eslint-disable no-console */
+    console.log('init persistDisk component');
+    /* eslint-enable no-console */
     this.setLocalSSDCount();
     this.setPersistentDisks();
 
     if (this.getLocalSSDDisks().length && !this.command?.viewState?.instanceTypeDetails?.storage?.localSSDSupported) {
+      /* eslint-disable no-console */
+      console.log('updating disks on init ', this.sortDisks(this.getPersistentDisks()));
+      /* eslint-enable no-console */
       this.updateDisks({ disks: this.sortDisks(this.getPersistentDisks()) });
     }
 
@@ -53,7 +59,13 @@ class GceDiskConfigurerController implements IComponentController {
 
   public handlePersistentDiskChange(): void {
     let disks = this.persistentDisks.concat(this.getLocalSSDDisks());
+    /* eslint-disable no-console */
+    console.log('handle persist disk change, before sort', disks);
+    /* eslint-enable no-console */
     disks = this.sortDisks(disks);
+    /* eslint-disable no-console */
+    console.log('handle persist disk change, after sort', disks);
+    /* eslint-enable no-console */
     this.updateDisks({ disks });
   }
 
@@ -87,6 +99,9 @@ class GceDiskConfigurerController implements IComponentController {
     const diskWithoutImage = disks.find(
       (disk) => (disk.type.startsWith('pd-') || disk.type.startsWith('hyperdisk-')) && disk.sourceImage === undefined,
     );
+    /* eslint-disable no-console */
+    console.log('in sort,', disks, diskWithoutImage);
+    /* eslint-enable no-console */
     return [diskWithoutImage].concat(without(disks, diskWithoutImage));
   }
 
@@ -95,6 +110,9 @@ class GceDiskConfigurerController implements IComponentController {
   }
 
   private getPersistentDisks(): IGceDisk[] {
+    /* eslint-disable no-console */
+    console.log('getting persist disks ', this.command.disks);
+    /* eslint-enable no-console */
     return (this.command.disks || []).filter(
       (disk: IGceDisk) => disk.type.startsWith('pd-') || disk.type.startsWith('hyperdisk-'),
     );


### PR DESCRIPTION
Adds support for `hyperdisk-balanced` in Spinnaker for GCE. See: https://cloud.google.com/compute/docs/disks/hyperdisks

In the following changes, I added `hyperdisk-balanced` as option for Persistent Disk in the deploy stage when using GCE in Spinnaker.

<img width="924" alt="Captura de pantalla 2024-10-02 a la(s) 6 27 22 p m" src="https://github.com/user-attachments/assets/c581e235-9a63-48af-8243-7399189fc7f0">

This allows any user to configure their GCE instance to use hyperdisk. The backend already supports this new persistent disk type with the following PR: https://github.com/spinnaker/clouddriver/pull/6288