### PR TITLE
fix(google): Add partner metadata on clone

### DIFF
--- a/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -521,6 +521,8 @@ angular
             populateTags(serverGroup.launchConfig.instanceTemplate.properties.tags, command);
             populateLabels(serverGroup.instanceTemplateLabels, command);
             populateAuthScopes(serverGroup.launchConfig.instanceTemplate.properties.serviceAccounts, command);
+            populateResourceManagerTags(serverGroup.resourceManagerTags, command);
+            populatePartnerMetadata(serverGroup.partnerMetadata, command);
 
             return populateDisksFromExisting(serverGroup.launchConfig.instanceTemplate.properties.disks, command).then(
               function () {

--- a/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/packages/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -521,8 +521,11 @@ angular
             populateTags(serverGroup.launchConfig.instanceTemplate.properties.tags, command);
             populateLabels(serverGroup.instanceTemplateLabels, command);
             populateAuthScopes(serverGroup.launchConfig.instanceTemplate.properties.serviceAccounts, command);
-            populateResourceManagerTags(serverGroup.resourceManagerTags, command);
-            populatePartnerMetadata(serverGroup.partnerMetadata, command);
+            populateResourceManagerTags(
+              serverGroup.launchConfig.instanceTemplate.properties.resourceManagerTags,
+              command,
+            );
+            populatePartnerMetadata(serverGroup.launchConfig.instanceTemplate.properties.partnerMetadata, command);
 
             return populateDisksFromExisting(serverGroup.launchConfig.instanceTemplate.properties.disks, command).then(
               function () {

--- a/packages/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/packages/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -471,6 +471,11 @@ angular
               return serverGroup;
             },
             serverGroupCommand: () => {
+              /* eslint-disable no-console */
+              console.log('showing server group to clone');
+              console.log(serverGroup);
+              console.log(app);
+              /* eslint-enable no-console */
               return gceServerGroupCommandBuilder.buildServerGroupCommandFromExisting(app, serverGroup);
             },
           },

--- a/packages/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/packages/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -471,11 +471,6 @@ angular
               return serverGroup;
             },
             serverGroupCommand: () => {
-              /* eslint-disable no-console */
-              console.log('showing server group to clone');
-              console.log(serverGroup);
-              console.log(app);
-              /* eslint-enable no-console */
               return gceServerGroupCommandBuilder.buildServerGroupCommandFromExisting(app, serverGroup);
             },
           },


### PR DESCRIPTION
**ISSUE**

When cloning a server group using the UI. The resourceManagerTags and partnerMetadata are not populated even if the deployment is configured with resourceManagerTags and partnerMetadata.

**Expected Behavior**
If the server group has resourceManagerTags and partnerMetadata configured. Cloning the server group should populate these fields automatically.

<img width="1255" alt="Captura de pantalla 2025-01-17 a la(s) 4 07 23 p m" src="https://github.com/user-attachments/assets/3c66b77f-4784-4ee8-bc74-ce7d6a7fc42e" />

<img width="1257" alt="Captura de pantalla 2025-01-17 a la(s) 4 07 40 p m" src="https://github.com/user-attachments/assets/0d6c0b88-db60-468c-acc7-d5f2137bb45b" />

<img width="894" alt="Captura de pantalla 2025-01-17 a la(s) 4 08 26 p m" src="https://github.com/user-attachments/assets/85ce898b-13f4-4e42-bf60-f0a05a259970" />


The main issue comes from Clouddriver because the instanceTemplate doesn't include the partner metadata. See: https://github.com/spinnaker/clouddriver/pull/6334

In Deck, we just populate the resourceManagerTags and partnerMetadata in the instanceTemplateProperties under the lauchConfiguration.


