### PR TITLE
fix(pipelineStage): Rendering with a warning with the pipelineParameters are defined as a SpeL expression

### DIFF
--- a/packages/core/src/pipeline/config/stages/pipeline/pipelineStage.html
+++ b/packages/core/src/pipeline/config/stages/pipeline/pipelineStage.html
@@ -104,6 +104,17 @@
         <button class="self-right passive" ng-click="pipelineStageCtrl.removeInvalidParameters()">Remove all</button>
       </div>
     </div>
+    <div ng-if="hasSpeLDefinedParameterBlock()" class="horizontal center sp-margin-l-top" style="width: 100%">
+      <div class="warning-text alert-info vertical">
+        <p>
+          <i class="fa fa-exclamation-triangle"></i>
+          The pipelineParameters is defined as a SpeL expression and will be fully evaluated on Runtime.
+        </p>
+        <p>
+          <code ng-bind-html="stage.pipelineParameters"></code>
+        </p>
+      </div>
+    </div>
   </div>
   <stage-config-field label="Skip downstream output" help-key="pipeline.skipDownstreamOutput">
     <input type="checkbox" class="input-sm" name="skipDownstreamOutput" ng-model="stage.skipDownstreamOutput" />


### PR DESCRIPTION
Although not used by many a user can define the pipelineParameters in the pipeline json as a single SpeL expression and this will be evaluated by Orca during the execution. 
Deck however doesnt render this correctly.

Stage json:
```
{
  "application": "testpipline",
  "failPipeline": true,
  "name": "Pipeline",
  "pipeline": "497ba489-beef-4e60-badb-32f2798c8fac",
  "pipelineParameters": "${{parameters.p1: parameters.p2}}",
  "type": "pipeline",
  "waitForCompletion": true
}
```
Before the fix: 

![Screenshot 2025-02-07 at 14 36 24](https://github.com/user-attachments/assets/654f95ce-b8a5-4deb-8018-118d7b3b8a4b)

After the fix: 

![Screenshot 2025-02-07 at 14 36 24](https://github.com/user-attachments/assets/ec41f77c-9543-4d84-80ef-8545b075670a)
