### PR TITLE
feat(amazon): support ALBRequestCountPerTarget scaling policies

### DIFF
--- a/packages/amazon/src/domain/ITargetTrackingPolicy.ts
+++ b/packages/amazon/src/domain/ITargetTrackingPolicy.ts
@@ -21,6 +21,11 @@ export interface ICustomizedMetricSpecification {
 
 export interface IPredefinedMetricSpecification {
   predefinedMetricType: PredefinedMetricType;
+  resourceLabel?: string;
 }
 
-export type PredefinedMetricType = 'ASGAverageCPUUtilization' | 'ASGAverageNetworkIn' | 'ASGAverageNetworkOut';
+export type PredefinedMetricType =
+  | 'ASGAverageCPUUtilization'
+  | 'ASGAverageNetworkIn'
+  | 'ASGAverageNetworkOut'
+  | 'ALBRequestCountPerTarget';

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/chart/MetricAlarmChart.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/chart/MetricAlarmChart.tsx
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import * as React from 'react';
 
 import type { ICloudMetricStatistics } from '@spinnaker/core';
@@ -36,7 +37,7 @@ export function MetricAlarmChartImpl(props: IMetricAlarmChartProps) {
       return result;
     },
     { datapoints: [], unit: '' },
-    [namespace, statistic, period, type, account, region, metricName],
+    [namespace, statistic, period, type, account, region, metricName, alarm.dimensions],
   );
 
   if (status === 'PENDING') {
@@ -60,13 +61,15 @@ export function MetricAlarmChartImpl(props: IMetricAlarmChartProps) {
 
   const now = new Date();
   const oneDayAgo = new Date(Date.now() - 1000 * 60 * 60 * 24);
-
   const line: IDateLine = {
     label: metricName,
     fill: 'stack',
     borderColor: 'green',
     borderWidth: 2,
-    data: result.datapoints.map((dp) => ({ x: new Date(dp.timestamp), y: dp.average })),
+    data: result.datapoints.map((dp) => ({
+      x: new Date(dp.timestamp),
+      y: get(dp, [alarm.statistic.toLowerCase()], undefined),
+    })),
   };
 
   const setline: IDateLine = {

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/TargetMetricFields.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/TargetMetricFields.tsx
@@ -134,21 +134,7 @@ export const TargetMetricFields = ({
               inputClassName="metric-select-input"
             />
           )}
-          {!isCustomMetric &&
-            command.targetTrackingConfiguration.predefinedMetricSpecification?.predefinedMetricType ===
-              'ALBRequestCountPerTarget' && (
-              <ReactSelectInput
-                value={command.targetTrackingConfiguration.predefinedMetricSpecification?.resourceLabel}
-                options={targetGroupOptions()}
-                onChange={(e) =>
-                  setCommandField(
-                    'targetTrackingConfiguration.predefinedMetricSpecification.resourceLabel',
-                    e.target.value,
-                  )
-                }
-                inputClassName="metric-select-input"
-              />
-            )}
+
           {isCustomMetric && (
             <MetricSelector
               alarm={command.targetTrackingConfiguration.customizedMetricSpecification as IScalingPolicyAlarmView}
@@ -163,6 +149,26 @@ export const TargetMetricFields = ({
           )}
         </div>
       </div>
+      {!isCustomMetric &&
+        command.targetTrackingConfiguration.predefinedMetricSpecification?.predefinedMetricType ===
+          'ALBRequestCountPerTarget' && (
+          <div className="row sp-margin-s-yaxis">
+            <div className="col-md-2 sm-label-right">Target Group</div>
+            <div className="col-md-10 content-fields horizontal">
+              <ReactSelectInput
+                value={command.targetTrackingConfiguration.predefinedMetricSpecification?.resourceLabel}
+                options={targetGroupOptions()}
+                onChange={(e) =>
+                  setCommandField(
+                    'targetTrackingConfiguration.predefinedMetricSpecification.resourceLabel',
+                    e.target.value,
+                  )
+                }
+                inputClassName="metric-select-input"
+              />
+            </div>
+          </div>
+        )}
       <div className="row sp-margin-s-yaxis">
         <div className="col-md-2 sm-label-right">Target</div>
         <div className="col-md-10 content-fields horizontal">

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/TargetMetricFields.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/TargetMetricFields.tsx
@@ -2,10 +2,17 @@ import { cloneDeep, set } from 'lodash';
 import * as React from 'react';
 
 import { NumberInput, ReactSelectInput } from '@spinnaker/core';
+import type { Application, ILoadBalancer } from '@spinnaker/core';
 
 import type { ITargetTrackingPolicyCommand } from '../ScalingPolicyWriter';
 import { TargetTrackingChart } from './TargetTrackingChart';
-import type { IAmazonServerGroup, ICustomizedMetricSpecification, IScalingPolicyAlarmView } from '../../../../domain';
+import type {
+  IAmazonApplicationLoadBalancer,
+  IAmazonServerGroup,
+  ICustomizedMetricSpecification,
+  IScalingPolicyAlarmView,
+  ITargetGroup,
+} from '../../../../domain';
 import { MetricSelector } from '../upsert/alarm/MetricSelector';
 
 import './TargetMetricFields.less';
@@ -16,9 +23,18 @@ export interface ITargetMetricFieldsProps {
   cloudwatch?: boolean;
   command: ITargetTrackingPolicyCommand;
   isCustomMetric: boolean;
+  app: Application;
   serverGroup: IAmazonServerGroup;
   toggleMetricType?: (type: MetricType) => void;
   updateCommand: (command: ITargetTrackingPolicyCommand) => void;
+}
+
+interface IalbArn {
+  loadBalancerArn: string;
+}
+
+interface ItargetGroupArn {
+  targetGroupArn: string;
 }
 
 export const TargetMetricFields = ({
@@ -26,11 +42,17 @@ export const TargetMetricFields = ({
   cloudwatch,
   command,
   isCustomMetric,
+  app,
   serverGroup,
   toggleMetricType,
   updateCommand,
 }: ITargetMetricFieldsProps) => {
-  const predefinedMetrics = ['ASGAverageCPUUtilization', 'ASGAverageNetworkOut', 'ASGAverageNetworkIn'];
+  const predefinedMetrics = [
+    'ASGAverageCPUUtilization',
+    'ASGAverageNetworkOut',
+    'ASGAverageNetworkIn',
+    'ALBRequestCountPerTarget',
+  ];
   const statistics = ['Average', 'Maximum', 'Minimum', 'SampleCount', 'Sum'];
   const [unit, setUnit] = React.useState<string>(null);
 
@@ -65,6 +87,24 @@ export const TargetMetricFields = ({
     toggleMetricType(isCustomMetric ? 'predefined' : 'custom');
   };
 
+  const targetGroupOptions = () => {
+    const loadBalancers = app.loadBalancers.data as ILoadBalancer[];
+    const albs = loadBalancers.filter(
+      (lb) => lb.account === serverGroup.account && lb.region === serverGroup.region,
+    ) as Array<IAmazonApplicationLoadBalancer & IalbArn>;
+    const targetGroups = albs.flatMap((alb) =>
+      alb.targetGroups
+        .filter((tg) => serverGroup.targetGroups.some((serverGroupTg) => serverGroupTg === tg.name))
+        .map((tg) => ({ ...tg, loadBalancerArn: alb.loadBalancerArn })),
+    ) as Array<ITargetGroup & IalbArn & ItargetGroupArn>;
+    return targetGroups.map((tg) => ({
+      label: tg.name,
+      value: `${tg.loadBalancerArn.substring(tg.loadBalancerArn.indexOf('app'))}/${tg.targetGroupArn.substring(
+        tg.targetGroupArn.indexOf('targetgroup'),
+      )}`,
+    }));
+  };
+
   return (
     <div className="TargetMetricFields sp-margin-l-xaxis">
       <p>
@@ -94,6 +134,21 @@ export const TargetMetricFields = ({
               inputClassName="metric-select-input"
             />
           )}
+          {!isCustomMetric &&
+            command.targetTrackingConfiguration.predefinedMetricSpecification?.predefinedMetricType ===
+              'ALBRequestCountPerTarget' && (
+              <ReactSelectInput
+                value={command.targetTrackingConfiguration.predefinedMetricSpecification?.resourceLabel}
+                options={targetGroupOptions()}
+                onChange={(e) =>
+                  setCommandField(
+                    'targetTrackingConfiguration.predefinedMetricSpecification.resourceLabel',
+                    e.target.value,
+                  )
+                }
+                inputClassName="metric-select-input"
+              />
+            )}
           {isCustomMetric && (
             <MetricSelector
               alarm={command.targetTrackingConfiguration.customizedMetricSpecification as IScalingPolicyAlarmView}

--- a/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/UpsertTargetTrackingModal.tsx
+++ b/packages/amazon/src/serverGroup/details/scalingPolicy/targetTracking/UpsertTargetTrackingModal.tsx
@@ -58,6 +58,7 @@ export const UpsertTargetTrackingModal = ({
             cloudwatch={false}
             command={command as ITargetTrackingPolicyCommand}
             isCustomMetric={isCustom}
+            app={app}
             serverGroup={serverGroup}
             toggleMetricType={(t) => setIsCustom(t === 'custom')}
             updateCommand={setCommand}

--- a/packages/core/src/domain/ICloudMetric.ts
+++ b/packages/core/src/domain/ICloudMetric.ts
@@ -11,7 +11,11 @@ export interface IMetricAlarmDimension {
 
 interface IDataPoint {
   timestamp: number;
-  average: number;
+  average?: number;
+  sum?: number;
+  minimum?: number;
+  maximum?: number;
+  sampleCount?: number;
 }
 
 export interface ICloudMetricStatistics {

--- a/packages/titus/src/serverGroup/details/scalingPolicy/targetTracking/UpsertTargetTrackingModal.tsx
+++ b/packages/titus/src/serverGroup/details/scalingPolicy/targetTracking/UpsertTargetTrackingModal.tsx
@@ -63,6 +63,7 @@ export const UpsertTargetTrackingModal = ({
             cloudwatch={true}
             command={command as ITargetTrackingPolicyCommand}
             isCustomMetric={isCustom}
+            app={app}
             serverGroup={(serverGroup as unknown) as IAmazonServerGroup}
             toggleMetricType={(t) => setIsCustom(t === 'custom')}
             updateCommand={setCommand}


### PR DESCRIPTION
The UI for TargetTracking scaling policies didn't support ALBRequestCountPerTarget. This was the only missing metric documented here: https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-target-tracking.html

This requires setting the resourceLabel parameter which is a combination of part of both the ALB and target group ARNs. This metric also only works with the Sum statistic. I found that the chart component hard coded average so that had to be fixed up as well.

Here are some screenshots
Summary before and after:
![image](https://github.com/user-attachments/assets/a58de7be-1ed0-4ba9-a6e4-5a3b5a84fafd)

![image](https://github.com/user-attachments/assets/d48db85c-1470-4edb-9e18-fb0448f7a07f)
UpsertModal before and after:
(before the ALBRequestCountPerTarget isn't available)
![image](https://github.com/user-attachments/assets/c186aed9-faa3-402b-90ad-26d3d91b4b7b)

![image](https://github.com/user-attachments/assets/0f1a86e8-2985-4ff5-9f28-abf79e9a5efe)
