### PR TITLE
fix(deck): Fix RunJob external logs when component is not mounted and  interpolation is needed

### DIFF
--- a/packages/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/packages/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -1,4 +1,4 @@
-import { template } from 'lodash';
+import { isEmpty, template } from 'lodash';
 import React from 'react';
 import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -52,7 +52,7 @@ export class JobStageExecutionLogs extends React.Component<IJobStageExecutionLog
     const { manifest } = this.state;
     const { externalLink, podNamesProviders, location, account } = this.props;
     // prefer links to external logging platforms
-    if (externalLink) {
+    if (externalLink && (!externalLink.includes('{{') || !isEmpty(manifest))) {
       return (
         <a target="_blank" href={this.renderExternalLink(externalLink, manifest)}>
           Console Output (External)


### PR DESCRIPTION
Deck is failing to render the external logs link when interpolation is needed but the async operation to Clouddriver to mount the manifest. This PR fixes this issue but keeps the ExternalLog link when interpolation is not needed