### PR TITLE
fix(stages): accountExtractor in k8s stages should extract data from a context

### DIFF
--- a/packages/kubernetes/src/pipelines/stages/deleteManifest/deleteManifestStage.ts
+++ b/packages/kubernetes/src/pipelines/stages/deleteManifest/deleteManifestStage.ts
@@ -15,7 +15,7 @@ Registry.pipeline.registerStage({
   cloudProvider: 'kubernetes',
   component: DeleteManifestStageConfig,
   executionDetailsSections: [manifestExecutionDetails(STAGE_KEY), ExecutionDetailsTasks],
-  accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
+  accountExtractor: (stage: IStage): string[] => (stage.context.account ? [stage.context.account] : []),
   configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
   validators: manifestSelectorValidators(STAGE_NAME),
 });

--- a/packages/kubernetes/src/pipelines/stages/deployManifest/deployManifestStage.ts
+++ b/packages/kubernetes/src/pipelines/stages/deployManifest/deployManifestStage.ts
@@ -21,7 +21,7 @@ Registry.pipeline.registerStage({
   producesArtifacts: true,
   supportsCustomTimeout: true,
   validators: deployManifestValidators(),
-  accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
+  accountExtractor: (stage: IStage): string[] => (stage.context.account ? [stage.context.account] : []),
   configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
   artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['manifestArtifactId', 'requiredArtifactIds']),
   artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['manifestArtifactId', 'requiredArtifactIds']),

--- a/packages/kubernetes/src/pipelines/stages/findArtifactsFromResource/findArtifactsFromResourceStage.ts
+++ b/packages/kubernetes/src/pipelines/stages/findArtifactsFromResource/findArtifactsFromResourceStage.ts
@@ -1,3 +1,4 @@
+import type { IStage } from '@spinnaker/core';
 import { ExecutionArtifactTab, ExecutionDetailsTasks, Registry } from '@spinnaker/core';
 
 import { FindArtifactsFromResourceConfig } from './FindArtifactsFromResourceConfig';
@@ -15,4 +16,6 @@ Registry.pipeline.registerStage({
   executionDetailsSections: [ExecutionDetailsTasks, ExecutionArtifactTab],
   producesArtifacts: true,
   validators: manifestSelectorValidators(STAGE_NAME),
+  accountExtractor: (stage: IStage): string[] => (stage.context.account ? [stage.context.account] : []),
+  configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
 });

--- a/packages/kubernetes/src/pipelines/stages/scaleManifest/scaleManifestStage.ts
+++ b/packages/kubernetes/src/pipelines/stages/scaleManifest/scaleManifestStage.ts
@@ -1,3 +1,4 @@
+import type { IStage } from '@spinnaker/core';
 import { ExecutionDetailsTasks, Registry } from '@spinnaker/core';
 
 import { manifestExecutionDetails } from '../ManifestExecutionDetails';
@@ -14,6 +15,8 @@ Registry.pipeline.registerStage({
   cloudProvider: 'kubernetes',
   component: ScaleManifestStageConfig,
   executionDetailsSections: [manifestExecutionDetails(STAGE_KEY), ExecutionDetailsTasks],
+  accountExtractor: (stage: IStage): string[] => (stage.context.account ? [stage.context.account] : []),
+  configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
   validators: [
     ...manifestSelectorValidators(STAGE_NAME),
     { type: 'requiredField', fieldName: 'replicas', fieldLabel: 'Replicas' },


### PR DESCRIPTION
For reference, see other stages:
- https://github.com/spinnaker/deck/blob/c96faa581482d251c07132bdcc023e04fc8e869b/packages/cloudfoundry/src/pipeline/stages/runJob/cloudFoundryRunJob.module.ts#L8
- https://github.com/spinnaker/deck/blob/c49d9b545642f511bfd2e14588b78fdf76385c5a/packages/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js#L18

During execution, the account is stored in the context

Screenshot after fixing:

<kbd>![](https://github.com/user-attachments/assets/bd1cf653-78b2-4409-ad98-9e8f1bdf5e4c)</kbd>


