### PR TITLE
feat(deployManifest): Adding Label Selectors feature support

### DIFF
--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -53,6 +53,7 @@ export interface IFeatures {
   functions?: boolean;
   kubernetesRawResources?: boolean;
   renderPipelineStageThreshold?: number;
+  deployManifestStageAdvancedConfiguration?: boolean;
 }
 
 export interface IDockerInsightSettings {

--- a/packages/kubernetes/src/help/kubernetes.help.ts
+++ b/packages/kubernetes/src/help/kubernetes.help.ts
@@ -213,6 +213,10 @@ const helpContents: { [key: string]: string } = {
     '<p>Skip SpEL expression evaluation of the manifest artifact in this stage. Can be paired with the "Evaluate SpEL expressions in overrides at bake time" option in the Bake Manifest stage when baking a third-party manifest artifact with expressions not meant for Spinnaker to evaluate as SpEL.</p>',
   'kubernetes.manifest.skipSpecTemplateLabels': `
       <p>Skip applying the <a href="https://spinnaker.io/docs/reference/providers/kubernetes-v2/#reserved-labels" target="_blank">Reserved labels</a> to the manifest's <b><i>.spec.template.metadata.labels.</i></b></p>`,
+  'kubernetes.manifest.deployLabelSelectors': `
+      <p>Via Label Selectors, Spinnaker can deploy a subset of manifests satisfying the Label Selectors. See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors" target="_blank">Kubernetes Label Selectors</a> for more details. Multiple selectors combine with AND (All must be satisfied).</p>`,
+  'kubernetes.manifest.deployLabelSelectors.allowNothingSelected': `
+      <p>When unchecked an error is thrown if none of the provided manifests satisfy the Label Selectors</p>`,
   'kubernetes.manifest.undoRollout.revisionsBack': `
       <p>How many revisions to rollback from the current active revision. This is not a hard-coded revision to rollout.</p>
       <p>For example: If you specify "1", and this stage executes, the prior revision will be active upon success.</p>


### PR DESCRIPTION
Adding support in the deployManifest stage for the Label Selectors features introduced in 1.35.x (see https://github.com/spinnaker/clouddriver/pull/6220) 


https://github.com/user-attachments/assets/8d86f2bd-d5b6-427d-bb22-91c11c362ed9

