### PR TITLE
feat(deployManifest): Adding skipSpecTemplateLabels option

### DIFF
--- a/packages/kubernetes/src/help/kubernetes.help.ts
+++ b/packages/kubernetes/src/help/kubernetes.help.ts
@@ -211,6 +211,8 @@ const helpContents: { [key: string]: string } = {
     'These artifacts must be present in the context for this stage to successfully complete. Artifacts specified will be <a href="https://www.spinnaker.io/reference/artifacts/in-kubernetes-v2/#binding-artifacts-in-manifests" target="_blank">bound to the deployed manifest.</a>',
   'kubernetes.manifest.skipExpressionEvaluation':
     '<p>Skip SpEL expression evaluation of the manifest artifact in this stage. Can be paired with the "Evaluate SpEL expressions in overrides at bake time" option in the Bake Manifest stage when baking a third-party manifest artifact with expressions not meant for Spinnaker to evaluate as SpEL.</p>',
+  'kubernetes.manifest.skipSpecTemplateLabels': `
+      <p>Skip applying the <a href="https://spinnaker.io/docs/reference/providers/kubernetes-v2/#reserved-labels" target="_blank">Reserved labels</a> to the manifest's <b><i>.spec.template.metadata.labels.</i></b></p>`,
   'kubernetes.manifest.undoRollout.revisionsBack': `
       <p>How many revisions to rollback from the current active revision. This is not a hard-coded revision to rollout.</p>
       <p>For example: If you specify "1", and this stage executes, the prior revision will be active upon success.</p>

--- a/packages/kubernetes/src/pipelines/stages/deployManifest/DeployManifestStageForm.tsx
+++ b/packages/kubernetes/src/pipelines/stages/deployManifest/DeployManifestStageForm.tsx
@@ -187,6 +187,14 @@ export class DeployManifestStageForm extends React.Component<
           />
         </StageConfigField>
         <hr />
+        <h4>Deploy Configuration</h4>
+        <StageConfigField label="Skip Spec Template Labels" helpKey="kubernetes.manifest.skipSpecTemplateLabels">
+          <CheckboxInput
+            checked={stage.skipSpecTemplateLabels === true}
+            onChange={(e: any) => this.props.formik.setFieldValue('skipSpecTemplateLabels', e.target.checked)}
+          />
+        </StageConfigField>
+        <hr />
         <ManifestDeploymentOptions
           accounts={this.props.accounts}
           config={stage.trafficManagement}


### PR DESCRIPTION
Adding the UI piece for the feature https://github.com/spinnaker/clouddriver/pull/6254 included in 1.35.x release

For existing stages the pipeline json wont be changed however if the user opts-in to the skipSpecTemplateLabels and sets it true it will be included in the pipeline json. Disabling it will put the skipSpecTemplateLabels as false. 

![image](https://github.com/user-attachments/assets/7bc6ed42-ac2a-474d-ba2c-524610c8a021)

![image](https://github.com/user-attachments/assets/c2c0e4e6-2da3-489c-a5e4-69acb5c046a2)

